### PR TITLE
Adapts to compact size classes

### DIFF
--- a/Multiplatform/Shared/MainApp.swift
+++ b/Multiplatform/Shared/MainApp.swift
@@ -29,7 +29,6 @@ struct MainApp: App {
 				.environmentObject(sceneModel)
 				.toolbar {
 					
-					
 					ToolbarItem {
 						Button(action: {}, label: {
 							Image(systemName: "plus").foregroundColor(.secondary)
@@ -41,7 +40,6 @@ struct MainApp: App {
 							Image(systemName: "folder.fill.badge.plus").foregroundColor(.pink)
 						}).help("New Folder")
 					}
-					
 					
 					ToolbarItem {
 						Button(action: {}, label: {

--- a/Multiplatform/Shared/SceneNavigationView.swift
+++ b/Multiplatform/Shared/SceneNavigationView.swift
@@ -9,16 +9,41 @@
 import SwiftUI
 
 struct SceneNavigationView: View {
-    var body: some View {
+    
+	#if os(iOS)
+	@Environment(\.horizontalSizeClass) private var horizontalSizeClass
+	#endif
+	
+	@ViewBuilder var sidebar: some View {
+		#if os(iOS)
+		if horizontalSizeClass == .compact {
+			CompactNavigationView()
+		} else {
+			SidebarView()
+		}
+		#else
+			SidebarView()
+		#endif
+	}
+	
+	var body: some View {
 		NavigationView {
 			#if os(macOS)
-			SidebarView().frame(minWidth: 100, idealWidth: 150, maxWidth: 200, maxHeight: .infinity)
+			sidebar
+				.frame(minWidth: 100, idealWidth: 150, maxWidth: 200, maxHeight: .infinity)
 			#else
-			SidebarView()
+				sidebar
 			#endif
 
+			#if os(iOS)
+			if horizontalSizeClass != .compact {
+				Text("Timeline")
+					.frame(maxWidth: .infinity, maxHeight: .infinity)
+			}
+			#else
 			Text("Timeline")
 				.frame(maxWidth: .infinity, maxHeight: .infinity)
+			#endif
 
 			#if os(macOS)
 			Text("None Selected")

--- a/Multiplatform/Shared/Sidebar/CompactNavigationView.swift
+++ b/Multiplatform/Shared/Sidebar/CompactNavigationView.swift
@@ -1,19 +1,19 @@
 //
-//  SidebarView.swift
-//  NetNewsWire
+//  CompactNavigationView.swift
+//  Multiplatform iOS
 //
-//  Created by Maurice Parker on 6/28/20.
+//  Created by Stuart Breckenridge on 29/6/20.
 //  Copyright © 2020 Ranchero Software. All rights reserved.
 //
 
 import SwiftUI
 
-struct SidebarView: View {
-	
+struct CompactNavigationView: View {
+    
 	@EnvironmentObject private var sceneModel: SceneModel
 	@StateObject private var sidebarModel = SidebarModel()
 	
-    @ViewBuilder var body: some View {
+	var body: some View {
 		List {
 			ForEach(sidebarModel.sidebarItems) { section in
 				OutlineGroup(sidebarModel.sidebarItems, children: \.children) { sidebarItem in
@@ -21,8 +21,8 @@ struct SidebarView: View {
 				}
 			}
 		}
-		.navigationTitle(Text("Feeds"))
-		.listStyle(SidebarListStyle())
+		.navigationBarTitle(Text("Feeds"))
+		.listStyle(PlainListStyle())
 		.onAppear {
 			sceneModel.sidebarModel = sidebarModel
 			sidebarModel.delegate = sceneModel
@@ -30,11 +30,12 @@ struct SidebarView: View {
 		}
 
 	}
+	
+	
 }
 
-struct SidebarView_Previews: PreviewProvider {
+struct CompactSidebarView_Previews: PreviewProvider {
     static var previews: some View {
-        SidebarView()
-			.environmentObject(SceneModel())
+        CompactNavigationView()
     }
 }

--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1729529524AA1CAA00D65E66 /* GeneralPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1729529224AA1CAA00D65E66 /* GeneralPreferencesView.swift */; };
 		1729529724AA1CD000D65E66 /* MacPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1729529624AA1CD000D65E66 /* MacPreferencesView.swift */; };
 		1729529B24AA1FD200D65E66 /* MacSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1729529A24AA1FD200D65E66 /* MacSearchField.swift */; };
+		172952B024AA287100D65E66 /* CompactNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172952AF24AA287100D65E66 /* CompactNavigationView.swift */; };
 		179DB1DFBCF9177104B12E0F /* AccountsNewsBlurWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179DBBA2B22A659F81EED6F9 /* AccountsNewsBlurWindowController.swift */; };
 		179DB3CE822BFCC2D774D9F4 /* AccountsNewsBlurWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179DBBA2B22A659F81EED6F9 /* AccountsNewsBlurWindowController.swift */; };
 		3B3A32A5238B820900314204 /* FeedWranglerAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A328B238B820900314204 /* FeedWranglerAccountViewController.swift */; };
@@ -1671,6 +1672,7 @@
 		1729529224AA1CAA00D65E66 /* GeneralPreferencesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralPreferencesView.swift; sourceTree = "<group>"; };
 		1729529624AA1CD000D65E66 /* MacPreferencesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MacPreferencesView.swift; sourceTree = "<group>"; };
 		1729529A24AA1FD200D65E66 /* MacSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSearchField.swift; sourceTree = "<group>"; };
+		172952AF24AA287100D65E66 /* CompactNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactNavigationView.swift; sourceTree = "<group>"; };
 		179DBBA2B22A659F81EED6F9 /* AccountsNewsBlurWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsNewsBlurWindowController.swift; sourceTree = "<group>"; };
 		3B3A328B238B820900314204 /* FeedWranglerAccountViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedWranglerAccountViewController.swift; sourceTree = "<group>"; };
 		3B826DB02385C84800FC1ADB /* AccountsFeedWrangler.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AccountsFeedWrangler.xib; sourceTree = "<group>"; };
@@ -2802,6 +2804,7 @@
 			children = (
 				51E499FC24A9137600B667CB /* SidebarModel.swift */,
 				51E499FF24A91FC100B667CB /* SidebarView.swift */,
+				172952AF24AA287100D65E66 /* CompactNavigationView.swift */,
 				51408B7D24A9EC6F0073CF4E /* SidebarItem.swift */,
 			);
 			path = Sidebar;
@@ -4650,6 +4653,7 @@
 				51E4993624A867E800B667CB /* UserInfoKey.swift in Sources */,
 				51E4990924A808C500B667CB /* WebFeedIconDownloader.swift in Sources */,
 				51E498F524A8085D00B667CB /* TodayFeedDelegate.swift in Sources */,
+				172952B024AA287100D65E66 /* CompactNavigationView.swift in Sources */,
 				51E4990B24A808C500B667CB /* ImageDownloader.swift in Sources */,
 				51E498F424A8085D00B667CB /* SmartFeedDelegate.swift in Sources */,
 				51E4993024A8676400B667CB /* ArticleSorter.swift in Sources */,


### PR DESCRIPTION
For iOS only: if the `horizontalSizeClass` is `compact` it uses the `CompactNavigationView` instead of the Sidebar.