### PR TITLE
Stop media playback when article will disappear

### DIFF
--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -123,6 +123,12 @@ class WebViewController: UIViewController {
 		}
 		
 	}
+
+	override func viewWillDisappear(_ animated: Bool) {
+		super.viewWillDisappear(animated)
+
+		stopMediaPlayback()
+	}
 	
 	// MARK: Notifications
 	
@@ -525,6 +531,10 @@ private extension WebViewController {
 			
 			coordinator.showFullScreenImage(image: image, imageTitle: clickMessage.imageTitle, transitioningDelegate: self)
 		}
+	}
+
+	func stopMediaPlayback() {
+		webView?.evaluateJavaScript("stopMediaPlayback();")
 	}
 	
 	func configureTopShowBarsView() {

--- a/iOS/Resources/main_ios.js
+++ b/iOS/Resources/main_ios.js
@@ -145,3 +145,14 @@ function postRenderProcessing() {
 	ImageViewer.init();
 	inlineVideos();
 }
+
+function stopMediaPlayback() {
+	document.querySelectorAll("iframe").forEach(element => {
+		var iframeSrc = element.src;
+		element.src = iframeSrc;
+	});
+
+	document.querySelectorAll("video, audio").forEach(element => {
+		element.pause();
+	});
+}


### PR DESCRIPTION
This PR addresses issue #1647 

Stopping the playback of pure video element can easily be done by calling `pause` on the element.
Youtube and Vimeo videos are wrapped in frames, there we can't directly access the video element. Resetting the `src` of the iframe will stop the playback.

I'm not sure if this is a solution we want to go for but it worked well in my testings. I also included stopping of audio element.

As usual, very happy to adjust or explore further if we can go for a different solution.