### PR TITLE
Fix a11y for zoomed image buttons

### DIFF
--- a/iOS/Article/ImageViewController.swift
+++ b/iOS/Article/ImageViewController.swift
@@ -29,6 +29,8 @@ class ImageViewController: UIViewController {
         super.viewDidLoad()
 		
 		closeButton.imageView?.contentMode = .scaleAspectFit
+		closeButton.accessibilityLabel = NSLocalizedString("Close", comment: "Close")
+		shareButton.accessibilityLabel = NSLocalizedString("Share", comment: "Share")
 		
         imageScrollView.setup()
         imageScrollView.imageScrollViewDelegate = self


### PR DESCRIPTION
Fixes #1969 

Image View Controller buttons both close and share don't have correct
a11y label. This will add the localised label.


### A11y Inspector screen shots

![Screenshot 2020-04-21 at 6 57 13 PM](https://user-images.githubusercontent.com/12063704/79891014-f3f41880-841d-11ea-892d-9bbeb2e34a30.png)
![Screenshot 2020-04-21 at 6 57 22 PM](https://user-images.githubusercontent.com/12063704/79891023-fa829000-841d-11ea-84e9-28a8b595e157.png)
