### PR TITLE
Notifications/Reader View/InspectorModel

### DIFF
--- a/Multiplatform/Shared/Inspector/InspectorModel.swift
+++ b/Multiplatform/Shared/Inspector/InspectorModel.swift
@@ -1,0 +1,103 @@
+//
+//  InspectorModel.swift
+//  NetNewsWire
+//
+//  Created by Stuart Breckenridge on 18/7/20.
+//  Copyright © 2020 Ranchero Software. All rights reserved.
+//
+
+import Foundation
+import UserNotifications
+import RSCore
+import Account
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+
+class InspectorModel: ObservableObject {
+	
+	@Published var notificationSettings: UNNotificationSettings?
+	@Published var editedName: String = ""
+	@Published var shouldUpdate: Bool = false
+	@Published var notifyAboutNewArticles: Bool = false {
+		didSet {
+			updateNotificationSettings()
+		}
+	}
+	@Published var alwaysShowReaderView: Bool = false
+	private let centre = UNUserNotificationCenter.current()
+	private var selectedWebFeed: WebFeed?
+	private var selectedFolder: Folder?
+	private var selectedAccount: Account?
+	
+	init() {
+		getNotificationSettings()
+	}
+	
+	func getNotificationSettings() {
+		centre.getNotificationSettings { (settings) in
+			DispatchQueue.main.async {
+				self.notificationSettings = settings
+				if settings.authorizationStatus == .authorized {
+					#if os(macOS)
+					NSApplication.shared.registerForRemoteNotifications()
+					#else
+					UIApplication.shared.registerForRemoteNotifications()
+					#endif
+				}
+			}
+		}
+	}
+	
+	func configure(with feed: WebFeed) {
+		selectedWebFeed = feed
+		notifyAboutNewArticles = selectedWebFeed?.isNotifyAboutNewArticles ?? false
+		alwaysShowReaderView = selectedWebFeed?.isArticleExtractorAlwaysOn ?? false
+		editedName = feed.nameForDisplay
+	}
+	
+	func configure(with folder: Folder) {
+		selectedFolder = folder
+		editedName = folder.nameForDisplay
+	}
+	
+	func configure(with account: Account) {
+		selectedAccount = account
+		editedName = account.nameForDisplay
+	}
+	
+	func updateNotificationSettings() {
+		guard let feed = selectedWebFeed,
+			  let settings = notificationSettings
+		else { return }
+		if settings.authorizationStatus == .denied {
+			notifyAboutNewArticles = false
+		} else if settings.authorizationStatus == .authorized {
+			feed.isNotifyAboutNewArticles = notifyAboutNewArticles
+		} else {
+			UNUserNotificationCenter.current().requestAuthorization(options:[.badge, .sound, .alert]) { [weak self] (granted, error) in
+				self?.updateNotificationSettings()
+				if granted {
+					DispatchQueue.main.async {
+						self?.selectedWebFeed!.isNotifyAboutNewArticles = self?.notifyAboutNewArticles
+						#if os(macOS)
+						NSApplication.shared.registerForRemoteNotifications()
+						#else
+						UIApplication.shared.registerForRemoteNotifications()
+						#endif
+					}
+				} else {
+					DispatchQueue.main.async {
+						self?.notifyAboutNewArticles = false
+					}
+				}
+			}
+		}
+	}
+	
+	
+}
+

--- a/Multiplatform/Shared/Inspector/InspectorModel.swift
+++ b/Multiplatform/Shared/Inspector/InspectorModel.swift
@@ -27,7 +27,11 @@ class InspectorModel: ObservableObject {
 			updateNotificationSettings()
 		}
 	}
-	@Published var alwaysShowReaderView: Bool = false
+	@Published var alwaysShowReaderView: Bool = false {
+		didSet {
+			selectedWebFeed?.isArticleExtractorAlwaysOn = alwaysShowReaderView
+		}
+	}
 	private let centre = UNUserNotificationCenter.current()
 	private var selectedWebFeed: WebFeed?
 	private var selectedFolder: Folder?

--- a/Multiplatform/Shared/Inspector/InspectorPlatformModifier.swift
+++ b/Multiplatform/Shared/Inspector/InspectorPlatformModifier.swift
@@ -30,7 +30,7 @@ struct InspectorPlatformModifier: ViewModifier {
 						presentationMode.wrappedValue.dismiss()
 					}),
 					trailing:
-					Button("Confirm", action: {
+					Button("Done", action: {
 						shouldUpdate = true
 					})
 				)

--- a/Multiplatform/Shared/Inspector/InspectorView.swift
+++ b/Multiplatform/Shared/Inspector/InspectorView.swift
@@ -70,7 +70,7 @@ struct InspectorView: View {
 				Button("Cancel", action: {
 					presentationMode.wrappedValue.dismiss()
 				})
-				Button("Confirm", action: {
+				Button("Done", action: {
 					shouldUpdate = true
 				})
 			}.padding(.top)
@@ -112,7 +112,7 @@ struct InspectorView: View {
 				Button("Cancel", action: {
 					presentationMode.wrappedValue.dismiss()
 				})
-				Button("Confirm", action: {
+				Button("Done", action: {
 					shouldUpdate = true
 				})
 			}.padding(.top)
@@ -156,7 +156,7 @@ struct InspectorView: View {
 				Button("Cancel", action: {
 					presentationMode.wrappedValue.dismiss()
 				})
-				Button("Confirm", action: {
+				Button("Done", action: {
 					shouldUpdate = true
 				})
 			}.padding(.top)

--- a/Multiplatform/Shared/Sidebar/SidebarContextMenu.swift
+++ b/Multiplatform/Shared/Sidebar/SidebarContextMenu.swift
@@ -86,13 +86,6 @@ struct SidebarContextMenu: View {
 			Divider()
 			Button {
 			} label: {
-				Text("Rename")
-				#if os(iOS)
-				AppAssets.renameImage
-				#endif
-			}
-			Button {
-			} label: {
 				Text("Delete")
 				#if os(iOS)
 				AppAssets.deleteImage
@@ -102,6 +95,14 @@ struct SidebarContextMenu: View {
 		
 		if sidebarItem.representedType == .folder {
 			Button {
+				showInspector = true
+			} label: {
+				Text("Get Info")
+				#if os(iOS)
+				AppAssets.getInfoImage
+				#endif
+			}
+			Button {
 			} label: {
 				Text("Mark All As Read")
 				#if os(iOS)
@@ -109,14 +110,6 @@ struct SidebarContextMenu: View {
 				#endif
 			}
 			Divider()
-			Button {
-				showInspector = true
-			} label: {
-				Text("Rename")
-				#if os(iOS)
-				AppAssets.renameImage
-				#endif
-			}
 			Button {
 			} label: {
 				Text("Delete")

--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		17930ED524AF10EE00A9BA52 /* AddWebFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17930ED324AF10EE00A9BA52 /* AddWebFeedView.swift */; };
 		1799E6A924C2F93F00511E91 /* InspectorPlatformModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1799E6A824C2F93F00511E91 /* InspectorPlatformModifier.swift */; };
 		1799E6AA24C2F93F00511E91 /* InspectorPlatformModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1799E6A824C2F93F00511E91 /* InspectorPlatformModifier.swift */; };
+		1799E6CD24C320D600511E91 /* InspectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1799E6CC24C320D600511E91 /* InspectorModel.swift */; };
+		1799E6CE24C320D600511E91 /* InspectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1799E6CC24C320D600511E91 /* InspectorModel.swift */; };
 		179DB1DFBCF9177104B12E0F /* AccountsNewsBlurWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179DBBA2B22A659F81EED6F9 /* AccountsNewsBlurWindowController.swift */; };
 		179DB3CE822BFCC2D774D9F4 /* AccountsNewsBlurWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179DBBA2B22A659F81EED6F9 /* AccountsNewsBlurWindowController.swift */; };
 		17D232A824AFF10A0005F075 /* AddWebFeedModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D232A724AFF10A0005F075 /* AddWebFeedModel.swift */; };
@@ -1830,6 +1832,7 @@
 		17897AC924C281A40014BA03 /* InspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorView.swift; sourceTree = "<group>"; };
 		17930ED324AF10EE00A9BA52 /* AddWebFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddWebFeedView.swift; sourceTree = "<group>"; };
 		1799E6A824C2F93F00511E91 /* InspectorPlatformModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorPlatformModifier.swift; sourceTree = "<group>"; };
+		1799E6CC24C320D600511E91 /* InspectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectorModel.swift; sourceTree = "<group>"; };
 		179DBBA2B22A659F81EED6F9 /* AccountsNewsBlurWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountsNewsBlurWindowController.swift; sourceTree = "<group>"; };
 		17B223DB24AC24D2001E4592 /* TimelineLayoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineLayoutView.swift; sourceTree = "<group>"; };
 		17D232A724AFF10A0005F075 /* AddWebFeedModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddWebFeedModel.swift; sourceTree = "<group>"; };
@@ -2647,6 +2650,7 @@
 			children = (
 				17897AC924C281A40014BA03 /* InspectorView.swift */,
 				1799E6A824C2F93F00511E91 /* InspectorPlatformModifier.swift */,
+				1799E6CC24C320D600511E91 /* InspectorModel.swift */,
 			);
 			path = Inspector;
 			sourceTree = "<group>";
@@ -5246,6 +5250,7 @@
 				51E4990224A808BB00B667CB /* ColorHash.swift in Sources */,
 				51919FAC24AA8CCA00541E64 /* UnreadCountView.swift in Sources */,
 				5177476224B3BC4700EB0F74 /* SettingsAboutView.swift in Sources */,
+				1799E6CD24C320D600511E91 /* InspectorModel.swift in Sources */,
 				51E4991924A8090A00B667CB /* CacheCleaner.swift in Sources */,
 				51E498F724A8085D00B667CB /* SearchTimelineFeedDelegate.swift in Sources */,
 				175942AA24AD533200585066 /* RefreshInterval.swift in Sources */,
@@ -5392,6 +5397,7 @@
 				51392D1C24AC19A000BE0D35 /* SidebarExpandedContainers.swift in Sources */,
 				51C0515F24A77DF800194D5E /* MainApp.swift in Sources */,
 				51B54A4324B5499B0014348B /* WebViewProvider.swift in Sources */,
+				1799E6CE24C320D600511E91 /* InspectorModel.swift in Sources */,
 				514E6C0024AD255D00AC6F6E /* PreviewArticles.swift in Sources */,
 				1729529524AA1CAA00D65E66 /* GeneralPreferencesView.swift in Sources */,
 				1769E32724BC5B6C000E1E8E /* AddAccountModel.swift in Sources */,


### PR DESCRIPTION
- "Confirm" is now "Done", and on macOS "Done" is the default keyboard action
- `InspectorModel` now handles all name changes, notifications, and reader view changes
- Rename has been replaced with Get Info 
