### PR TITLE
Subscribing to a Feedly feed only downloads the first page worth of content

### DIFF
--- a/Frameworks/Account/AccountTests/Feedly/FeedlySyncStreamContentsOperationTests.swift
+++ b/Frameworks/Account/AccountTests/Feedly/FeedlySyncStreamContentsOperationTests.swift
@@ -45,7 +45,7 @@ class FeedlySyncStreamContentsOperationTests: XCTestCase {
 			XCTAssertNil(serviceUnreadOnly)
 		}
 		
-		let syncStreamContents = FeedlySyncStreamContentsOperation(account: account, resource: resource, service: service, newerThan: newerThan, log: support.log)
+		let syncStreamContents = FeedlySyncStreamContentsOperation(account: account, resource: resource, service: service, isPagingEnabled: true, newerThan: newerThan, log: support.log)
 		
 		let completionExpectation = expectation(description: "Did Finish")
 		syncStreamContents.completionBlock = { _ in
@@ -79,7 +79,7 @@ class FeedlySyncStreamContentsOperationTests: XCTestCase {
 			XCTAssertNil(serviceUnreadOnly)
 		}
 		
-		let syncStreamContents = FeedlySyncStreamContentsOperation(account: account, resource: resource, service: service, newerThan: newerThan, log: support.log)
+		let syncStreamContents = FeedlySyncStreamContentsOperation(account: account, resource: resource, service: service, isPagingEnabled: true, newerThan: newerThan, log: support.log)
 		
 		let completionExpectation = expectation(description: "Did Finish")
 		syncStreamContents.completionBlock = { _ in
@@ -120,7 +120,7 @@ class FeedlySyncStreamContentsOperationTests: XCTestCase {
 			getStreamPageExpectation.fulfill()
 		}
 		
-		let syncStreamContents = FeedlySyncStreamContentsOperation(account: account, resource: resource, service: service, newerThan: newerThan, log: support.log)
+		let syncStreamContents = FeedlySyncStreamContentsOperation(account: account, resource: resource, service: service, isPagingEnabled: true, newerThan: newerThan, log: support.log)
 		
 		let completionExpectation = expectation(description: "Did Finish")
 		syncStreamContents.completionBlock = { _ in

--- a/Frameworks/Account/Feedly/Operations/FeedlyAddNewFeedOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyAddNewFeedOperation.swift
@@ -83,28 +83,28 @@ class FeedlyAddNewFeedOperation: FeedlyOperation, FeedlyOperationDelegate, Feedl
 		let addRequest = FeedlyAddFeedToCollectionOperation(account: account, folder: folder, feedResource: feedResourceId, feedName: feedName, collectionId: collectionId, service: addToCollectionService)
 		addRequest.delegate = self
 		addRequest.downloadProgress = downloadProgress
-		self.operationQueue.addOperation(addRequest)
+		operationQueue.addOperation(addRequest)
 		
 		let createFeeds = FeedlyCreateFeedsForCollectionFoldersOperation(account: account, feedsAndFoldersProvider: addRequest, log: log)
 		operationQueue.make(createFeeds, dependOn: addRequest)
 		createFeeds.downloadProgress = downloadProgress
-		self.operationQueue.addOperation(createFeeds)
+		operationQueue.addOperation(createFeeds)
 		
 		let syncUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, credentials: credentials, service: syncUnreadIdsService, database: database, newerThan: nil, log: log)
 		operationQueue.make(syncUnread, dependOn: createFeeds)
 		syncUnread.downloadProgress = downloadProgress
-		self.operationQueue.addOperation(syncUnread)
+		operationQueue.addOperation(syncUnread)
 		
-		let syncFeed = FeedlySyncStreamContentsOperation(account: account, resource: feedResourceId, service: getStreamContentsService, newerThan: nil, log: log)
+		let syncFeed = FeedlySyncStreamContentsOperation(account: account, resource: feedResourceId, service: getStreamContentsService, isPagingEnabled: false, newerThan: nil, log: log)
 		operationQueue.make(syncFeed, dependOn: syncUnread)
 		syncFeed.downloadProgress = downloadProgress
-		self.operationQueue.addOperation(syncFeed)
+		operationQueue.addOperation(syncFeed)
 		
 		let finishOperation = FeedlyCheckpointOperation()
 		finishOperation.checkpointDelegate = self
 		finishOperation.downloadProgress = downloadProgress
 		operationQueue.make(finishOperation, dependOn: syncFeed)
-		self.operationQueue.addOperation(finishOperation)
+		operationQueue.addOperation(finishOperation)
 	}
 	
 	func feedlyOperation(_ operation: FeedlyOperation, didFailWith error: Error) {

--- a/Frameworks/Account/Feedly/Operations/FeedlySyncStreamContentsOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlySyncStreamContentsOperation.swift
@@ -17,13 +17,15 @@ final class FeedlySyncStreamContentsOperation: FeedlyOperation, FeedlyOperationD
 	private let operationQueue = MainThreadOperationQueue()
 	private let service: FeedlyGetStreamContentsService
 	private let newerThan: Date?
+	private let isPagingEnabled: Bool
 	private let log: OSLog
 	private let finishOperation: FeedlyCheckpointOperation
 	
-	init(account: Account, resource: FeedlyResourceId, service: FeedlyGetStreamContentsService, newerThan: Date?, log: OSLog) {
+	init(account: Account, resource: FeedlyResourceId, service: FeedlyGetStreamContentsService, isPagingEnabled: Bool, newerThan: Date?, log: OSLog) {
 		self.account = account
 		self.resource = resource
 		self.service = service
+		self.isPagingEnabled = isPagingEnabled
 		self.operationQueue.suspend()
 		self.newerThan = newerThan
 		self.log = log
@@ -38,7 +40,7 @@ final class FeedlySyncStreamContentsOperation: FeedlyOperation, FeedlyOperationD
 	
 	convenience init(account: Account, credentials: Credentials, service: FeedlyGetStreamContentsService, newerThan: Date?, log: OSLog) {
 		let all = FeedlyCategoryResourceId.Global.all(for: credentials.username)
-		self.init(account: account, resource: all, service: service, newerThan: newerThan, log: log)
+		self.init(account: account, resource: all, service: service, isPagingEnabled: true, newerThan: newerThan, log: log)
 	}
 	
 	override func cancel() {
@@ -98,7 +100,7 @@ final class FeedlySyncStreamContentsOperation: FeedlyOperation, FeedlyOperationD
 		
 		os_log(.debug, log: log, "Ingesting %i items from %@", stream.items.count, stream.id)
 		
-		guard let continuation = stream.continuation else {
+		guard isPagingEnabled, let continuation = stream.continuation else {
 			os_log(.debug, log: log, "Reached end of stream for %@", stream.id)
 			return
 		}


### PR DESCRIPTION
This PR makes it that when a Feedly user subscribes to a feed, NNW ingests the 1000 most recent posts.

Previously, we were downloading each and every page.

Maybe related to #1408.