### PR TITLE
Share string with subject and URL instead of plain URL for Omnifocus and Things

### DIFF
--- a/iOS/ArticleActivityItemSource.swift
+++ b/iOS/ArticleActivityItemSource.swift
@@ -23,7 +23,18 @@ class ArticleActivityItemSource: NSObject, UIActivityItemSource {
 	}
 	
 	func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-		return url
+		guard let activityType = activityType,
+			let subject = subject else {
+				return url
+		}
+
+		switch activityType.rawValue {
+		case "com.omnigroup.OmniFocus3.iOS.QuickEntry",
+			 "com.culturedcode.ThingsiPhone.ShareExtension":
+			return "\(subject)\n\(url)"
+		default:
+			return url
+		}
 	}
 	
 	func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {


### PR DESCRIPTION
This issue fixes #1517 

Omnifocus and Things don't call the `subjectForActivityType` method to obtain the title of a shared article. Instead they use the first line of a shared string as the title for a to-do and use the rest to populate the notes field.

For this PR I decided to specify the exceptions as to when a formatted string should be shared and sticking with sharing a plain URL as default. Many Apps provide special functionality when only a URL is shared. For example Messages.app with preview cards.