### PR TITLE
Apply UINavigationBarAppearance appearance to scroll edge

### DIFF
--- a/iOS/UIKit Extensions/InteractiveNavigationController.swift
+++ b/iOS/UIKit Extensions/InteractiveNavigationController.swift
@@ -51,6 +51,7 @@ private extension InteractiveNavigationController {
 		navigationAppearance.titleTextAttributes = [.foregroundColor: UIColor.label]
 		navigationAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.label]
 		navigationBar.standardAppearance = navigationAppearance
+		navigationBar.scrollEdgeAppearance = navigationAppearance
 		navigationBar.tintColor = AppAssets.primaryAccentColor
 		
 		let toolbarAppearance = UIToolbarAppearance()


### PR DESCRIPTION
This PR is an evolution of #1651 and addresses issue #1238.

Apply the navigation bar appearance to the scroll edge seems to fix the issue of items being shown behind the navigation bar.
As mentioned in the previous PR, the large title animation when popping the ViewController is slightly different with the applied appearance.