### PR TITLE
mac-release: Strip inline max-height and max-width from elements

### DIFF
--- a/Shared/Article Rendering/ArticleRenderer.swift
+++ b/Shared/Article Rendering/ArticleRenderer.swift
@@ -344,7 +344,7 @@ private extension ArticleRenderer {
 			},
 			stripStyles: function() {
 				document.getElementsByTagName("body")[0].querySelectorAll("style, link[rel=stylesheet]").forEach(element => element.remove());
-				document.getElementsByTagName("body")[0].querySelectorAll("[style]").forEach(element => stripStylesFromElement(element, ["color", "background", "font"]));
+				document.getElementsByTagName("body")[0].querySelectorAll("[style]").forEach(element => stripStylesFromElement(element, ["color", "background", "font", "max-width", "max-height"]));
 			},
 			linkHover: function() {
 				var anchors = document.getElementsByTagName("a");


### PR DESCRIPTION
`mac-release` version of the fix.