### PR TITLE
Embedded widget fix

### DIFF
--- a/Mac/MainWindow/Detail/styleSheet.css
+++ b/Mac/MainWindow/Detail/styleSheet.css
@@ -122,9 +122,14 @@ code, pre {
 pre  {
 	white-space: pre-wrap;
 }
-img, figure, video, iframe, div {
+img, figure, video, div {
 	max-width: 100%;
 	height: auto !important;
+	margin: 0 auto;
+}
+
+iframe {
+	max-width: 100%;
 	margin: 0 auto;
 }
 

--- a/Shared/Article Rendering/ArticleRenderer.swift
+++ b/Shared/Article Rendering/ArticleRenderer.swift
@@ -333,6 +333,9 @@ private extension ArticleRenderer {
 		var init = {
 			wrapFrames: function () {
 				document.querySelectorAll("iframe").forEach(element => {
+					if (element.height > 0 || parseInt(element.style.height) > 0)
+						return;
+		
 					var wrapper = document.createElement("div");
 					wrapper.classList.add("iframeWrap");
 					element.parentNode.insertBefore(wrapper, element);

--- a/Shared/Article Rendering/ArticleRenderer.swift
+++ b/Shared/Article Rendering/ArticleRenderer.swift
@@ -324,6 +324,12 @@ private extension ArticleRenderer {
 		s += """
 
 		<script type="text/javascript">
+		function stripStylesFromElement(element, propertiesToStrip) {
+			for (name of propertiesToStrip) {
+				element.style.removeProperty(name);
+			}
+		}
+
 		var init = {
 			wrapFrames: function () {
 				document.querySelectorAll("iframe").forEach(element => {
@@ -335,7 +341,7 @@ private extension ArticleRenderer {
 			},
 			stripStyles: function() {
 				document.getElementsByTagName("body")[0].querySelectorAll("style, link[rel=stylesheet]").forEach(element => element.remove());
-				document.getElementsByTagName("body")[0].querySelectorAll("[style]").forEach(element => element.removeAttribute("style"));
+				document.getElementsByTagName("body")[0].querySelectorAll("[style]").forEach(element => stripStylesFromElement(element, ["color", "background", "font"]));
 			},
 			linkHover: function() {
 				var anchors = document.getElementsByTagName("a");


### PR DESCRIPTION
Fixes #1290.

Changes:
- Don't force iframe height to `auto`.
- Don't wrap iframes that specify their own height in a `div`.

This fixes the height of embeds from music sites while still preventing YouTube embeds from being cut off.