### PR TITLE
Put <title> and <base> in the <head> instead of <body>

### DIFF
--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -199,6 +199,8 @@ extension DetailWebViewController: WKNavigationDelegate {
 struct TemplateData: Codable {
 	let style: String
 	let body: String
+	let title: String
+	let baseURL: String
 }
 
 private extension DetailWebViewController {
@@ -227,7 +229,7 @@ private extension DetailWebViewController {
 			rendering = ArticleRenderer.articleHTML(article: article, extractedArticle: extractedArticle, style: style)
 		}
 		
-		let templateData = TemplateData(style: rendering.style, body: rendering.html)
+		let templateData = TemplateData(style: rendering.style, body: rendering.html, title: rendering.title, baseURL: rendering.baseURL)
 		
 		let encoder = JSONEncoder()
 		var render = "error();"

--- a/Mac/MainWindow/Detail/page.html
+++ b/Mac/MainWindow/Detail/page.html
@@ -1,5 +1,7 @@
 <html>
     <head>
+		<title></title>
+		<base href="">
         <style>
         </style>
         <script src="main.js"></script>

--- a/Mac/MainWindow/Detail/page.html
+++ b/Mac/MainWindow/Detail/page.html
@@ -1,13 +1,13 @@
 <html>
-    <head>
+	<head>
 		<title></title>
 		<base href="">
-        <style>
-        </style>
-        <script src="main.js"></script>
-        <script src="main_mac.js"></script>
+		<style>
+		</style>
+		<script src="main.js"></script>
+		<script src="main_mac.js"></script>
 		<script src="newsfoot.js" async="async"></script>
-    </head>
-    <body>
-    </body>
+	</head>
+	<body>
+	</body>
 </html>

--- a/Shared/Article Rendering/ArticleRenderer.swift
+++ b/Shared/Article Rendering/ArticleRenderer.swift
@@ -13,7 +13,7 @@ import Account
 
 struct ArticleRenderer {
 
-	typealias Rendering = (style: String, html: String)
+	typealias Rendering = (style: String, html: String, title: String, baseURL: String)
 	typealias Page = (url: URL, baseURL: URL)
 
 	static var imageIconScheme = "nnwImageIcon"
@@ -49,27 +49,27 @@ struct ArticleRenderer {
 
 	static func articleHTML(article: Article, extractedArticle: ExtractedArticle? = nil, style: ArticleStyle) -> Rendering {
 		let renderer = ArticleRenderer(article: article, extractedArticle: extractedArticle, style: style)
-		return (renderer.styleString(), renderer.articleHTML)
+		return (renderer.styleString(), renderer.articleHTML, renderer.title, renderer.baseURL ?? "")
 	}
 
 	static func multipleSelectionHTML(style: ArticleStyle) -> Rendering {
 		let renderer = ArticleRenderer(article: nil, extractedArticle: nil, style: style)
-		return (renderer.styleString(), renderer.multipleSelectionHTML)
+		return (renderer.styleString(), renderer.multipleSelectionHTML, renderer.title, renderer.baseURL ?? "")
 	}
 
 	static func loadingHTML(style: ArticleStyle) -> Rendering {
 		let renderer = ArticleRenderer(article: nil, extractedArticle: nil, style: style)
-		return (renderer.styleString(), renderer.loadingHTML)
+		return (renderer.styleString(), renderer.loadingHTML, renderer.title, renderer.baseURL ?? "")
 	}
 
 	static func noSelectionHTML(style: ArticleStyle) -> Rendering {
 		let renderer = ArticleRenderer(article: nil, extractedArticle: nil, style: style)
-		return (renderer.styleString(), renderer.noSelectionHTML)
+		return (renderer.styleString(), renderer.noSelectionHTML, renderer.title, renderer.baseURL ?? "")
 	}
 	
 	static func noContentHTML(style: ArticleStyle) -> Rendering {
 		let renderer = ArticleRenderer(article: nil, extractedArticle: nil, style: style)
-		return (renderer.styleString(), renderer.noContentHTML)
+		return (renderer.styleString(), renderer.noContentHTML, renderer.title, renderer.baseURL ?? "")
 	}
 }
 
@@ -79,26 +79,26 @@ private extension ArticleRenderer {
 
 	private var articleHTML: String {
 		let body = try! MacroProcessor.renderedText(withTemplate: template(), substitutions: articleSubstitutions())
-		return renderHTML(withBody: body)
+		return body
 	}
 
 	private var multipleSelectionHTML: String {
 		let body = "<h3 class='systemMessage'>Multiple selection</h3>"
-		return renderHTML(withBody: body)
+		return body
 	}
 
 	private var loadingHTML: String {
 		let body = "<h3 class='systemMessage'>Loading...</h3>"
-		return renderHTML(withBody: body)
+		return body
 	}
 
 	private var noSelectionHTML: String {
 		let body = "<h3 class='systemMessage'>No selection</h3>"
-		return renderHTML(withBody: body)
+		return body
 	}
 
 	private var noContentHTML: String {
-		return renderHTML(withBody: "")
+		return ""
 	}
 
 	static var defaultStyleSheet: String = {
@@ -223,17 +223,6 @@ private extension ArticleRenderer {
 		dateFormatter.dateStyle = dateStyle
 		dateFormatter.timeStyle = timeStyle
 		return dateFormatter.string(from: date)
-	}
-
-	func renderHTML(withBody body: String) -> String {
-		var s = ""
-		if let baseURL = baseURL {
-			s += ("<base href=\"" + baseURL + "\"\n>")
-		}
-		s += title.htmlBySurroundingWithTag("title")
-		
-		s += body
-		return s
 	}
 
 }

--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -90,6 +90,13 @@ function error() {
 
 function render(data, scrollY) {
 	document.getElementsByTagName("style")[0].innerHTML = data.style;
+
+	let title = document.getElementsByTagName("title")[0];
+	title.textContent = data.title
+
+	let base = document.getElementsByTagName("base")[0];
+	base.href = data.baseURL
+
 	document.body.innerHTML = data.body;
 	
 	window.scrollTo(0, scrollY);

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -437,6 +437,8 @@ extension WebViewController: UIScrollViewDelegate {
 private struct TemplateData: Codable {
 	let style: String
 	let body: String
+	let title: String
+	let baseURL: String
 }
 
 private struct ImageClickMessage: Codable {
@@ -478,7 +480,7 @@ private extension WebViewController {
 			rendering = ArticleRenderer.noSelectionHTML(style: style)
 		}
 		
-		let templateData = TemplateData(style: rendering.style, body: rendering.html)
+		let templateData = TemplateData(style: rendering.style, body: rendering.html, title: rendering.title, baseURL: rendering.baseURL)
 		
 		let encoder = JSONEncoder()
 		var render = "error();"

--- a/iOS/Resources/page.html
+++ b/iOS/Resources/page.html
@@ -1,17 +1,17 @@
 <html>
-    <head>
+	<head>
 		<title></title>
 		<base href="">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-        <style>
+		<style>
 			:root {
 				color-scheme: light dark;
 			}
-        </style>
-        <script src="main.js"></script>
-        <script src="main_ios.js"></script>
+		</style>
+		<script src="main.js"></script>
+		<script src="main_ios.js"></script>
 		<script src="newsfoot.js" async="async"></script>
-    </head>
-    <body>
-    </body>
+	</head>
+	<body>
+	</body>
 </html>

--- a/iOS/Resources/page.html
+++ b/iOS/Resources/page.html
@@ -1,5 +1,7 @@
 <html>
     <head>
+		<title></title>
+		<base href="">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
         <style>
 			:root {


### PR DESCRIPTION
This also means renderHTML() is no longer needed.

Fixes #1744.