### PR TITLE
Make shift-space scroll up in the detail view even when it doesn't have focus

### DIFF
--- a/Mac/MainWindow/Detail/DetailViewController.swift
+++ b/Mac/MainWindow/Detail/DetailViewController.swift
@@ -66,8 +66,16 @@ final class DetailViewController: NSViewController, WKUIDelegate {
 		currentWebViewController.canScrollDown(callback)
 	}
 
+	func canScrollUp(_ callback: @escaping (Bool) -> Void) {
+		currentWebViewController.canScrollUp(callback)
+	}
+
 	override func scrollPageDown(_ sender: Any?) {
 		currentWebViewController.scrollPageDown(sender)
+	}
+
+	override func scrollPageUp(_ sender: Any?) {
+		currentWebViewController.scrollPageUp(sender)
 	}
 	
 	// MARK: - Navigation

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -167,8 +167,18 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 		}
 	}
 
+	func canScrollUp(_ completion: @escaping (Bool) -> Void) {
+		fetchScrollInfo { (scrollInfo) in
+			completion(scrollInfo?.canScrollUp ?? false)
+		}
+	}
+
 	override func scrollPageDown(_ sender: Any?) {
 		webView.scrollPageDown(sender)
+	}
+
+	override func scrollPageUp(_ sender: Any?) {
+		webView.scrollPageUp(sender)
 	}
 }
 

--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -264,6 +264,19 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 		}
 	}
 
+	@IBAction func scrollUp(_ sender: Any?) {
+		guard let detailViewController = detailViewController else {
+			return
+		}
+		detailViewController.canScrollUp { (canScroll) in
+			if (canScroll) {
+				NSCursor.setHiddenUntilMouseMoves(true)
+				detailViewController.scrollPageUp(sender)
+			}
+		}
+
+	}
+
 	@IBAction func openArticleInBrowser(_ sender: Any?) {
 		if let link = currentLink {
 			Browser.open(link, invertPreference: NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false)

--- a/Shared/Resources/GlobalKeyboardShortcuts.plist
+++ b/Shared/Resources/GlobalKeyboardShortcuts.plist
@@ -12,6 +12,16 @@
 	</dict>
 	<dict>
 		<key>title</key>
+		<string>Scroll or Go to Next Unread</string>
+		<key>key</key>
+		<string>[space]</string>
+		<key>shiftModifier</key>
+		<true/>
+		<key>action</key>
+		<string>scrollUp:</string>
+	</dict>
+	<dict>
+		<key>title</key>
 		<string>Go to Previous Unread</string>
 		<key>key</key>
 		<string>-</string>

--- a/iOS/Article/ArticleViewController.swift
+++ b/iOS/Article/ArticleViewController.swift
@@ -293,8 +293,16 @@ class ArticleViewController: UIViewController {
 		return currentWebViewController?.canScrollDown() ?? false
 	}
 
+	func canScrollUp() -> Bool {
+		return currentWebViewController?.canScrollUp() ?? false
+	}
+
 	func scrollPageDown() {
 		currentWebViewController?.scrollPageDown()
+	}
+
+	func scrollPageUp() {
+		currentWebViewController?.scrollPageUp()
 	}
 	
 	func stopArticleExtractorIfProcessing() {

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -123,24 +123,38 @@ class WebViewController: UIViewController {
 
 	func canScrollDown() -> Bool {
 		guard let webView = webView else { return false }
-		return webView.scrollView.contentOffset.y < finalScrollPosition()
+		return webView.scrollView.contentOffset.y < finalScrollPosition(scrollingUp: false)
 	}
 
-	func scrollPageDown() {
+	func canScrollUp() -> Bool {
+		guard let webView = webView else { return false }
+		return webView.scrollView.contentOffset.y > finalScrollPosition(scrollingUp: true)
+	}
+
+	private func scrollPage(up scrollingUp: Bool) {
 		guard let webView = webView else { return }
-		
+
 		let overlap = 2 * UIFont.systemFont(ofSize: UIFont.systemFontSize).lineHeight * UIScreen.main.scale
 		let scrollToY: CGFloat = {
-			let fullScroll = webView.scrollView.contentOffset.y + webView.scrollView.layoutMarginsGuide.layoutFrame.height - overlap
-			let final = finalScrollPosition()
-			return fullScroll < final ? fullScroll : final
+			let scrollDistance = webView.scrollView.layoutMarginsGuide.layoutFrame.height - overlap;
+			let fullScroll = webView.scrollView.contentOffset.y + (scrollingUp ? -scrollDistance : scrollDistance)
+			let final = finalScrollPosition(scrollingUp: scrollingUp)
+			return (scrollingUp ? fullScroll > final : fullScroll < final) ? fullScroll : final
 		}()
-		
+
 		let convertedPoint = self.view.convert(CGPoint(x: 0, y: 0), to: webView.scrollView)
 		let scrollToPoint = CGPoint(x: convertedPoint.x, y: scrollToY)
 		webView.scrollView.setContentOffset(scrollToPoint, animated: true)
 	}
-	
+
+	func scrollPageDown() {
+		scrollPage(up: false)
+	}
+
+	func scrollPageUp() {
+		scrollPage(up: true)
+	}
+
 	func hideClickedImage() {
 		webView?.evaluateJavaScript("hideClickedImage();")
 	}
@@ -539,9 +553,14 @@ private extension WebViewController {
 		
 	}
 	
-	func finalScrollPosition() -> CGFloat {
+	func finalScrollPosition(scrollingUp: Bool) -> CGFloat {
 		guard let webView = webView else { return 0 }
-		return webView.scrollView.contentSize.height - webView.scrollView.bounds.height + webView.scrollView.safeAreaInsets.bottom
+
+		if scrollingUp {
+			return -webView.scrollView.safeAreaInsets.top
+		} else {
+			return webView.scrollView.contentSize.height - webView.scrollView.bounds.height + webView.scrollView.safeAreaInsets.bottom
+		}
 	}
 	
 	func startArticleExtractor() {

--- a/iOS/RootSplitViewController.swift
+++ b/iOS/RootSplitViewController.swift
@@ -35,6 +35,10 @@ class RootSplitViewController: UISplitViewController {
 	@objc func scrollOrGoToNextUnread(_ sender: Any?) {
 		coordinator.scrollOrGoToNextUnread()
 	}
+
+	@objc func scrollUp(_ sender: Any?) {
+		coordinator.scrollUp()
+	}
 	
 	@objc func goToPreviousUnread(_ sender: Any?) {
 		coordinator.selectPrevUnread()

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -990,6 +990,12 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 			selectNextUnread()
 		}
 	}
+
+	func scrollUp() {
+		if articleViewController?.canScrollUp() ?? false {
+			articleViewController?.scrollPageUp()
+		}
+	}
 	
 	func markAllAsRead(_ articles: [Article]) {
 		markArticlesWithUndo(articles, statusKey: .read, flag: true)


### PR DESCRIPTION
Fixes #452 for both macOS and iOS.