### PR TITLE
Update README to link CI badge to CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![Icon](Technotes/Images/icon.png) NetNewsWire
 
-![CI](https://github.com/Ranchero-Software/NetNewsWire/workflows/CI/badge.svg?branch=master)
+[![CI](https://github.com/Ranchero-Software/NetNewsWire/workflows/CI/badge.svg?branch=master)](https://github.com/Ranchero-Software/NetNewsWire/actions?query=workflow%3ACI+branch%3Amaster)
 
 It’s a free and open source feed reader for macOS and iOS.
 


### PR DESCRIPTION
The image is hyperlinked by default in GitHub Flavoured Markdown,
but points to the image itself, which is not so useful...

Link it to the list of recent builds instead. 🙂