### PR TITLE
Fix issue where pressing [return] would not open article in browser

### DIFF
--- a/Shared/Resources/GlobalKeyboardShortcuts.plist
+++ b/Shared/Resources/GlobalKeyboardShortcuts.plist
@@ -106,7 +106,7 @@
 	</dict>
 	<dict>
 		<key>title</key>
-		<string>Open in App Browser</string>
+		<string>Open in Browser</string>
 		<key>key</key>
 		<string>[return]</string>
 		<key>action</key>

--- a/Shared/Resources/GlobalKeyboardShortcuts.plist
+++ b/Shared/Resources/GlobalKeyboardShortcuts.plist
@@ -110,7 +110,7 @@
 		<key>key</key>
 		<string>[return]</string>
 		<key>action</key>
-		<string>openFeedInAppBrowser:</string>
+		<string>openInBrowser:</string>
 	</dict>
 	<dict>
 		<key>key</key>


### PR DESCRIPTION
- Keyboard shortcut [return] was calling selector `openFeedInAppBrowser:` which is not implemented in the macOS app. Changed to `openInBrowser:`.
- Updated keyboard shortcut title to match naming of other shortcuts that performed the same action.