### PR TITLE
Only show mark unread above/below actions if articles above/below contain unread items

### DIFF
--- a/Shared/Timeline/ArticleArray.swift
+++ b/Shared/Timeline/ArticleArray.swift
@@ -109,5 +109,30 @@ extension Array where Element == Article {
 		}
 		return true
 	}
+
+	func articlesAbove(article: Article) -> [Article] {
+		guard let position = firstIndex(of: article) else {
+			return []
+		}
+
+		let articlesAbove = self[..<position]
+		return Array(articlesAbove)
+	}
+
+	func articlesBelow(article: Article) -> [Article] {
+		guard let position = firstIndex(of: article) else {
+			return []
+		}
+
+		var articlesBelow = Array(self[position...])
+
+		guard !articlesBelow.isEmpty else {
+			return []
+		}
+
+		articlesBelow.removeFirst()
+
+		return articlesBelow
+	}
 }
 

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -872,7 +872,8 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 	}
 
 	func canMarkAboveAsRead(for article: Article) -> Bool {
-		return articles.first != article
+		let articlesAboveArray = articles.articlesAbove(article: article)
+		return articlesAboveArray.canMarkAllAsRead()
 	}
 
 	func markAboveAsRead() {
@@ -884,16 +885,13 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 	}
 
 	func markAboveAsRead(_ article: Article) {
-		guard let position = articles.firstIndex(of: article) else {
-			return
-		}
-
-		let articlesAbove = articles[..<position]
-		markAllAsRead(Array(articlesAbove))
+		let articlesAboveArray = articles.articlesAbove(article: article)
+		markAllAsRead(articlesAboveArray)
 	}
 
 	func canMarkBelowAsRead(for article: Article) -> Bool {
-		return articles.last != article
+		let articleBelowArray = articles.articlesBelow(article: article)
+		return articleBelowArray.canMarkAllAsRead()
 	}
 
 	func markBelowAsRead() {
@@ -905,18 +903,8 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 	}
 
 	func markBelowAsRead(_ article: Article) {
-		guard let position = articles.firstIndex(of: article) else {
-			return
-		}
-
-		var articlesBelow = Array(articles[position...])
-
-		guard !articlesBelow.isEmpty else {
-			return
-		}
-
-		articlesBelow.removeFirst()
-		markAllAsRead(articlesBelow)
+		let articleBelowArray = articles.articlesBelow(article: article)
+		markAllAsRead(articleBelowArray)
 	}
 	
 	func markAsReadForCurrentArticle() {


### PR DESCRIPTION
This PR dresses issue #1548 

Instead of only checking for the first/last item in canMarkAboveAsRead and canMarkBelowAsRead it's now using Array<Article>.canMarkAllAsRead to determine wether the action should be shown.

As the logic to get the articles above/below a certain article is now used canMarkAbove/BelowAsRead and markAbove/BelowAsRead I moved it to private helper functions.
I was considering moving the helper functions to `ArticleArray` but was not sure if there are special rules adding something to the shared codebase.