### PR TITLE
KeyCommands

### DIFF
--- a/Multiplatform/Shared/MainApp.swift
+++ b/Multiplatform/Shared/MainApp.swift
@@ -20,19 +20,108 @@ struct MainApp: App {
 	
 	@StateObject private var sceneModel = SceneModel()
 	
-    var body: some Scene {
-        WindowGroup {
-			#if os(macOS)
+	@SceneBuilder var body: some Scene {
+		#if os(macOS)
+		WindowGroup {
 			SceneNavigationView()
 				.frame(minWidth: 600, idealWidth: 1000, maxWidth: .infinity, minHeight: 600, idealHeight: 700, maxHeight: .infinity)
 				.environmentObject(sceneModel)
-			#endif
-			
-			#if os(iOS)
+		}
+		.commands {
+			CommandGroup(after: .newItem, addition: {
+				Button("New Feed", action: {})
+					.keyboardShortcut("N")
+				Button("New Folder", action: {})
+					.keyboardShortcut("N", modifiers: [.shift, .command])
+				Button("Refresh", action: {})
+					.keyboardShortcut("R")
+			})
+			CommandGroup(before: .sidebar, addition: {
+				Button("Show Sidebar", action: {})
+					.keyboardShortcut("S", modifiers: [.control, .command])
+			})
+			CommandMenu("Subscriptions", content: {
+				Button("Import Subscriptions", action: {})
+					.keyboardShortcut("I", modifiers: [.shift, .command])
+				Button("Import NNW 3 Subscriptions", action: {})
+					.keyboardShortcut("O", modifiers: [.shift, .command])
+				Button("Export Subscriptions", action: {})
+					.keyboardShortcut("E", modifiers: [.shift, .command])
+			})
+			CommandMenu("Go", content: {
+				Button("Next Unread", action: {})
+					.keyboardShortcut("/", modifiers: [.command])
+				Button("Today", action: {})
+					.keyboardShortcut("1", modifiers: [.command])
+				Button("All Unread", action: {})
+					.keyboardShortcut("2", modifiers: [.command])
+				Button("Starred", action: {})
+					.keyboardShortcut("3", modifiers: [.command])
+			})
+			CommandMenu("Article", content: {
+				Button("Mark as Read", action: {})
+					.keyboardShortcut("U", modifiers: [.shift, .command])
+				Button("Mark All as Read", action: {})
+					.keyboardShortcut("K", modifiers: [.command])
+				Button("Mark Older as Read", action: {})
+					.keyboardShortcut("K", modifiers: [.shift, .command])
+				Button("Mark as Starred", action: {})
+					.keyboardShortcut("L", modifiers: [.shift, .command])
+				Button("Open in Browser", action: {})
+					.keyboardShortcut(.rightArrow, modifiers: [.command])
+			})
+		}
+		.windowToolbarStyle(UnifiedWindowToolbarStyle())
+		#endif
+		
+		#if os(iOS)
+		WindowGroup {
 			SceneNavigationView()
 				.environmentObject(sceneModel)
-			#endif
-        }
-    }
-	
+		}.commands {
+			CommandGroup(after: .newItem, addition: {
+				Button("New Feed", action: {})
+					.keyboardShortcut("N")
+				Button("New Folder", action: {})
+					.keyboardShortcut("N", modifiers: [.shift, .command])
+				Button("Refresh", action: {})
+					.keyboardShortcut("R")
+			})
+			CommandGroup(before: .sidebar, addition: {
+				Button("Show Sidebar", action: {})
+					.keyboardShortcut("S", modifiers: [.control, .command])
+			})
+			CommandMenu("Subscriptions", content: {
+				Button("Import Subscriptions", action: {})
+					.keyboardShortcut("I", modifiers: [.shift, .command])
+				Button("Import NNW 3 Subscriptions", action: {})
+					.keyboardShortcut("O", modifiers: [.shift, .command])
+				Button("Export Subscriptions", action: {})
+					.keyboardShortcut("E", modifiers: [.shift, .command])
+			})
+			CommandMenu("Go", content: {
+				Button("Next Unread", action: {})
+					.keyboardShortcut("/", modifiers: [.command])
+				Button("Today", action: {})
+					.keyboardShortcut("1", modifiers: [.command])
+				Button("All Unread", action: {})
+					.keyboardShortcut("2", modifiers: [.command])
+				Button("Starred", action: {})
+					.keyboardShortcut("3", modifiers: [.command])
+			})
+			CommandMenu("Article", content: {
+				Button("Mark as Read", action: {})
+					.keyboardShortcut("U", modifiers: [.shift, .command])
+				Button("Mark All as Read", action: {})
+					.keyboardShortcut("K", modifiers: [.command])
+				Button("Mark Older as Read", action: {})
+					.keyboardShortcut("K", modifiers: [.shift, .command])
+				Button("Mark as Starred", action: {})
+					.keyboardShortcut("L", modifiers: [.shift, .command])
+				Button("Open in Browser", action: {})
+					.keyboardShortcut(.rightArrow, modifiers: [.command])
+			})
+		}
+		#endif
+	}
 }


### PR DESCRIPTION
This changes `MainApp` to use `@SceneBuilder` and adds placeholder key commands from the existing app (no functionality is triggered).

Note: unlike the existing app, the key commands are occasionally put into separate menus on macOS. 