### PR TITLE
Gives iOS a chance to open universal links

### DIFF
--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -354,9 +354,17 @@ extension WebViewController: WKNavigationDelegate {
 			
 			let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
 			if components?.scheme == "http" || components?.scheme == "https" {
-				let vc = SFSafariViewController(url: url)
-				present(vc, animated: true)
 				decisionHandler(.cancel)
+				
+				// If the resource cannot be opened with an installed app, present the web view.
+				UIApplication.shared.open(url, options: [.universalLinksOnly: true]) { didOpen in
+					assert(Thread.isMainThread)
+					guard didOpen == false else {
+						return
+					}
+					let vc = SFSafariViewController(url: url)
+					self.present(vc, animated: true)
+				}
 			} else {
 				decisionHandler(.allow)
 			}


### PR DESCRIPTION
This PR implements #1625. 

Turns out Twitter [doesn't seem to support universal links](https://twitter.com/.well-known/apple-app-site-association) per Apple's [documentation](https://developer.apple.com/documentation/security/password_autofill/setting_up_an_app_s_associated_domains#3001215). I'll reach out to Twitter and see what's going on.

One way I verified this PR is by installing YouTube on my device and opening a YouTube URL. For example, the kottke.org article titled "Noah Takes a Photo of Himself Every Day for 20 Years" contains a link "The Simpsons even did a parody of it" to a YouTube video.