### PR TITLE
Use string-based key paths instead of Swift key paths…

### DIFF
--- a/Frameworks/Account/Feedly/Operations/FeedlyOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyOperation.swift
@@ -94,19 +94,19 @@ class FeedlyOperation: Operation {
 		let isFinishedDidChange = finished != isFinishedOperation
 
 		if isFinishedDidChange {
-			willChangeValue(for: \.isFinished)
+			willChangeValue(forKey: #keyPath(isFinished))
 		}
 		if isExecutingDidChange {
-			willChangeValue(for: \.isExecuting)
+			willChangeValue(forKey: #keyPath(isExecuting))
 		}
 		isExecutingOperation = executing
 		isFinishedOperation = finished
 
 		if isExecutingDidChange {
-			didChangeValue(for: \.isExecuting)
+			didChangeValue(forKey: #keyPath(isExecuting))
 		}
 		if isFinishedDidChange {
-			didChangeValue(for: \.isFinished)
+			didChangeValue(forKey: #keyPath(isFinished))
 		}
 	}
 }


### PR DESCRIPTION
…for FeedlyOperation. #1481

A [comment](https://github.com/Ranchero-Software/NetNewsWire/issues/1481#issuecomment-570772838) on #1481 anecdotally suggests using a `String` key path instead of Swift `KeyPath<Value, Root>` key paths because the latter just "don't work" and "[c]hanging to strings for the key paths fixed things for me". Figure it can't hurt to try.