### PR TITLE
Share extension activation rule for text

### DIFF
--- a/iOS/ShareExtension/Info.plist
+++ b/iOS/ShareExtension/Info.plist
@@ -32,6 +32,8 @@
 			<dict>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<string>1</string>
 			</dict>
 			<key>NSExtensionJavaScriptPreprocessingFile</key>
 			<string>SafariExt</string>


### PR DESCRIPTION
Possibly fixes #2042 

Tested in simulator for plain text sharing and was able to get the NNW on share sheet.