### PR TITLE
Table CSS

### DIFF
--- a/Mac/MainWindow/Detail/styleSheet.css
+++ b/Mac/MainWindow/Detail/styleSheet.css
@@ -39,6 +39,7 @@ a:hover {
 	--body-code-color: #666;
 	--system-message-color: #cbcbcb;
 	--feedlink-color: rgba(0, 0, 0, 0.6);
+	--table-cell-border-color: lightgray;
 }
 
 @media(prefers-color-scheme: dark) {
@@ -50,7 +51,8 @@ a:hover {
 		--header-color: #d2d2d2;
 		--header-link-color: #4490e2;
 		--body-code-color: #b2b2b2;
-		--system-message-color: #5f5f5f
+		--system-message-color: #5f5f5f;
+		--table-cell-border-color: dimgray;
 	}
 }
 
@@ -129,6 +131,36 @@ code, pre {
 	font-family: "SF Mono", Menlo, "Courier New", Courier, monospace;
 	font-size: 14px;
 }
+
+/*
+ Instead of the last-child bits, border-collapse: collapse
+ could have been used. However, then the inter-cell borders
+ overlap the table border, which looks bad.
+ */
+.nnw-overflow table {
+	margin-bottom: 1px;
+	border-spacing: 0;
+	border: 1px solid #777;
+}
+.nnw-overflow td, .nnw-overflow th {
+	-webkit-hyphens: none;
+	word-break: normal;
+	border: 1px solid var(--table-cell-border-color);
+	border-top: none;
+	border-left: none;
+	padding: 5px;
+}
+.nnw-overflow tr td:last-child, .nnw-overflow tr th:last-child {
+	border-right: none;
+}
+.nnw-overflow tr:last-child td, .nnw-overflow tr:last-child th {
+	border-bottom: none;
+}
+.nnw-overflow td pre {
+	border: none;
+	padding: 0;
+}
+
 img, figure, iframe, div {
 	max-width: 100%;
 	height: auto !important;

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -45,6 +45,7 @@ a:hover {
 	--system-message-color: #cbcbcb;
 	--feedlink-color: rgba(0, 0, 0, 0.6);
 	--article-title-color: #333;
+	--table-border-color: lightgray;
 }
 
 @media(prefers-color-scheme: dark) {
@@ -56,6 +57,7 @@ a:hover {
 		--body-code-color: #b2b2b2;
 		--system-message-color: #5f5f5f;
 		--article-title-color: #e0e0e0;
+		--table-border-color: dimgray;
 	}
 }
 
@@ -138,14 +140,44 @@ pre {
 	word-wrap: normal;
 	word-break: normal;
 }
-.nnw-overflow {
-	overflow-x: auto;
-}
 code, pre {
 	font-family: "SF Mono", Menlo, "Courier New", Courier, monospace;
 	font-size: .8235rem;
 	-webkit-hyphens: none;
 }
+
+.nnw-overflow {
+	overflow-x: auto;
+}
+/*
+ Instead of the last-child bits, border-collapse: collapse
+ could have been used. However, then the inter-cell borders
+ overlap the table border, which looks bad.
+ */
+.nnw-overflow table {
+	margin-bottom: 1px;
+	border-spacing: 0;
+	border: 1px solid var(--secondary-accent-color);
+}
+.nnw-overflow td, .nnw-overflow th {
+	-webkit-hyphens: none;
+	word-break: normal;
+	border: 1px solid var(--table-border-color);
+	border-top: none;
+	border-left: none;
+	padding: 5px;
+}
+.nnw-overflow tr td:last-child, .nnw-overflow tr th:last-child {
+	border-right: none;
+}
+.nnw-overflow tr:last-child td, .nnw-overflow tr:last-child th {
+	border-bottom: none;
+}
+.nnw-overflow td pre {
+	border: none;
+	padding: 0;
+}
+
 img, figure, iframe, div {
 	max-width: 100%;
 	height: auto !important;

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -45,7 +45,7 @@ a:hover {
 	--system-message-color: #cbcbcb;
 	--feedlink-color: rgba(0, 0, 0, 0.6);
 	--article-title-color: #333;
-	--table-border-color: lightgray;
+	--table-cell-border-color: lightgray;
 }
 
 @media(prefers-color-scheme: dark) {
@@ -57,7 +57,7 @@ a:hover {
 		--body-code-color: #b2b2b2;
 		--system-message-color: #5f5f5f;
 		--article-title-color: #e0e0e0;
-		--table-border-color: dimgray;
+		--table-cell-border-color: dimgray;
 	}
 }
 
@@ -162,7 +162,7 @@ code, pre {
 .nnw-overflow td, .nnw-overflow th {
 	-webkit-hyphens: none;
 	word-break: normal;
-	border: 1px solid var(--table-border-color);
+	border: 1px solid var(--table-cell-border-color);
 	border-top: none;
 	border-left: none;
 	padding: 5px;


### PR DESCRIPTION
Disables hyphenation and break-in-word in table cells, and also adds a faint border to cells. Colors the borders of tables the same color as we use for pre and the left side of blockquote.

Fixes #1662; fixes #1663.