### PR TITLE
Adds an account behavior to disable folders

### DIFF
--- a/Frameworks/Account/AccountBehaviors.swift
+++ b/Frameworks/Account/AccountBehaviors.swift
@@ -29,6 +29,11 @@ public enum AccountBehavior: Equatable {
 	case disallowFeedInRootFolder
 	
 	/**
+	Account doesn't support folders
+	*/
+	case disallowFolderManagement
+	
+	/**
 	 Account doesn't support OPML imports
 	*/
 	case disallowOPMLImports

--- a/Frameworks/Account/FeedWrangler/FeedWranglerAccountDelegate.swift
+++ b/Frameworks/Account/FeedWrangler/FeedWranglerAccountDelegate.swift
@@ -16,7 +16,7 @@ import Secrets
 
 final class FeedWranglerAccountDelegate: AccountDelegate {
 	
-	var behaviors: AccountBehaviors = []
+	var behaviors: AccountBehaviors = [.disallowFolderManagement]
 	
 	var isOPMLImportInProgress = false
 	var server: String? = FeedWranglerConfig.clientPath

--- a/Mac/MainWindow/AddFolder/AddFolderWindowController.swift
+++ b/Mac/MainWindow/AddFolder/AddFolderWindowController.swift
@@ -42,7 +42,11 @@ class AddFolderWindowController : NSWindowController {
 		let menu = NSMenu()
 		accountPopupButton.menu = menu
 		
-		for oneAccount in AccountManager.shared.sortedActiveAccounts {
+		let accounts = AccountManager.shared
+			.sortedActiveAccounts
+			.filter { !$0.behaviors.contains(.disallowFolderManagement) }
+		
+		for oneAccount in accounts {
 			
 			let oneMenuItem = NSMenuItem()
 			oneMenuItem.title = oneAccount.nameForDisplay

--- a/iOS/Add/AddFolderViewController.swift
+++ b/iOS/Add/AddFolderViewController.swift
@@ -43,7 +43,9 @@ class AddFolderViewController: UITableViewController, AddContainerViewController
 
 		super.viewDidLoad()
 		
-		accounts = AccountManager.shared.sortedActiveAccounts
+		accounts = AccountManager.shared
+			.sortedActiveAccounts
+			.filter { !$0.behaviors.contains(.disallowFolderManagement) }
 		
 		nameTextField.delegate = self
 		


### PR DESCRIPTION
Some sync services (Feed Wrangler) don't support folders. This behavior removes the account from the UI when adding new folders.

#2049 