### PR TITLE
Align feedname and date correctly if there is no title or summary

### DIFF
--- a/iOS/MasterTimeline/Cell/MasterTimelineDefaultCellLayout.swift
+++ b/iOS/MasterTimeline/Cell/MasterTimelineDefaultCellLayout.swift
@@ -89,7 +89,14 @@ struct MasterTimelineDefaultCellLayout: MasterTimelineCellLayout {
 		}
 		self.summaryRect = MasterTimelineDefaultCellLayout.rectForSummary(cellData, currentPoint, textAreaWidth, numberOfLinesForTitle)
 		
-		currentPoint.y = [self.titleRect, self.summaryRect].maxY()
+		var y = [self.titleRect, self.summaryRect].maxY()
+		if y == 0 {
+			y = iconImageRect.origin.y + iconImageRect.height
+			// Necessary calculation of either feed name or date since we are working with dynamic font-sizes
+			let tmp = MasterTimelineDefaultCellLayout.rectForDate(cellData, currentPoint, textAreaWidth)
+			y -= tmp.height
+		}
+		currentPoint.y = y
 		
 		// Feed Name and Pub Date
 		self.dateRect = MasterTimelineDefaultCellLayout.rectForDate(cellData, currentPoint, textAreaWidth)


### PR DESCRIPTION
This PR contains work related to issue #1807 

This is a general layout change since there shouldn't be any hot fixes for micro.blog only (or ANY platform).