### PR TITLE
Provide dedicated TitleActivityItemSource when sharing to Omnifocus and Things

### DIFF
--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -636,6 +636,8 @@
 		B2B80778239C4C7000F191E0 /* RSImage-AppIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B8075D239C49D300F191E0 /* RSImage-AppIcons.swift */; };
 		B2B80779239C4C7300F191E0 /* RSImage-AppIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B8075D239C49D300F191E0 /* RSImage-AppIcons.swift */; };
 		B528F81E23333C7E00E735DD /* page.html in Resources */ = {isa = PBXBuildFile; fileRef = B528F81D23333C7E00E735DD /* page.html */; };
+		C5A6ED5223C9AF4300AB6BE2 /* TitleActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A6ED5123C9AF4300AB6BE2 /* TitleActivityItemSource.swift */; };
+		C5A6ED6D23C9B0C800AB6BE2 /* UIActivityViewController-Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A6ED6C23C9B0C800AB6BE2 /* UIActivityViewController-Extensions.swift */; };
 		D553738B20186C20006D8857 /* Article+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D553737C20186C1F006D8857 /* Article+Scriptability.swift */; };
 		D57BE6E0204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57BE6DF204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift */; };
 		D5907D7F2004AC00005947E5 /* NSApplication+Scriptability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5907D7E2004AC00005947E5 /* NSApplication+Scriptability.swift */; };
@@ -1572,6 +1574,8 @@
 		B24EFD5923310109006C6242 /* WKPreferencesPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKPreferencesPrivate.h; sourceTree = "<group>"; };
 		B2B8075D239C49D300F191E0 /* RSImage-AppIcons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RSImage-AppIcons.swift"; sourceTree = "<group>"; };
 		B528F81D23333C7E00E735DD /* page.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = page.html; sourceTree = "<group>"; };
+		C5A6ED5123C9AF4300AB6BE2 /* TitleActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleActivityItemSource.swift; sourceTree = "<group>"; };
+		C5A6ED6C23C9B0C800AB6BE2 /* UIActivityViewController-Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIActivityViewController-Extensions.swift"; sourceTree = "<group>"; };
 		D519E74722EE553300923F27 /* NetNewsWire_safariextension_target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = NetNewsWire_safariextension_target.xcconfig; sourceTree = "<group>"; };
 		D553737C20186C1F006D8857 /* Article+Scriptability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Article+Scriptability.swift"; sourceTree = "<group>"; };
 		D57BE6DF204CD35F00D11AAC /* NSScriptCommand+NetNewsWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScriptCommand+NetNewsWire.swift"; sourceTree = "<group>"; };
@@ -1891,6 +1895,7 @@
 				51FFF0C3235EE8E5002762AA /* VibrantButton.swift */,
 				5186A634235EF3A800C97195 /* VibrantLabel.swift */,
 				5F323808231DF9F000706F6B /* VibrantTableViewCell.swift */,
+				C5A6ED6C23C9B0C800AB6BE2 /* UIActivityViewController-Extensions.swift */,
 			);
 			path = "UIKit Extensions";
 			sourceTree = "<group>";
@@ -2591,6 +2596,7 @@
 				51C45255226507D200C03939 /* AppDefaults.swift */,
 				51E3EB3C229AB08300645299 /* ErrorHandler.swift */,
 				51BB7C262335A8E5008E8144 /* ArticleActivityItemSource.swift */,
+				C5A6ED5123C9AF4300AB6BE2 /* TitleActivityItemSource.swift */,
 				51B62E67233186730085F949 /* IconView.swift */,
 				51C4525D226508F600C03939 /* MasterFeed */,
 				51C4526D2265091600C03939 /* MasterTimeline */,
@@ -3904,6 +3910,7 @@
 				51627A6B238629D8007B3B4B /* MasterFeedDataSource.swift in Sources */,
 				51102165233A7D6C0007A5F7 /* ArticleExtractorButton.swift in Sources */,
 				5141E7392373C18B0013FF27 /* WebFeedInspectorViewController.swift in Sources */,
+				C5A6ED6D23C9B0C800AB6BE2 /* UIActivityViewController-Extensions.swift in Sources */,
 				5108F6D42375EEEF001ABC45 /* TimelinePreviewTableViewController.swift in Sources */,
 				84CAFCA522BC8C08007694F0 /* FetchRequestQueue.swift in Sources */,
 				51C4529C22650A1000C03939 /* SingleFaviconDownloader.swift in Sources */,
@@ -3932,6 +3939,7 @@
 				51627A6923861DED007B3B4B /* MasterFeedViewController+Drop.swift in Sources */,
 				514219372352510100E07E2C /* ImageScrollView.swift in Sources */,
 				516AE9B32371C372007DEEAA /* MasterFeedTableViewSectionHeaderLayout.swift in Sources */,
+				C5A6ED5223C9AF4300AB6BE2 /* TitleActivityItemSource.swift in Sources */,
 				51C4529B22650A1000C03939 /* FaviconDownloader.swift in Sources */,
 				84DEE56622C32CA4005FC42C /* SmartFeedDelegate.swift in Sources */,
 				512E09012268907400BDCFDD /* MasterFeedTableViewSectionHeader.swift in Sources */,

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -280,9 +280,8 @@ class WebViewController: UIViewController {
 		guard let preferredLink = article?.preferredLink, let url = URL(string: preferredLink) else {
 			return
 		}
-		
-		let itemSource = ArticleActivityItemSource(url: url, subject: article!.title)
-		let activityViewController = UIActivityViewController(activityItems: [itemSource], applicationActivities: [OpenInSafariActivity()])
+
+		let activityViewController = UIActivityViewController(url: url, title: article?.title, applicationActivities: [OpenInSafariActivity()])
 		activityViewController.popoverPresentationController?.barButtonItem = popOverBarButtonItem
 		present(activityViewController, animated: true)
 	}

--- a/iOS/ArticleActivityItemSource.swift
+++ b/iOS/ArticleActivityItemSource.swift
@@ -23,18 +23,7 @@ class ArticleActivityItemSource: NSObject, UIActivityItemSource {
 	}
 	
 	func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-		guard let activityType = activityType,
-			let subject = subject else {
-				return url
-		}
-
-		switch activityType.rawValue {
-		case "com.omnigroup.OmniFocus3.iOS.QuickEntry",
-			 "com.culturedcode.ThingsiPhone.ShareExtension":
-			return "\(subject)\n\(url)"
-		default:
-			return url
-		}
+		return url
 	}
 	
 	func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {

--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -840,8 +840,7 @@ private extension MasterTimelineViewController {
 	}
 	
 	func shareDialogForTableCell(indexPath: IndexPath, url: URL, title: String?) {
-		let itemSource = ArticleActivityItemSource(url: url, subject: title)
-		let activityViewController = UIActivityViewController(activityItems: [itemSource], applicationActivities: nil)
+		let activityViewController = UIActivityViewController(url: url, title: title, applicationActivities: nil)
 		
 		guard let cell = tableView.cellForRow(at: indexPath) else { return }
 		let popoverController = activityViewController.popoverPresentationController

--- a/iOS/TitleActivityItemSource.swift
+++ b/iOS/TitleActivityItemSource.swift
@@ -1,0 +1,38 @@
+//
+//  TitleActivityItemSource.swift
+//  NetNewsWire-iOS
+//
+//  Created by Martin Hartl on 01/11/20.
+//  Copyright © 2020 Ranchero Software. All rights reserved.
+//
+
+import UIKit
+
+class TitleActivityItemSource: NSObject, UIActivityItemSource {
+
+	private let title: String?
+
+	init(title: String?) {
+		self.title = title
+	}
+
+	func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+		return title as Any
+	}
+
+	func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+		guard let activityType = activityType,
+			let title = title else {
+				return NSNull()
+		}
+
+		switch activityType.rawValue {
+		case "com.omnigroup.OmniFocus3.iOS.QuickEntry",
+			 "com.culturedcode.ThingsiPhone.ShareExtension":
+			return title
+		default:
+			return NSNull()
+		}
+	}
+	
+}

--- a/iOS/UIKit Extensions/UIActivityViewController-Extensions.swift
+++ b/iOS/UIKit Extensions/UIActivityViewController-Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  ShareArticleActivityViewController.swift
+//  NetNewsWire-iOS
+//
+//  Created by Martin Hartl on 01/11/20.
+//  Copyright © 2020 Ranchero Software. All rights reserved.
+//
+
+import UIKit
+
+extension UIActivityViewController {
+	convenience init(url: URL, title: String?, applicationActivities: [UIActivity]?) {
+		let itemSource = ArticleActivityItemSource(url: url, subject: title)
+		let titleSource = TitleActivityItemSource(title: title)
+		
+		self.init(activityItems: [titleSource, itemSource], applicationActivities: applicationActivities)
+	}
+}


### PR DESCRIPTION
While working on the previous Omnifocus related ticket, @douglashill mentioned how Firefox deals with the [issue](https://github.com/mozilla-mobile/firefox-ios/blob/master/Client/Frontend/Share/TitleActivityItemProvider.swift) of Omnifocus not populating the title and notes field as expected.

The changes in this PR are now a combination of the previous approach, to define all the exceptions where UIActivityViewController should share more than just a URL (Omnifocus, Things), and sharing several `UIActivityItemSource` objects instead of a formatted string.

`TitleActivityItemSource` only returns data if the sharing is happening to Omnifocus and Things. In other cases it returns null and will not be considered.

This addresses issue #1590 