### PR TITLE
Fix test failures by cancelling operations with the queue.

### DIFF
--- a/Frameworks/Account/AccountTests/Feedly/FeedlyCheckpointOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyCheckpointOperationTests.swift
@@ -55,7 +55,7 @@ class FeedlyCheckpointOperationTests: XCTestCase {
 		
 		MainThreadOperationQueue.shared.addOperation(operation)
 		
-		operation.cancel()
+		MainThreadOperationQueue.shared.cancelOperations([operation])
 		
 		waitForExpectations(timeout: 1)
 	}

--- a/Frameworks/Account/AccountTests/Feedly/FeedlyLogoutOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyLogoutOperationTests.swift
@@ -75,7 +75,7 @@ class FeedlyLogoutOperationTests: XCTestCase {
 		
 		MainThreadOperationQueue.shared.addOperation(logout)
 		
-		logout.cancel()
+		MainThreadOperationQueue.shared.cancelOperations([logout])
 		
 		waitForExpectations(timeout: 1)
 		

--- a/Frameworks/Account/AccountTests/Feedly/FeedlyOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyOperationTests.swift
@@ -117,7 +117,7 @@ class FeedlyOperationTests: XCTestCase {
 		
 		MainThreadOperationQueue.shared.addOperation(testOperation)
 		
-		testOperation.cancel()
+		MainThreadOperationQueue.shared.cancelOperations([testOperation])
 		
 		waitForExpectations(timeout: 2)
 		
@@ -180,8 +180,8 @@ class FeedlyOperationTests: XCTestCase {
 		MainThreadOperationQueue.shared.addOperation(testOperation)
 		
 		XCTAssertTrue(progress.numberRemaining == 1)
-		testOperation.cancel()
-		XCTAssertTrue(progress.numberRemaining == 1)
+		MainThreadOperationQueue.shared.cancelOperations([testOperation])
+		XCTAssertTrue(progress.numberRemaining == 0)
 		
 		waitForExpectations(timeout: 2)
 		

--- a/Frameworks/Account/AccountTests/Feedly/FeedlyRefreshAccessTokenOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyRefreshAccessTokenOperationTests.swift
@@ -63,7 +63,7 @@ class FeedlyRefreshAccessTokenOperationTests: XCTestCase {
 		
 		MainThreadOperationQueue.shared.addOperation(refresh)
 		
-		refresh.cancel()
+		MainThreadOperationQueue.shared.cancelOperations([refresh])
 		
 		waitForExpectations(timeout: 1)
 		

--- a/Frameworks/Account/AccountTests/Feedly/FeedlyUpdateAccountFeedsWithItemsOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlyUpdateAccountFeedsWithItemsOperationTests.swift
@@ -127,7 +127,7 @@ class FeedlyUpdateAccountFeedsWithItemsOperationTests: XCTestCase {
 		
 		MainThreadOperationQueue.shared.addOperation(update)
 		
-		update.cancel()
+		MainThreadOperationQueue.shared.cancelOperations([update])
 		
 		waitForExpectations(timeout: 2)
 		


### PR DESCRIPTION
It seems operations no longer can cancel themselves.