### PR TITLE
Issue 2084

### DIFF
--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -89,6 +89,14 @@ class MasterTimelineViewController: UITableViewController, UndoableCommandRunner
 			}
 		}
 		
+		// Disable swipe back on iPad Mice
+		if #available(iOS 13.4, *) {
+			guard let gesture = self.navigationController?.interactivePopGestureRecognizer as? UIPanGestureRecognizer else {
+				return
+			}
+			gesture.allowedScrollTypesMask = []
+		}
+		
 	}
 	
 	override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Fixes #2084 scrolling behaviour on iPad trackpads. 

Two-fingered swipe right gestures on Master Timeline won't trigger a pan back to the underlying master feed.