### PR TITLE
Deselect the cell row when selected for add account view controller

### DIFF
--- a/iOS/Settings/AddAccountViewController.swift
+++ b/iOS/Settings/AddAccountViewController.swift
@@ -32,6 +32,7 @@ class AddAccountViewController: UITableViewController, AddAccountDismissDelegate
 	#endif
 	
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		tableView.deselectRow(at: indexPath, animated: true)
 		switch indexPath.row {
 		case 0:
 			let navController = UIStoryboard.account.instantiateViewController(withIdentifier: "AddLocalAccountNavigationViewController") as! UINavigationController


### PR DESCRIPTION
To avoid the highlighting even after the row is selected.

Possibly fixes #2009 