### PR TITLE
master: Strip inline max-width and max-height from elements

### DIFF
--- a/Shared/Article Rendering/main.js
+++ b/Shared/Article Rendering/main.js
@@ -19,7 +19,7 @@ function stripStylesFromElement(element, propertiesToStrip) {
 function stripStyles() {
 	document.getElementsByTagName("body")[0].querySelectorAll("style, link[rel=stylesheet]").forEach(element => element.remove());
 	// Removing "background" and "font" will also remove properties that would be reflected in them, e.g., "background-color" and "font-family"
-	document.getElementsByTagName("body")[0].querySelectorAll("[style]").forEach(element => stripStylesFromElement(element, ["color", "background", "font"]));
+	document.getElementsByTagName("body")[0].querySelectorAll("[style]").forEach(element => stripStylesFromElement(element, ["color", "background", "font", "max-width", "max-height"]));
 }
 
 // Convert all Feedbin proxy images to be used as src, otherwise change image locations to be absolute if not already


### PR DESCRIPTION
`master`—and final—version of the fix for #2090.