### PR TITLE
Introducing issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,8 @@
+---
+name: Feature request
+about:  Would you like to suggest a feature? Please use this template. 
+title: 'Feature request: '
+assignees: ''
+---
+
+Please describe your idea, add any sources or examples that would be helpful. 

--- a/.github/ISSUE_TEMPLATE/ios_bug.md
+++ b/.github/ISSUE_TEMPLATE/ios_bug.md
@@ -1,0 +1,29 @@
+---
+name: iOS bug report 
+about:  Please fill as much info as you can. It would help us to make NetNewsWire for iOS better
+title: 'iOS: '
+labels: type:bug
+assignees: ''
+---
+## Additional description
+A clear and concise description of what the bug is.
+Please specify the feed url (if applicable)
+
+# Environment 
+NNW version: 5.x 
+Please specify build number if you're not using a release build
+
+iOS Version: 13.x
+Device: iPhone/iPad
+
+## How to reproduce
+If you know how to reproduce, please describe the steps:
+1.
+2. 
+3.
+
+## Expected result
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/macos_bug.md
+++ b/.github/ISSUE_TEMPLATE/macos_bug.md
@@ -1,0 +1,28 @@
+---
+name: macOS bug report 
+about:  Please fill as much info as you can. It would help us to make NetNewsWire for Mac better.
+title: 'macOS: '
+labels: type:bug
+assignees: ''
+---
+## Additional description
+A clear and concise description of what the bug is.
+Please specify the feed url (if applicable)
+
+# Environment 
+NNW version: 5.x 
+Please specify build number if you're not using a release build
+
+macOS Version: 10.15.x
+
+## How to reproduce
+If you know how to reproduce, please describe the steps:
+1.
+2. 
+3.
+
+## Expected result
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.


### PR DESCRIPTION
Implements suggestion from #1467 

I started with a small set of templates, just:
1. iOS bug
2. macOS bug
3. Feature request
