### PR TITLE
Positions the footnote popover on top of other content

### DIFF
--- a/Mac/MainWindow/Detail/styleSheet.css
+++ b/Mac/MainWindow/Detail/styleSheet.css
@@ -212,6 +212,7 @@ img[src*="share-buttons"] {
 .newsfoot-footnote-container {
 	position: relative;
 	display: inline-block;
+	z-index: 9999;
 }
 .newsfoot-footnote-popover {
 	position: absolute;

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -253,6 +253,7 @@ img[src*="share-buttons"] {
 .newsfoot-footnote-container {
 	position: relative;
 	display: inline-block;
+	z-index: 9999;
 }
 .newsfoot-footnote-popover {
 	position: absolute;


### PR DESCRIPTION
Fixes #1611.

I always feel a little weird pulling out the "use a very high `z-index`" trick, but this markup needs to contend with anything people put into feeds so it feels reasonable to reach for a very high level.

I also thought about creating a list of CSS vars to give semantic labels to global z-index rules, but really this is the first global z-index value we’ve needed. I think it's a good idea if we ever start getting at all complex with the layering.

![image](https://user-images.githubusercontent.com/190134/72647252-f29de600-392c-11ea-8839-165af78d91b8.png)
