### PR TITLE
Removes AddAccountDismissDelegate

### DIFF
--- a/iOS/Account/FeedWranglerAccountViewController.swift
+++ b/iOS/Account/FeedWranglerAccountViewController.swift
@@ -20,7 +20,6 @@ class FeedWranglerAccountViewController: UITableViewController {
 	@IBOutlet weak var actionButton: UIButton!
 	
 	weak var account: Account?
-	weak var delegate: AddAccountDismissDelegate?
 
 	override func viewDidLoad() {
         super.viewDidLoad()
@@ -59,7 +58,6 @@ class FeedWranglerAccountViewController: UITableViewController {
 
 	@IBAction func cancel(_ sender: Any) {
 		dismiss(animated: true, completion: nil)
-		delegate?.dismiss()
 	}
 	
 	@IBAction func showHidePassword(_ sender: Any) {
@@ -120,9 +118,7 @@ class FeedWranglerAccountViewController: UITableViewController {
 						}
 					}
 					
-					self.dismiss(animated: true, completion: nil)
-					self.delegate?.dismiss()
-					
+					self.dismiss(animated: true, completion: nil)					
 				} catch {
 					self.showError(NSLocalizedString("Keychain error while storing credentials.", comment: "Credentials Error"))
 				}

--- a/iOS/Account/FeedbinAccountViewController.swift
+++ b/iOS/Account/FeedbinAccountViewController.swift
@@ -20,7 +20,6 @@ class FeedbinAccountViewController: UITableViewController {
 	@IBOutlet weak var actionButton: UIButton!
 	
 	weak var account: Account?
-	weak var delegate: AddAccountDismissDelegate?
 
 	override func viewDidLoad() {
         super.viewDidLoad()
@@ -60,7 +59,6 @@ class FeedbinAccountViewController: UITableViewController {
 
 	@IBAction func cancel(_ sender: Any) {
 		dismiss(animated: true, completion: nil)
-		delegate?.dismiss()
 	}
 	
 	@IBAction func showHidePassword(_ sender: Any) {
@@ -118,7 +116,6 @@ class FeedbinAccountViewController: UITableViewController {
 						}
 						
 						self.dismiss(animated: true, completion: nil)
-						self.delegate?.dismiss()
 					} catch {
 						self.showError(NSLocalizedString("Keychain error while storing credentials.", comment: "Credentials Error"))
 					}

--- a/iOS/Account/LocalAccountViewController.swift
+++ b/iOS/Account/LocalAccountViewController.swift
@@ -12,8 +12,6 @@ import Account
 class LocalAccountViewController: UITableViewController {
 
 	@IBOutlet weak var nameTextField: UITextField!
-	
-	weak var delegate: AddAccountDismissDelegate?
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -25,14 +23,12 @@ class LocalAccountViewController: UITableViewController {
 
 	@IBAction func cancel(_ sender: Any) {
 		dismiss(animated: true, completion: nil)
-		delegate?.dismiss()
 	}
 	
 	@IBAction func add(_ sender: Any) {
 		let account = AccountManager.shared.createAccount(type: .onMyMac)
 		account.name = nameTextField.text
 		dismiss(animated: true, completion: nil)
-		delegate?.dismiss()
 	}
 	
 	override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/iOS/Settings/AddAccountViewController.swift
+++ b/iOS/Settings/AddAccountViewController.swift
@@ -10,11 +10,7 @@ import Account
 import UIKit
 import RSCore
 
-protocol AddAccountDismissDelegate: UIViewController {
-	func dismiss()
-}
-
-class AddAccountViewController: UITableViewController, AddAccountDismissDelegate {
+class AddAccountViewController: UITableViewController {
 
 	@IBOutlet private weak var localAccountImageView: UIImageView!
 	@IBOutlet private weak var localAccountNameLabel: UILabel!
@@ -36,14 +32,10 @@ class AddAccountViewController: UITableViewController, AddAccountDismissDelegate
 		case 0:
 			let navController = UIStoryboard.account.instantiateViewController(withIdentifier: "AddLocalAccountNavigationViewController") as! UINavigationController
 			navController.modalPresentationStyle = .currentContext
-			let addViewController = navController.topViewController as! LocalAccountViewController
-			addViewController.delegate = self
 			present(navController, animated: true)
 		case 1:
 			let navController = UIStoryboard.account.instantiateViewController(withIdentifier: "FeedbinAccountNavigationViewController") as! UINavigationController
 			navController.modalPresentationStyle = .currentContext
-			let addViewController = navController.topViewController as! FeedbinAccountViewController
-			addViewController.delegate = self
 			present(navController, animated: true)
 		case 2:
 			let addAccount = OAuthAccountAuthorizationOperation(accountType: .feedly)
@@ -53,8 +45,6 @@ class AddAccountViewController: UITableViewController, AddAccountDismissDelegate
 		case 3:
 			let navController = UIStoryboard.account.instantiateViewController(withIdentifier: "FeedWranglerAccountNavigationViewController") as! UINavigationController
 			navController.modalPresentationStyle = .currentContext
-			let addViewController = navController.topViewController as! FeedWranglerAccountViewController
-			addViewController.delegate = self
 			present(navController, animated: true)
 		default:
 			break


### PR DESCRIPTION
Delegate which was responsible to dismiss AddAccountViewController
whenever presented view controller dismissed is not needed. So removing
it simply will go to previous screen from where user comes.

Fixes #2010 