### PR TITLE
Feedly: renew access token once a day

### DIFF
--- a/Frameworks/Account/AccountMetadata.swift
+++ b/Frameworks/Account/AccountMetadata.swift
@@ -23,6 +23,7 @@ final class AccountMetadata: Codable {
 		case lastArticleFetchStartTime = "lastArticleFetch"
 		case lastArticleFetchEndTime
 		case endpointURL
+		case lastCredentialRenewTime = "lastCredentialRenewTime"
 	}
 
 	var name: String? {
@@ -77,6 +78,16 @@ final class AccountMetadata: Codable {
 		didSet {
 			if endpointURL != oldValue {
 				valueDidChange(.endpointURL)
+			}
+		}
+	}
+	
+	/// The last moment an account successfully renewed its credentials, or `nil` if no such moment exists.
+	/// An account delegate can use this value to decide when to next ask the service provider to renew credentials.
+	var lastCredentialRenewTime: Date? {
+		didSet {
+			if lastCredentialRenewTime != oldValue {
+				valueDidChange(.lastCredentialRenewTime)
 			}
 		}
 	}

--- a/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
+++ b/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
@@ -111,11 +111,20 @@ final class FeedlyAccountDelegate: AccountDelegate {
 		}
 		
 		let log = self.log
-		let operation = FeedlySyncAllOperation(account: account, credentials: credentials, caller: caller, database: database, lastSuccessfulFetchStartDate: accountMetadata?.lastArticleFetchStartTime, downloadProgress: refreshProgress, log: log)
 		
-		operation.downloadProgress = refreshProgress
+		let refreshAccessToken = FeedlyRefreshAccessTokenOperation(account: account, service: self, oauthClient: oauthAuthorizationClient, refreshDate: Date(), log: log)
+		refreshAccessToken.downloadProgress = refreshProgress
+		operationQueue.add(refreshAccessToken)
+		
+		let syncAllOperation = FeedlySyncAllOperation(account: account, feedlyUserId: credentials.username, caller: caller, database: database, lastSuccessfulFetchStartDate: accountMetadata?.lastArticleFetchStartTime, downloadProgress: refreshProgress, log: log)
+		
+		syncAllOperation.downloadProgress = refreshProgress
+		
+		// Ensure the sync uses the latest credential.
+		syncAllOperation.addDependency(refreshAccessToken)
+		
 		let date = Date()
-		operation.syncCompletionHandler = { [weak self] result in
+		syncAllOperation.syncCompletionHandler = { [weak self] result in
 			if case .success = result {
 				self?.accountMetadata?.lastArticleFetchStartTime = date
 				self?.accountMetadata?.lastArticleFetchEndTime = Date()
@@ -125,9 +134,9 @@ final class FeedlyAccountDelegate: AccountDelegate {
 			completion(result)
 		}
 		
-		currentSyncAllOperation = operation
+		currentSyncAllOperation = syncAllOperation
 		
-		operationQueue.add(operation)
+		operationQueue.add(syncAllOperation)
 	}
 	
 	func sendArticleStatus(for account: Account, completion: @escaping ((Result<Void, Error>) -> Void)) {
@@ -155,7 +164,7 @@ final class FeedlyAccountDelegate: AccountDelegate {
 		
 		let group = DispatchGroup()
 		
-		let ingestUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, credentials: credentials, service: caller, database: database, newerThan: nil, log: log)
+		let ingestUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, userId: credentials.username, service: caller, database: database, newerThan: nil, log: log)
 		
 		group.enter()
 		ingestUnread.completionBlock = { _ in
@@ -163,7 +172,7 @@ final class FeedlyAccountDelegate: AccountDelegate {
 			
 		}
 		
-		let ingestStarred = FeedlyIngestStarredArticleIdsOperation(account: account, credentials: credentials, service: caller, database: database, newerThan: nil, log: log)
+		let ingestStarred = FeedlyIngestStarredArticleIdsOperation(account: account, userId: credentials.username, service: caller, database: database, newerThan: nil, log: log)
 		
 		group.enter()
 		ingestStarred.completionBlock = { _ in
@@ -492,9 +501,6 @@ final class FeedlyAccountDelegate: AccountDelegate {
 	
 	func accountDidInitialize(_ account: Account) {
 		credentials = try? account.retrieveCredentials(type: .oauthAccessToken)
-		
-		let refreshAccessToken = FeedlyRefreshAccessTokenOperation(account: account, service: self, oauthClient: oauthAuthorizationClient, log: log)
-		operationQueue.add(refreshAccessToken)
 	}
 	
 	func accountWillBeDeleted(_ account: Account) {

--- a/Frameworks/Account/Feedly/Operations/FeedlyAddNewFeedOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyAddNewFeedOperation.swift
@@ -89,7 +89,7 @@ class FeedlyAddNewFeedOperation: FeedlyOperation, FeedlyOperationDelegate, Feedl
 		createFeeds.downloadProgress = downloadProgress
 		operationQueue.add(createFeeds)
 		
-		let syncUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, credentials: credentials, service: syncUnreadIdsService, database: database, newerThan: nil, log: log)
+		let syncUnread = FeedlyIngestUnreadArticleIdsOperation(account: account, userId: credentials.username, service: syncUnreadIdsService, database: database, newerThan: nil, log: log)
 		syncUnread.addDependency(createFeeds)
 		syncUnread.downloadProgress = downloadProgress
 		syncUnread.delegate = self

--- a/Frameworks/Account/Feedly/Operations/FeedlyGetUpdatedArticleIdsOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyGetUpdatedArticleIdsOperation.swift
@@ -29,8 +29,8 @@ class FeedlyGetUpdatedArticleIdsOperation: FeedlyOperation, FeedlyEntryIdentifie
 		self.log = log
 	}
 	
-	convenience init(account: Account, credentials: Credentials, service: FeedlyGetStreamIdsService, newerThan: Date?, log: OSLog) {
-		let all = FeedlyCategoryResourceId.Global.all(for: credentials.username)
+	convenience init(account: Account, userId: String, service: FeedlyGetStreamIdsService, newerThan: Date?, log: OSLog) {
+		let all = FeedlyCategoryResourceId.Global.all(for: userId)
 		self.init(account: account, resource: all, service: service, newerThan: newerThan, log: log)
 	}
 	

--- a/Frameworks/Account/Feedly/Operations/FeedlyIngestStarredArticleIdsOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyIngestStarredArticleIdsOperation.swift
@@ -25,8 +25,8 @@ final class FeedlyIngestStarredArticleIdsOperation: FeedlyOperation {
 	private var remoteEntryIds = Set<String>()
 	private let log: OSLog
 	
-	convenience init(account: Account, credentials: Credentials, service: FeedlyGetStreamIdsService, database: SyncDatabase, newerThan: Date?, log: OSLog) {
-		let resource = FeedlyTagResourceId.Global.saved(for: credentials.username)
+	convenience init(account: Account, userId: String, service: FeedlyGetStreamIdsService, database: SyncDatabase, newerThan: Date?, log: OSLog) {
+		let resource = FeedlyTagResourceId.Global.saved(for: userId)
 		self.init(account: account, resource: resource, service: service, database: database, newerThan: newerThan, log: log)
 	}
 	

--- a/Frameworks/Account/Feedly/Operations/FeedlyIngestStreamArticleIdsOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyIngestStreamArticleIdsOperation.swift
@@ -28,8 +28,8 @@ class FeedlyIngestStreamArticleIdsOperation: FeedlyOperation {
 		self.log = log
 	}
 	
-	convenience init(account: Account, credentials: Credentials, service: FeedlyGetStreamIdsService, log: OSLog) {
-		let all = FeedlyCategoryResourceId.Global.all(for: credentials.username)
+	convenience init(account: Account, userId: String, service: FeedlyGetStreamIdsService, log: OSLog) {
+		let all = FeedlyCategoryResourceId.Global.all(for: userId)
 		self.init(account: account, resource: all, service: service, log: log)
 	}
 	

--- a/Frameworks/Account/Feedly/Operations/FeedlyIngestUnreadArticleIdsOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyIngestUnreadArticleIdsOperation.swift
@@ -26,8 +26,8 @@ final class FeedlyIngestUnreadArticleIdsOperation: FeedlyOperation {
 	private var remoteEntryIds = Set<String>()
 	private let log: OSLog
 	
-	convenience init(account: Account, credentials: Credentials, service: FeedlyGetStreamIdsService, database: SyncDatabase, newerThan: Date?, log: OSLog) {
-		let resource = FeedlyCategoryResourceId.Global.all(for: credentials.username)
+	convenience init(account: Account, userId: String, service: FeedlyGetStreamIdsService, database: SyncDatabase, newerThan: Date?, log: OSLog) {
+		let resource = FeedlyCategoryResourceId.Global.all(for: userId)
 		self.init(account: account, resource: resource, service: service, database: database, newerThan: newerThan, log: log)
 	}
 	

--- a/Frameworks/Account/Feedly/Operations/FeedlyRefreshAccessTokenOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyRefreshAccessTokenOperation.swift
@@ -38,6 +38,7 @@ final class FeedlyRefreshAccessTokenOperation: FeedlyOperation {
 		}()
 		
 		guard shouldRefresh else {
+			os_log(.debug, log: log, "Skipping access token renewal.")
 			didFinish()
 			return
 		}

--- a/Frameworks/Account/Feedly/Operations/FeedlyRefreshAccessTokenOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyRefreshAccessTokenOperation.swift
@@ -17,14 +17,31 @@ final class FeedlyRefreshAccessTokenOperation: FeedlyOperation {
 	let account: Account
 	let log: OSLog
 	
-	init(account: Account, service: OAuthAccessTokenRefreshing, oauthClient: OAuthAuthorizationClient, log: OSLog) {
+	/// The moment the refresh is being requested. The token will refresh only if the account's `lastCredentialRenewTime` is not on the same day as this moment. When nil, the operation will always refresh the token.
+	let refreshDate: Date?
+	
+	init(account: Account, service: OAuthAccessTokenRefreshing, oauthClient: OAuthAuthorizationClient, refreshDate: Date?, log: OSLog) {
 		self.oauthClient = oauthClient
 		self.service = service
 		self.account = account
+		self.refreshDate = refreshDate
 		self.log = log
 	}
 	
 	override func run() {
+		// Only refresh the token if these dates are not on the same day.
+		let shouldRefresh: Bool = {
+			guard let date = refreshDate, let lastRenewDate = account.metadata.lastCredentialRenewTime else {
+				return true
+			}
+			return !Calendar.current.isDate(lastRenewDate, equalTo: date, toGranularity: .day)
+		}()
+		
+		guard shouldRefresh else {
+			didFinish()
+			return
+		}
+		
 		let refreshToken: Credentials
 		
 		do {
@@ -63,6 +80,8 @@ final class FeedlyRefreshAccessTokenOperation: FeedlyOperation {
 				os_log(.debug, log: log, "Storing access token.")
 				// Now store the access token because we want the account delegate to use it.
 				try account.storeCredentials(grant.accessToken)
+				
+				account.metadata.lastCredentialRenewTime = Date()
 				
 				didFinish()
 			} catch {


### PR DESCRIPTION
This PR:
* Adds the `lastCredentialRenewTime` key to the account metadata.
* Modifies the `FeedlyRefreshAccessTokenOperation` to renew the access token only if `lastCredentialRenewTime` is not on the same day as the date given to the operation.
* Modifies `FeedlyAccountDelegate` to ensure the access token is refreshed before syncing content (i.e.: making a `FeedlyRefreshAccessTokenOperation` a dependency for a `FeedlySyncAllOperation`).

This should eliminate the majority of the Feedly Unauthorized errors. There still might be some other situations, such as when the app first launches and sends read/unread statuses (this should be a silent failure) or searching, etc. I am working on a better solution to the problem than adding this operation in front of every other operation.

Partially implements #1859