### PR TITLE
Set lastImageCacheFlushDate on launch in CacheCleaner instead of registerDefaults()

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -226,8 +226,7 @@ struct AppDefaults {
  		let showDebugMenu = false
  		#endif
 
-		let defaults: [String : Any] = [Key.lastImageCacheFlushDate: Date(),
-										Key.sidebarFontSize: FontSize.medium.rawValue,
+		let defaults: [String : Any] = [Key.sidebarFontSize: FontSize.medium.rawValue,
 										Key.timelineFontSize: FontSize.medium.rawValue,
 										Key.detailFontSize: FontSize.medium.rawValue,
 										Key.timelineSortDirection: ComparisonResult.orderedDescending.rawValue,

--- a/Shared/Data/CacheCleaner.swift
+++ b/Shared/Data/CacheCleaner.swift
@@ -21,7 +21,7 @@ struct CacheCleaner {
 		}
 		
 		// If the image disk cache hasn't been flushed for 3 days and the network is available, delete it
-		if flushDate.addingTimeInterval(3600*24*3) < Date() {
+		if flushDate.addingTimeInterval(3600 * 24 * 3) < Date() {
 			if let reachability = try? Reachability(hostname: "apple.com") {
 				if reachability.connection != .unavailable {
 

--- a/Shared/Data/CacheCleaner.swift
+++ b/Shared/Data/CacheCleaner.swift
@@ -14,9 +14,14 @@ struct CacheCleaner {
 	static let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "CacheCleaner")
 
 	static func purgeIfNecessary() {
+
+		guard let flushDate = AppDefaults.lastImageCacheFlushDate else {
+			AppDefaults.lastImageCacheFlushDate = Date()
+			return
+		}
 		
 		// If the image disk cache hasn't been flushed for 3 days and the network is available, delete it
-		if let flushDate = AppDefaults.lastImageCacheFlushDate, flushDate.addingTimeInterval(3600*24*3) < Date() {
+		if flushDate.addingTimeInterval(3600*24*3) < Date() {
 			if let reachability = try? Reachability(hostname: "apple.com") {
 				if reachability.connection != .unavailable {
 

--- a/Shared/Favicons/FaviconURLFinder.swift
+++ b/Shared/Favicons/FaviconURLFinder.swift
@@ -40,7 +40,7 @@ struct FaviconURLFinder {
 	///   - homePageURL: The page to search.
 	///   - completion: A closure called when the links have been found.
 	///   - urls: An array of favicon URLs as strings.
-	static func findFaviconURLs(with homePageURL: String, _ completion: @escaping (_ urls:[String]?) -> Void) {
+	static func findFaviconURLs(with homePageURL: String, _ completion: @escaping (_ urls: [String]?) -> Void) {
 
 		guard let _ = URL(string: homePageURL) else {
 			completion(nil)

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -150,8 +150,7 @@ struct AppDefaults {
 	}
 	
 	static func registerDefaults() {
-		let defaults: [String : Any] = [Key.lastImageCacheFlushDate: Date(),
-										Key.timelineGroupByFeed: false,
+		let defaults: [String : Any] = [Key.timelineGroupByFeed: false,
 										Key.refreshClearsReadArticles: false,
 										Key.timelineNumberOfLines: 2,
 										Key.timelineIconSize: IconSize.medium.rawValue,


### PR DESCRIPTION
So it's actually persisted to disk.

Fixes #1770.

(Also includes a spacing tweak in `FaviconDownloader`.)