### PR TITLE
Save outline expanded state

### DIFF
--- a/Mac/Base.lproj/MainWindow.storyboard
+++ b/Mac/Base.lproj/MainWindow.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14868"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -283,7 +282,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="166" height="300"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="26" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="23" outlineTableColumn="ih9-mJ-EA7" id="cnV-kg-Dn2" customClass="SidebarOutlineView" customModule="NetNewsWire" customModuleProvider="target">
+                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" autosaveColumns="NO" typeSelect="NO" autosaveName="Sidebar" rowHeight="26" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="23" outlineTableColumn="ih9-mJ-EA7" id="cnV-kg-Dn2" customClass="SidebarOutlineView" customModule="NetNewsWire" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="167" height="300"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="0.0"/>

--- a/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
+++ b/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
@@ -47,6 +47,49 @@ import Account
 		return (node.representedObject as? PasteboardWriterOwner)?.pasteboardWriter
 	}
 
+	func outlineView(_ outlineView: NSOutlineView, persistentObjectForItem item: Any?) -> Any? {
+		if let folder = nodeForItem(item).representedObject as? Folder {
+			return ["folder": folder.name, "account": folder.account?.accountID]
+		}
+
+		if let _ = nodeForItem(item).representedObject as? SmartFeedsController {
+			return "SmartFeeds"
+		}
+
+		if let account = nodeForItem(item).representedObject as? Account {
+			return ["account": account.accountID]
+		}
+
+		return nil
+	}
+
+	func outlineView(_ outlineView: NSOutlineView, itemForPersistentObject object: Any) -> Any? {
+		if let dict = object as? [String: String] {
+			guard let accountName = dict["account"] else {
+				return nil
+			}
+
+			guard let account = AccountManager.shared.existingAccount(with: accountName) else {
+				return nil
+			}
+
+			if let name = dict["folder"] {
+				guard let folder = account.existingFolder(with: name) else {
+					return nil
+				}
+				return treeController.nodeInTreeRepresentingObject(folder)
+			}
+
+			return treeController.nodeInTreeRepresentingObject(account)
+		} else if let identifier = object as? String {
+			if identifier == "SmartFeeds" {
+				return treeController.nodeInTreeRepresentingObject(SmartFeedsController.shared)
+			}
+		}
+
+		return nil
+	}
+
 	// MARK: - Drag and Drop
 
 	func outlineView(_ outlineView: NSOutlineView, draggingSession session: NSDraggingSession, willBeginAt screenPoint: NSPoint, forItems draggedItems: [Any]) {

--- a/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
+++ b/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
@@ -47,17 +47,23 @@ import Account
 		return (node.representedObject as? PasteboardWriterOwner)?.pasteboardWriter
 	}
 
+	enum PersistentObjectKey {
+		static let smartFeeds = "SmartFeeds"
+		static let account = "account"
+		static let folder = "folder"
+	}
+
 	func outlineView(_ outlineView: NSOutlineView, persistentObjectForItem item: Any?) -> Any? {
 		if let folder = nodeForItem(item).representedObject as? Folder {
-			return ["folder": folder.name, "account": folder.account?.accountID]
+			return [PersistentObjectKey.folder: folder.name, PersistentObjectKey.account: folder.account?.accountID]
 		}
 
 		if let _ = nodeForItem(item).representedObject as? SmartFeedsController {
-			return "SmartFeeds"
+			return PersistentObjectKey.smartFeeds
 		}
 
 		if let account = nodeForItem(item).representedObject as? Account {
-			return ["account": account.accountID]
+			return [PersistentObjectKey.account: account.accountID]
 		}
 
 		return nil
@@ -65,7 +71,7 @@ import Account
 
 	func outlineView(_ outlineView: NSOutlineView, itemForPersistentObject object: Any) -> Any? {
 		if let dict = object as? [String: String] {
-			guard let accountName = dict["account"] else {
+			guard let accountName = dict[PersistentObjectKey.account] else {
 				return nil
 			}
 
@@ -73,7 +79,7 @@ import Account
 				return nil
 			}
 
-			if let name = dict["folder"] {
+			if let name = dict[PersistentObjectKey.folder] {
 				guard let folder = account.existingFolder(with: name) else {
 					return nil
 				}
@@ -82,7 +88,7 @@ import Account
 
 			return treeController.nodeInTreeRepresentingObject(account)
 		} else if let identifier = object as? String {
-			if identifier == "SmartFeeds" {
+			if identifier == PersistentObjectKey.smartFeeds {
 				return treeController.nodeInTreeRepresentingObject(SmartFeedsController.shared)
 			}
 		}

--- a/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
+++ b/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
@@ -47,12 +47,6 @@ import Account
 		return (node.representedObject as? PasteboardWriterOwner)?.pasteboardWriter
 	}
 
-	enum PersistentObjectKey {
-		static let smartFeeds = "SmartFeeds"
-		static let account = "account"
-		static let folder = "folder"
-	}
-
 	func outlineView(_ outlineView: NSOutlineView, persistentObjectForItem item: Any?) -> Any? {
 		guard let node = nodeForItem(item).representedObject as? ContainerIdentifiable else {
 			return nil

--- a/Mac/MainWindow/Sidebar/SidebarViewController.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController.swift
@@ -69,18 +69,23 @@ protocol SidebarDelegate: class {
 
 		outlineView.reloadData()
 
-		// Always expand all group items on initial display.
-		var row = 0
-		while(true) {
-			guard let item = outlineView.item(atRow: row) else {
-				break
+		// Always expand all group items on first run.
+		if AppDefaults.isFirstRun {
+			var row = 0
+			while(true) {
+				guard let item = outlineView.item(atRow: row) else {
+					break
+				}
+				let node = item as! Node
+				if node.isGroupItem {
+					outlineView.expandItem(item)
+				}
+				row += 1
 			}
-			let node = item as! Node
-			if node.isGroupItem {
-				outlineView.expandItem(item)
-			}
-			row += 1
 		}
+
+		outlineView.autosaveExpandedItems = true
+
 	}
 
 	// MARK: - Notifications

--- a/Mac/MainWindow/Sidebar/SidebarViewController.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController.swift
@@ -17,7 +17,7 @@ protocol SidebarDelegate: class {
 	func unreadCount(for: AnyObject) -> Int
 }
 
-@objc class SidebarViewController: NSViewController, NSOutlineViewDelegate, NSOutlineViewDataSource, NSMenuDelegate, UndoableCommandRunner {
+@objc class SidebarViewController: NSViewController, NSOutlineViewDelegate, NSMenuDelegate, UndoableCommandRunner {
     
 	@IBOutlet var outlineView: SidebarOutlineView!
 

--- a/Mac/MainWindow/Sidebar/SidebarViewController.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController.swift
@@ -306,7 +306,7 @@ protocol SidebarDelegate: class {
 		selectionDidChange(selectedObjects.isEmpty ? nil : selectedObjects)
     }
 
-	func expandRelevantFoldersForAccount(_ account: Account) {
+	func expandAppropriateFoldersForAccount(_ account: Account) {
 		guard let folders = account.folders else { return }
 
 		guard let autosaveName = outlineView.autosaveName else { return }
@@ -333,7 +333,7 @@ protocol SidebarDelegate: class {
 		guard let item = notification.userInfo?["NSObject"] as? Node,
 			let account = nodeForItem(item).representedObject as? Account else { return }
 
-		expandRelevantFoldersForAccount(account)
+		expandAppropriateFoldersForAccount(account)
 	}
 
 	//MARK: - Node Manipulation


### PR DESCRIPTION
Saves expanded/collapsed state for accounts and folders, and uses the current defaults for first launch. I *think* these states will be used for new (i.e., not restored) windows with the same control identifiers once multi-window support is done, but that'll need to be verified.

The only thing that still needs implementing is restoring the state of expanded folders inside of collapsed accounts when the account is re-expanded. The built-in mechanism saves them, but doesn't auto-expand the folders.

Currently, the state will be completely collapsed for returning users, since the system's state-saving stuff tracks expanded state, not collapsed. A user default along the lines of `hasBeenRunWithOutlineStateSaving` might be appropriate.

(Mostly? fixes #562.)

