### PR TITLE
Configure navigation bar with opaque background

### DIFF
--- a/iOS/UIKit Extensions/InteractiveNavigationController.swift
+++ b/iOS/UIKit Extensions/InteractiveNavigationController.swift
@@ -48,9 +48,11 @@ private extension InteractiveNavigationController {
 		isToolbarHidden = false
 		
 		let navigationAppearance = UINavigationBarAppearance()
+		navigationAppearance.configureWithOpaqueBackground()
 		navigationAppearance.titleTextAttributes = [.foregroundColor: UIColor.label]
 		navigationAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.label]
 		navigationBar.standardAppearance = navigationAppearance
+		navigationBar.scrollEdgeAppearance = navigationAppearance
 		navigationBar.tintColor = AppAssets.primaryAccentColor
 		
 		let toolbarAppearance = UIToolbarAppearance()


### PR DESCRIPTION
I tackled issue #1238 with a clean mind without locking at any previous work done for it.
After a few hours, I ended up with a similar solution to https://github.com/Ranchero-Software/NetNewsWire/commit/2a59a28a53a68ea466f6421e3ad875e14c432208 including the regression from #1272.

The fix in this PR goes a different direction and has different drawbacks. Please feel free to reject the PR if this is not the direction we want to go or doesn't address the issue in the expected way:

Calling `configureWithOpaqueBackground` on `UINavigationBarAppearance` configures the bar with opaque colours. Also setting the appearance for `scrollEdgeAppearance` hides the scrolled past items from behind the navigation bar, as outlined in the issue:

[result.mov.zip](https://github.com/Ranchero-Software/NetNewsWire/files/4082394/result.mov.zip)

Because of the opaque colours, scrolled past items no longer cause the tiny blurred colour effect on the navigation bar.

Also the fading-in animation of the large title navigation bar changes, as you can see comparing these two videos:

[old-new.zip](https://github.com/Ranchero-Software/NetNewsWire/files/4082398/old-new.zip)