### PR TITLE
Rename Feedbin account "Create" button to "Add Account"

### DIFF
--- a/Mac/Preferences/Accounts/AccountsFeedbinWindowController.swift
+++ b/Mac/Preferences/Accounts/AccountsFeedbinWindowController.swift
@@ -34,7 +34,7 @@ class AccountsFeedbinWindowController: NSWindowController {
 			}
 			actionButton.title = NSLocalizedString("Update", comment: "Update")
 		} else {
-			actionButton.title = NSLocalizedString("Create", comment: "Create")
+			actionButton.title = NSLocalizedString("Add Account", comment: "Add Account")
 		}
 	}
 	


### PR DESCRIPTION
Fixes #1544