### PR TITLE
CSS tweaks

### DIFF
--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -6,13 +6,17 @@
 body {
 	margin-top: 3px;
 	margin-bottom: 20px;
-	margin-left: 20px;
-	margin-right: 20px;
+	margin-left: auto;
+	margin-right: auto;
+	padding-left: 20px;
+	padding-right: 20px;
 
 	word-wrap: break-word;
 	word-break: break-word;
 	-webkit-hyphens: auto;
 	-webkit-text-size-adjust: none;
+	
+	max-width: 44em;
 }
 
 a {

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -15,7 +15,7 @@ body {
 	word-break: break-word;
 	-webkit-hyphens: auto;
 	-webkit-text-size-adjust: none;
-	
+
 	max-width: 44em;
 }
 
@@ -191,6 +191,11 @@ img, figure, iframe, div {
 	max-width: 100%;
 	height: auto !important;
 	margin: 0 auto;
+}
+
+figure {
+	margin-bottom: 1em;
+	margin-top: 1em;
 }
 
 video {


### PR DESCRIPTION
- Sets `max-width` to `44em` as was done on Mac (fixes #1847).
- Re-adds a 1em top and bottom margin to `figure` elements (which will collapse; fixes #1819).