### PR TITLE
Make <pre> and <code> elements scale with Dynamic Type

### DIFF
--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -1,9 +1,12 @@
+:root {
+	font: -apple-system-body;
+}
+
 body {
 	margin-top: 3px;
 	margin-bottom: 20px;
 	margin-left: 20px;
 	margin-right: 20px;
-	font: -apple-system-body;
 
 	word-wrap: break-word;
 	word-break: break-word;
@@ -125,7 +128,7 @@ pre {
 	margin: 0;
 	overflow: auto;
 	overflow-y: hidden;
-	line-height: 20px;
+	line-height: 1.4286em;
 	border: 1px solid var(--secondary-accent-color);
 	padding: 5px;
 	word-wrap: normal;
@@ -137,7 +140,7 @@ pre {
 }
 code, pre {
 	font-family: "SF Mono", Menlo, "Courier New", Courier, monospace;
-	font-size: 14px;
+	font-size: .8235rem;
 }
 img, figure, video, iframe, div {
 	max-width: 100%;


### PR DESCRIPTION
I run my phone at the lowest text size, and noticed that `<pre>` elements weren't scaling. This fixes that. The default size is still 14px (20px line-height; within 3 decimal places) at the default type size.