### PR TITLE
Treat empty URLs as nil for web feed home pages

### DIFF
--- a/Frameworks/Account/WebFeed.swift
+++ b/Frameworks/Account/WebFeed.swift
@@ -42,7 +42,7 @@ public final class WebFeed: Feed, Renamable, Hashable {
 			return metadata.homePageURL
 		}
 		set {
-			if let url = newValue {
+			if let url = newValue, !url.isEmpty {
 				metadata.homePageURL = url.rs_normalizedURL()
 			}
 			else {


### PR DESCRIPTION
Fixes #1612.

The correct fix is probably to make `-rs_normalizedURLString` return `nil` when the URL string is all whitespace, but that would require extra code changes and testing, and can probably wait until it's ported to Swift.