### PR TITLE
Notifications

### DIFF
--- a/Shared/UserNotifications/UserNotificationManager.swift
+++ b/Shared/UserNotifications/UserNotificationManager.swift
@@ -53,15 +53,15 @@ private extension UserNotificationManager {
 		}
 		
 		content.body = ArticleStringFormatter.truncatedSummary(article)
-
-		content.sound = UNNotificationSound.default
-		content.userInfo = [UserInfoKey.articlePath: article.pathUserInfo]
+		
 		content.threadIdentifier = webFeed.webFeedID
 		content.summaryArgument = "\(webFeed.nameForDisplay)"
 		content.summaryArgumentCount = 1
-
-		let request = UNNotificationRequest.init(identifier: "articleID:\(article.articleID)", content: content, trigger: nil)
 		
+		content.sound = UNNotificationSound.default
+		content.userInfo = [UserInfoKey.articlePath: article.pathUserInfo]
+		
+		let request = UNNotificationRequest.init(identifier: "articleID:\(article.articleID)", content: content, trigger: nil)
 		UNUserNotificationCenter.current().add(request)
 	}
 	

--- a/Shared/UserNotifications/UserNotificationManager.swift
+++ b/Shared/UserNotifications/UserNotificationManager.swift
@@ -47,15 +47,21 @@ private extension UserNotificationManager {
 		let content = UNMutableNotificationContent()
 						
 		content.title = webFeed.nameForDisplay
-		content.body = ArticleStringFormatter.truncatedTitle(article)
-		if content.body.isEmpty {
-			content.body = ArticleStringFormatter.truncatedSummary(article)
+		
+		if !ArticleStringFormatter.truncatedTitle(article).isEmpty {
+			content.subtitle = ArticleStringFormatter.truncatedTitle(article)
 		}
+		
+		content.body = ArticleStringFormatter.truncatedSummary(article)
 
 		content.sound = UNNotificationSound.default
 		content.userInfo = [UserInfoKey.articlePath: article.pathUserInfo]
+		content.threadIdentifier = webFeed.webFeedID
+		content.summaryArgument = "\(webFeed.nameForDisplay)"
+		content.summaryArgumentCount = 1
 
 		let request = UNNotificationRequest.init(identifier: "articleID:\(article.articleID)", content: content, trigger: nil)
+		
 		UNUserNotificationCenter.current().add(request)
 	}
 	


### PR DESCRIPTION
Fixes #2076 

- If a truncated title is available, the notification `subtitle` is set. 
- Notifications are grouped using the `webFeedID`. 
- Notification summaries use `webFeed.nameForDisplay`.

