### PR TITLE
Mark all as read context menu

### DIFF
--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -547,7 +547,7 @@ extension MasterFeedViewController: UIContextMenuInteractionDelegate {
 
 			var actions = [accountInfoAction, deactivateAction]
 
-			if let markAllAction = self.markAllAsReadAction(account: account) {
+			if let markAllAction = self.markAllAsReadAction(account: account, contentView: interaction.view) {
 				actions.insert(markAllAction, at: 1)
 			}
 
@@ -1064,23 +1064,31 @@ private extension MasterFeedViewController {
 		return markAllAsReadAction(articles: articles, nameForDisplay: articleFetcher.nameForDisplay, indexPath: indexPath)
 	}
 
-	func markAllAsReadAction(account: Account) -> UIAction? {
+	func markAllAsReadAction(account: Account, contentView: UIView?) -> UIAction? {
 		guard let fetchedArticles = try? account.fetchArticles(FetchType.unread) else {
 			return nil
 		}
 
 		let articles = Array(fetchedArticles)
-		return markAllAsReadAction(articles: articles, nameForDisplay: account.nameForDisplay)
+		return markAllAsReadAction(articles: articles, nameForDisplay: account.nameForDisplay, contentView: contentView)
 	}
 
 	func markAllAsReadAction(articles: [Article], nameForDisplay: String, indexPath: IndexPath? = nil) -> UIAction? {
-		guard articles.canMarkAllAsRead(), let indexPath = indexPath, let contentView = self.tableView.cellForRow(at: indexPath)?.contentView else {
+		guard let indexPath = indexPath,
+			let contentView = self.tableView.cellForRow(at: indexPath)?.contentView else {
+				return nil
+		}
+
+		return markAllAsReadAction(articles: articles, nameForDisplay: nameForDisplay, contentView: contentView)
+	}
+
+	func markAllAsReadAction(articles: [Article], nameForDisplay: String, contentView: UIView?) -> UIAction? {
+		guard articles.canMarkAllAsRead(), let contentView = contentView else {
 			return nil
 		}
 
 		let localizedMenuText = NSLocalizedString("Mark All as Read in “%@”", comment: "Command")
 		let title = NSString.localizedStringWithFormat(localizedMenuText as NSString, nameForDisplay) as String
-		
 		let action = UIAction(title: title, image: AppAssets.markAllAsReadImage) { [weak self] action in
 			MarkAsReadAlertController.confirm(self, coordinator: self?.coordinator, confirmTitle: title, sourceType: contentView) { [weak self] in
 				self?.coordinator.markAllAsRead(articles)


### PR DESCRIPTION
Fixes #2158 

The reason why it's failing to show context menu for "Mark All as Read" in accounts is because its expecting a content view and since it doesn't have one from `UIInteraction` its failing.

So I did some refactoring and added content view from both index paths or straight away from any `UIView`.

I did test all the contextual menus on `MasterFeedController` just to make sure I don't break anything.


## Screenshot

<img src="https://user-images.githubusercontent.com/12063704/86215085-c5bb5380-bb99-11ea-880a-5282a0620f18.png"/>
