### PR TITLE
Add keyboard shortcut for “Mark Above as Read” #1485

### DIFF
--- a/iOS/KeyboardManager.swift
+++ b/iOS/KeyboardManager.swift
@@ -168,8 +168,11 @@ private extension KeyboardManager {
 		let toggleReadTitle = NSLocalizedString("Toggle Read Status", comment: "Toggle Read Status")
 		keys.append(KeyboardManager.createKeyCommand(title: toggleReadTitle, action: "toggleRead:", input: "u", modifiers: [.command, .shift]))
 
-		let markOlderAsReadTitle = NSLocalizedString("Mark Below as Read", comment: "Mark Below as Read")
-		keys.append(KeyboardManager.createKeyCommand(title: markOlderAsReadTitle, action: "markBelowAsRead:", input: "k", modifiers: [.command, .shift]))
+		let markAboveAsReadTitle = NSLocalizedString("Mark Above as Read", comment: "Mark Above as Read")
+		keys.append(KeyboardManager.createKeyCommand(title: markAboveAsReadTitle, action: "markAboveAsRead:", input: "k", modifiers: [.command, .control]))
+
+		let markBelowAsReadTitle = NSLocalizedString("Mark Below as Read", comment: "Mark Below as Read")
+		keys.append(KeyboardManager.createKeyCommand(title: markBelowAsReadTitle, action: "markBelowAsRead:", input: "k", modifiers: [.command, .shift]))
 
 		let toggleStarredTitle = NSLocalizedString("Toggle Starred Status", comment: "Toggle Starred Status")
 		keys.append(KeyboardManager.createKeyCommand(title: toggleStarredTitle, action: "toggleStarred:", input: "l", modifiers: [.command, .shift]))

--- a/iOS/RootSplitViewController.swift
+++ b/iOS/RootSplitViewController.swift
@@ -53,6 +53,10 @@ class RootSplitViewController: UISplitViewController {
 		coordinator.markAllAsReadInTimeline()
 		coordinator.selectNextUnread()
 	}
+
+	@objc func markAboveAsRead(_ sender: Any?) {
+		coordinator.markAboveAsRead()
+	}
 	
 	@objc func markBelowAsRead(_ sender: Any?) {
 		coordinator.markBelowAsRead()

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -875,6 +875,14 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 		return articles.first != article
 	}
 
+	func markAboveAsRead() {
+		guard let currentArticle = currentArticle else {
+			return
+		}
+
+		markAboveAsRead(currentArticle)
+	}
+
 	func markAboveAsRead(_ article: Article) {
 		guard let position = articles.firstIndex(of: article) else {
 			return


### PR DESCRIPTION
The keyboard shortcuts is added using the `cmd-ctrl-K` combination.

Also renamed `markOlderAsReadTitle` to `markBelowAsReadTitle`

This addresses the comments from issue #1485 