### PR TITLE
Feedly: renew OAuth access tokens as needed

### DIFF
--- a/Frameworks/Account/AccountMetadata.swift
+++ b/Frameworks/Account/AccountMetadata.swift
@@ -23,7 +23,6 @@ final class AccountMetadata: Codable {
 		case lastArticleFetchStartTime = "lastArticleFetch"
 		case lastArticleFetchEndTime
 		case endpointURL
-		case lastCredentialRenewTime = "lastCredentialRenewTime"
 		case performedApril2020RetentionPolicyChange
 	}
 
@@ -79,16 +78,6 @@ final class AccountMetadata: Codable {
 		didSet {
 			if endpointURL != oldValue {
 				valueDidChange(.endpointURL)
-			}
-		}
-	}
-	
-	/// The last moment an account successfully renewed its credentials, or `nil` if no such moment exists.
-	/// An account delegate can use this value to decide when to next ask the service provider to renew credentials.
-	var lastCredentialRenewTime: Date? {
-		didSet {
-			if lastCredentialRenewTime != oldValue {
-				valueDidChange(.lastCredentialRenewTime)
 			}
 		}
 	}

--- a/Frameworks/Account/Feedly/FeedlyAPICaller.swift
+++ b/Frameworks/Account/Feedly/FeedlyAPICaller.swift
@@ -9,6 +9,12 @@
 import Foundation
 import RSWeb
 
+protocol FeedlyAPICallerDelegate: class {
+	/// Implemented by the `FeedlyAccountDelegate` reauthorize the client with a fresh OAuth token so the client can retry the unauthorized request.
+	/// Pass `true` to the completion handler if the failing request should be retried with a fresh token or `false` if the unauthorized request should complete with the original failure error.
+	func reauthorizeFeedlyAPICaller(_ caller: FeedlyAPICaller, completionHandler: @escaping (Bool) -> ())
+}
+
 final class FeedlyAPICaller {
 	
 	enum API {
@@ -47,6 +53,8 @@ final class FeedlyAPICaller {
 		self.baseUrlComponents = api.baseUrlComponents
 	}
 	
+	weak var delegate: FeedlyAPICallerDelegate?
+	
 	var credentials: Credentials?
 	
 	var server: String? {
@@ -67,6 +75,54 @@ final class FeedlyAPICaller {
 	
 	func resume() {
 		isSuspended = false
+	}
+	
+	func send<R: Decodable>(request: URLRequest, resultType: R.Type, dateDecoding: JSONDecoder.DateDecodingStrategy = .iso8601, keyDecoding: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys, completion: @escaping (Result<(HTTPURLResponse, R?), Error>) -> Void) {
+		transport.send(request: request, resultType: resultType, dateDecoding: dateDecoding, keyDecoding: keyDecoding) { [weak self] result in
+			assert(Thread.isMainThread)
+			
+			switch result {
+			case .success:
+				completion(result)
+			case .failure(let error):
+				switch error {
+				case TransportError.httpError(let statusCode) where statusCode == 401:
+					
+					assert(self == nil ? true : self?.delegate != nil, "Check the delegate is set to \(FeedlyAccountDelegate.self).")
+					
+					guard let self = self, let delegate = self.delegate else {
+						completion(result)
+						return
+					}
+					
+					/// Capture the credentials before the reauthorization to check for a change.
+					let credentialsBefore = self.credentials
+					
+					delegate.reauthorizeFeedlyAPICaller(self) { [weak self] isReauthorizedAndShouldRetry in
+						assert(Thread.isMainThread)
+						
+						guard isReauthorizedAndShouldRetry, let self = self else {
+							completion(result)
+							return
+						}
+						
+						// Check for a change. Not only would it help debugging, but it'll also catch an infinitely recursive attempt to refresh.
+						guard let accessToken = self.credentials?.secret, accessToken != credentialsBefore?.secret else {
+							assertionFailure("Could not update the request with a new OAuth token. Did \(String(describing: self.delegate)) set them on \(self)?")
+							completion(result)
+							return
+						}
+						
+						var reauthorizedRequest = request
+						reauthorizedRequest.setValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
+						
+						self.send(request: reauthorizedRequest, resultType: resultType, dateDecoding: dateDecoding, keyDecoding: keyDecoding, completion: completion)
+					}
+				default:
+					completion(result)
+				}
+			}
+		}
 	}
 	
 	func importOpml(_ opmlData: Data, completion: @escaping (Result<Void, Error>) -> ()) {
@@ -95,7 +151,7 @@ final class FeedlyAPICaller {
 		request.addValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
 		request.httpBody = opmlData
 		
-		transport.send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (httpResponse, _)):
 				if httpResponse.statusCode == 200 {
@@ -147,7 +203,7 @@ final class FeedlyAPICaller {
 			}
 		}
 		
-		transport.send(request: request, resultType: [FeedlyCollection].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: [FeedlyCollection].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (httpResponse, collections)):
 				if httpResponse.statusCode == 200, let collection = collections?.first {
@@ -200,7 +256,7 @@ final class FeedlyAPICaller {
 			}
 		}
 		
-		transport.send(request: request, resultType: [FeedlyCollection].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: [FeedlyCollection].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (httpResponse, collections)):
 				if httpResponse.statusCode == 200, let collection = collections?.first {
@@ -248,7 +304,7 @@ final class FeedlyAPICaller {
 		request.addValue("application/json", forHTTPHeaderField: "Accept-Type")
 		request.addValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
 		
-		transport.send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (httpResponse, _)):
 				if httpResponse.statusCode == 200 {
@@ -307,7 +363,7 @@ final class FeedlyAPICaller {
 			}
 		}
 		
-		transport.send(request: request, resultType: [FeedlyFeed].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: [FeedlyFeed].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success((let httpResponse, _)):
 				if httpResponse.statusCode == 200 {
@@ -369,7 +425,7 @@ extension FeedlyAPICaller: FeedlyAddFeedToCollectionService {
 			}
 		}
 		
-		transport.send(request: request, resultType: [FeedlyFeed].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: [FeedlyFeed].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success((_, let collectionFeeds)):
 				if let feeds = collectionFeeds {
@@ -435,7 +491,7 @@ extension FeedlyAPICaller: OAuthAuthorizationCodeGrantRequesting {
 			return
 		}
 		
-		transport.send(request: request, resultType: AccessTokenResponse.self, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: AccessTokenResponse.self, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (_, tokenResponse)):
 				if let response = tokenResponse {
@@ -482,7 +538,7 @@ extension FeedlyAPICaller: OAuthAcessTokenRefreshRequesting {
 			return
 		}
 		
-		transport.send(request: request, resultType: AccessTokenResponse.self, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: AccessTokenResponse.self, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (_, tokenResponse)):
 				if let response = tokenResponse {
@@ -523,7 +579,7 @@ extension FeedlyAPICaller: FeedlyGetCollectionsService {
 		request.addValue("application/json", forHTTPHeaderField: "Accept-Type")
 		request.addValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
 		
-		transport.send(request: request, resultType: [FeedlyCollection].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: [FeedlyCollection].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (_, collections)):
 				if let response = collections {
@@ -591,7 +647,7 @@ extension FeedlyAPICaller: FeedlyGetStreamContentsService {
 		request.addValue("application/json", forHTTPHeaderField: "Accept-Type")
 		request.addValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
 		
-		transport.send(request: request, resultType: FeedlyStream.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: FeedlyStream.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (_, collections)):
 				if let response = collections {
@@ -659,7 +715,7 @@ extension FeedlyAPICaller: FeedlyGetStreamIdsService {
 		request.addValue("application/json", forHTTPHeaderField: "Accept-Type")
 		request.addValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
 		
-		transport.send(request: request, resultType: FeedlyStreamIds.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: FeedlyStreamIds.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (_, collections)):
 				if let response = collections {
@@ -714,7 +770,7 @@ extension FeedlyAPICaller: FeedlyGetEntriesService {
 		request.addValue("application/json", forHTTPHeaderField: "Accept-Type")
 		request.addValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
 		
-		transport.send(request: request, resultType: [FeedlyEntry].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: [FeedlyEntry].self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (_, entries)):
 				if let response = entries {
@@ -773,7 +829,7 @@ extension FeedlyAPICaller: FeedlyMarkArticlesService {
 			}
 		}
 		
-		transport.send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (httpResponse, _)):
 				if httpResponse.statusCode == 200 {
@@ -817,7 +873,7 @@ extension FeedlyAPICaller: FeedlySearchService {
 		request.addValue("application/json", forHTTPHeaderField: HTTPRequestHeader.contentType)
 		request.addValue("application/json", forHTTPHeaderField: "Accept-Type")
 		
-		transport.send(request: request, resultType: FeedlyFeedsSearchResponse.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: FeedlyFeedsSearchResponse.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (_, searchResponse)):
 				if let response = searchResponse {
@@ -859,7 +915,7 @@ extension FeedlyAPICaller: FeedlyLogoutService {
 		request.addValue("application/json", forHTTPHeaderField: "Accept-Type")
 		request.addValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
 		
-		transport.send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (httpResponse, _)):
 				if httpResponse.statusCode == 200 {

--- a/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
+++ b/Frameworks/Account/Feedly/FeedlyAccountDelegate.swift
@@ -554,7 +554,7 @@ extension FeedlyAccountDelegate: FeedlyAPICallerDelegate {
 			}
 		}
 		
-		let refreshAccessToken = FeedlyRefreshAccessTokenOperation(account: account, service: self, oauthClient: oauthAuthorizationClient, refreshDate: Date(), log: log)
+		let refreshAccessToken = FeedlyRefreshAccessTokenOperation(account: account, service: self, oauthClient: oauthAuthorizationClient, log: log)
 		refreshAccessToken.downloadProgress = refreshProgress
 		
 		/// This must be strongly referenced by the completionBlock of the `FeedlyRefreshAccessTokenOperation`.

--- a/Frameworks/Account/Feedly/OAuthAuthorizationClient+Feedly.swift
+++ b/Frameworks/Account/Feedly/OAuthAuthorizationClient+Feedly.swift
@@ -25,11 +25,11 @@ extension OAuthAuthorizationClient {
 		/// See https://developer.feedly.com/v3/sandbox/ for more information.
 		/// The return value models public sandbox API values found at:
 		/// https://groups.google.com/forum/#!topic/feedly-cloud/WwQWMgDmOuw
-		/// They are due to expire on January 31 2020.
+		/// They are due to expire on May 31st 2020.
 		/// Verify the sandbox URL host in the FeedlyAPICaller.API.baseUrlComponents method, too.
 		return OAuthAuthorizationClient(id: "sandbox",
 										redirectUri: "urn:ietf:wg:oauth:2.0:oob",
 										state: nil,
-										secret: "nZmS4bqxgRQkdPks")
+										secret: "4ZfZ5DvqmJ8vKgMj")
 	}
 }

--- a/Frameworks/Account/Feedly/Operations/FeedlyRefreshAccessTokenOperation.swift
+++ b/Frameworks/Account/Feedly/Operations/FeedlyRefreshAccessTokenOperation.swift
@@ -17,32 +17,14 @@ final class FeedlyRefreshAccessTokenOperation: FeedlyOperation {
 	let account: Account
 	let log: OSLog
 	
-	/// The moment the refresh is being requested. The token will refresh only if the account's `lastCredentialRenewTime` is not on the same day as this moment. When nil, the operation will always refresh the token.
-	let refreshDate: Date?
-	
-	init(account: Account, service: OAuthAccessTokenRefreshing, oauthClient: OAuthAuthorizationClient, refreshDate: Date?, log: OSLog) {
+	init(account: Account, service: OAuthAccessTokenRefreshing, oauthClient: OAuthAuthorizationClient, log: OSLog) {
 		self.oauthClient = oauthClient
 		self.service = service
 		self.account = account
-		self.refreshDate = refreshDate
 		self.log = log
 	}
 	
 	override func run() {
-		// Only refresh the token if these dates are not on the same day.
-		let shouldRefresh: Bool = {
-			guard let date = refreshDate, let lastRenewDate = account.metadata.lastCredentialRenewTime else {
-				return true
-			}
-			return !Calendar.current.isDate(lastRenewDate, equalTo: date, toGranularity: .day)
-		}()
-		
-		guard shouldRefresh else {
-			os_log(.debug, log: log, "Skipping access token renewal.")
-			didFinish()
-			return
-		}
-		
 		let refreshToken: Credentials
 		
 		do {
@@ -81,8 +63,6 @@ final class FeedlyRefreshAccessTokenOperation: FeedlyOperation {
 				os_log(.debug, log: log, "Storing access token.")
 				// Now store the access token because we want the account delegate to use it.
 				try account.storeCredentials(grant.accessToken)
-				
-				account.metadata.lastCredentialRenewTime = Date()
 				
 				didFinish()
 			} catch {


### PR DESCRIPTION
When Feedly responds with a 401 Unauthorized, attempt to refresh the token and retry the request. This PR also reverts the temporary fix to reduce the occurrence of the 401 Unauthorized alerts because these green changes apply generally for all requests Feedly expects to be authorised.

Fixes #1859