### PR TITLE
iOS: Account Login Field should switch first responder on return #1870

### DIFF
--- a/iOS/Account/Account.storyboard
+++ b/iOS/Account/Account.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/iOS/Account/FeedWranglerAccountViewController.swift
+++ b/iOS/Account/FeedWranglerAccountViewController.swift
@@ -78,17 +78,17 @@ class FeedWranglerAccountViewController: UITableViewController {
 			showError(NSLocalizedString("Username & password required.", comment: "Credentials Error"))
 			return
 		}
-	
-		startAnimatingActivityIndicator()
-		disableNavigation()
+		resignFirstResponder()
+		toggleActivityIndicatorAnimation(visible: true)
+		setNavigationEnabled(to: false)
 		
 		// When you fill in the email address via auto-complete it adds extra whitespace
 		let trimmedEmail = email.trimmingCharacters(in: .whitespaces)
 		let credentials = Credentials(type: .feedWranglerBasic, username: trimmedEmail, secret: password)
 		Account.validateCredentials(type: .feedWrangler, credentials: credentials) { result in
 			
-			self.stopAnimtatingActivityIndicator()
-			self.enableNavigation()
+			self.toggleActivityIndicatorAnimation(visible: false)
+			self.setNavigationEnabled(to: true)
 			
 			switch result {
 			case .success(let validatedCredentials):
@@ -138,27 +138,21 @@ class FeedWranglerAccountViewController: UITableViewController {
 	}
 	
 	private func showError(_ message: String) {
-		presentError(title: "Error", message: message)
+		presentError(title: NSLocalizedString("Error", comment: "Credentials Error"), message: message)
 	}
 	
-	private func enableNavigation() {
-		self.cancelBarButtonItem.isEnabled = true
-		self.actionButton.isEnabled = true
+	private func setNavigationEnabled(to value:Bool){
+		cancelBarButtonItem.isEnabled = value
+		actionButton.isEnabled = value
 	}
 	
-	private func disableNavigation() {
-		cancelBarButtonItem.isEnabled = false
-		actionButton.isEnabled = false
-	}
-	
-	private func startAnimatingActivityIndicator() {
-		activityIndicator.isHidden = false
-		activityIndicator.startAnimating()
-	}
-	
-	private func stopAnimtatingActivityIndicator() {
-		self.activityIndicator.isHidden = true
-		self.activityIndicator.stopAnimating()
+	private func toggleActivityIndicatorAnimation(visible value: Bool){
+		activityIndicator.isHidden = !value
+		if value {
+			activityIndicator.startAnimating()
+		} else {
+			activityIndicator.stopAnimating()
+		}
 	}
 		
 }

--- a/iOS/Account/FeedWranglerAccountViewController.swift
+++ b/iOS/Account/FeedWranglerAccountViewController.swift
@@ -164,6 +164,7 @@ extension FeedWranglerAccountViewController: UITextFieldDelegate {
 			passwordTextField.becomeFirstResponder()
 		} else {
 			textField.resignFirstResponder()
+			action(self)
 		}
 		return true
 	}

--- a/iOS/Account/FeedWranglerAccountViewController.swift
+++ b/iOS/Account/FeedWranglerAccountViewController.swift
@@ -166,7 +166,11 @@ class FeedWranglerAccountViewController: UITableViewController {
 extension FeedWranglerAccountViewController: UITextFieldDelegate {
 	
 	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-		textField.resignFirstResponder()
+		if textField == emailTextField {
+			passwordTextField.becomeFirstResponder()
+		} else {
+			textField.resignFirstResponder()
+		}
 		return true
 	}
 	

--- a/iOS/Account/FeedbinAccountViewController.swift
+++ b/iOS/Account/FeedbinAccountViewController.swift
@@ -163,6 +163,7 @@ extension FeedbinAccountViewController: UITextFieldDelegate {
 			passwordTextField.becomeFirstResponder()
 		} else {
 			textField.resignFirstResponder()
+			action(self)
 		}
 		return true
 	}

--- a/iOS/Account/FeedbinAccountViewController.swift
+++ b/iOS/Account/FeedbinAccountViewController.swift
@@ -166,7 +166,11 @@ class FeedbinAccountViewController: UITableViewController {
 extension FeedbinAccountViewController: UITextFieldDelegate {
 	
 	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-		textField.resignFirstResponder()
+		if textField == emailTextField {
+			passwordTextField.becomeFirstResponder()
+		} else {
+			textField.resignFirstResponder()
+		}
 		return true
 	}
 	

--- a/iOS/Account/FeedbinAccountViewController.swift
+++ b/iOS/Account/FeedbinAccountViewController.swift
@@ -79,17 +79,16 @@ class FeedbinAccountViewController: UITableViewController {
 			showError(NSLocalizedString("Username & password required.", comment: "Credentials Error"))
 			return
 		}
-	
-		startAnimatingActivityIndicator()
-		disableNavigation()
+		resignFirstResponder()
+		toggleActivityIndicatorAnimation(visible: true)
+		setNavigationEnabled(to: false)
 		
 		// When you fill in the email address via auto-complete it adds extra whitespace
 		let trimmedEmail = email.trimmingCharacters(in: .whitespaces)
 		let credentials = Credentials(type: .basic, username: trimmedEmail, secret: password)
 		Account.validateCredentials(type: .feedbin, credentials: credentials) { result in
-			
-			self.stopAnimtatingActivityIndicator()
-			self.enableNavigation()
+			self.toggleActivityIndicatorAnimation(visible: false)
+			self.setNavigationEnabled(to: true)
 			
 			switch result {
 			case .success(let credentials):
@@ -138,27 +137,21 @@ class FeedbinAccountViewController: UITableViewController {
 	}
 	
 	private func showError(_ message: String) {
-		presentError(title: "Error", message: message)
+		presentError(title: NSLocalizedString("Error", comment: "Credentials Error"), message: message)
 	}
 	
-	private func enableNavigation() {
-		self.cancelBarButtonItem.isEnabled = true
-		self.actionButton.isEnabled = true
+	private func setNavigationEnabled(to value:Bool){
+		cancelBarButtonItem.isEnabled = value
+		actionButton.isEnabled = value
 	}
 	
-	private func disableNavigation() {
-		cancelBarButtonItem.isEnabled = false
-		actionButton.isEnabled = false
-	}
-	
-	private func startAnimatingActivityIndicator() {
-		activityIndicator.isHidden = false
-		activityIndicator.startAnimating()
-	}
-	
-	private func stopAnimtatingActivityIndicator() {
-		self.activityIndicator.isHidden = true
-		self.activityIndicator.stopAnimating()
+	private func toggleActivityIndicatorAnimation(visible value: Bool){
+		activityIndicator.isHidden = !value
+		if value {
+			activityIndicator.startAnimating()
+		} else {
+			activityIndicator.stopAnimating()
+		}
 	}
 		
 }

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9cW-lu-HoC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9cW-lu-HoC">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>


### PR DESCRIPTION
Contains work on issue [#1870] iOS: Account Login Field should switch first responder on return #1870.

This PR affects both the feedbin and feedly account view-controller.

This PR achieves the following:

- When the user presses the return key in the email textfield the first responder switches to the password field.
- If the user presses the return key while the password field is first responder then the login action is triggered.
- When the user presses the action button the first responder is resigned.
- Some redundant logic in the view controllers has been streamlined. Less code - less bugs.

Greetings from Germany!