### PR TITLE
Fix read articles switching back to unread in Feedly

### DIFF
--- a/Frameworks/Account/AccountTests/Feedly/FeedlyAddNewFeedOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyAddNewFeedOperationTests.swift
@@ -89,6 +89,7 @@ class FeedlyAddNewFeedOperationTests: XCTestCase {
 		}
 		
 		let progress = DownloadProgress(numberOfTasks: 0)
+		let container = support.makeTestDatabaseContainer()
 		let _ = expectationForCompletion(of: progress)
 		
 		let addNewFeed = try! FeedlyAddNewFeedOperation(account: account,
@@ -99,6 +100,7 @@ class FeedlyAddNewFeedOperationTests: XCTestCase {
 														addToCollectionService: caller,
 														syncUnreadIdsService: caller,
 														getStreamContentsService: caller,
+														database: container.database,
 														container: folder,
 														progress: progress,
 														log: support.log)
@@ -126,6 +128,7 @@ class FeedlyAddNewFeedOperationTests: XCTestCase {
 		}
 		
 		let progress = DownloadProgress(numberOfTasks: 0)
+		let container = support.makeTestDatabaseContainer()
 		let _ = expectationForCompletion(of: progress)
 		
 		let subdirectory = "feedly-add-new-feed"
@@ -145,6 +148,7 @@ class FeedlyAddNewFeedOperationTests: XCTestCase {
 														addToCollectionService: caller,
 														syncUnreadIdsService: caller,
 														getStreamContentsService: caller,
+														database: container.database,
 														container: folder,
 														progress: progress,
 														log: support.log)
@@ -191,6 +195,7 @@ class FeedlyAddNewFeedOperationTests: XCTestCase {
 		}
 		
 		let progress = DownloadProgress(numberOfTasks: 0)
+		let container = support.makeTestDatabaseContainer()
 		let _ = expectationForCompletion(of: progress)
 		
 		let subdirectory = "feedly-add-new-feed"
@@ -220,6 +225,7 @@ class FeedlyAddNewFeedOperationTests: XCTestCase {
 														addToCollectionService: service,
 														syncUnreadIdsService: caller,
 														getStreamContentsService: caller,
+														database: container.database,
 														container: folder,
 														progress: progress,
 														log: support.log)

--- a/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
+++ b/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
@@ -156,7 +156,7 @@ final class FeedlyAccountDelegate: AccountDelegate {
 		
 		let group = DispatchGroup()
 		
-		let ingestUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, credentials: credentials, service: caller, newerThan: nil, log: log)
+		let ingestUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, credentials: credentials, service: caller, database: database, newerThan: nil, log: log)
 		
 		group.enter()
 		ingestUnread.completionBlock = {
@@ -164,7 +164,7 @@ final class FeedlyAccountDelegate: AccountDelegate {
 			
 		}
 		
-		let ingestStarred = FeedlyIngestStarredArticleIdsOperation(account: account, credentials: credentials, service: caller, newerThan: nil, log: log)
+		let ingestStarred = FeedlyIngestStarredArticleIdsOperation(account: account, credentials: credentials, service: caller, database: database, newerThan: nil, log: log)
 		
 		group.enter()
 		ingestStarred.completionBlock = {
@@ -297,6 +297,7 @@ final class FeedlyAccountDelegate: AccountDelegate {
 														   addToCollectionService: caller,
 														   syncUnreadIdsService: caller,
 														   getStreamContentsService: caller,
+														   database: database,
 														   container: container,
 														   progress: refreshProgress,
 														   log: log)

--- a/Frameworks/Account/Feedly/Operations/FeedlySyncAllOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlySyncAllOperation.swift
@@ -73,7 +73,7 @@ final class FeedlySyncAllOperation: FeedlyOperation {
 		self.operationQueue.addOperation(getAllArticleIds)
 		
 		// Get each page of unread article ids in the global.all stream for the last 31 days (nil = Feedly API default).
-		let getUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, credentials: credentials, service: getUnreadService, newerThan: nil, log: log)
+		let getUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, credentials: credentials, service: getUnreadService, database: database, newerThan: nil, log: log)
 		getUnread.delegate = self
 		getUnread.addDependency(getAllArticleIds)
 		getUnread.downloadProgress = downloadProgress
@@ -88,7 +88,7 @@ final class FeedlySyncAllOperation: FeedlyOperation {
 		self.operationQueue.addOperation(getUpdated)
 		
 		// Get each page of the article ids for starred articles.
-		let getStarred = FeedlyIngestStarredArticleIdsOperation(account: account, credentials: credentials, service: getStarredService, newerThan: nil, log: log)
+		let getStarred = FeedlyIngestStarredArticleIdsOperation(account: account, credentials: credentials, service: getStarredService, database: database, newerThan: nil, log: log)
 		getStarred.delegate = self
 		getStarred.downloadProgress = downloadProgress
 		getStarred.addDependency(createFeedsOperation)


### PR DESCRIPTION
This PR fixes an issue where a pending status created during syncing with Feedly is temporarily overridden by Feedly’s status of the same article.

 Fixes #1516.