### PR TITLE
Add IDNA support

### DIFF
--- a/Mac/Browser.swift
+++ b/Mac/Browser.swift
@@ -43,7 +43,7 @@ struct Browser {
 	/// - Note: Some browsers (specifically Chromium-derived ones) will ignore the request
 	///   to open in the background.
 	static func open(_ urlString: String, inBackground: Bool) {
-		if let url = URL(string: urlString) {
+		if let url = URL(unicodeString: urlString) {
 			if let defaultBrowser = defaultBrowser {
 				defaultBrowser.openURL(url, inBackground: inBackground)
 			} else {

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -126,11 +126,11 @@ private extension WebFeedInspectorViewController {
 	}
 
 	func updateHomePageURL() {
-		homePageURLTextField?.stringValue = feed?.homePageURL ?? ""
+		homePageURLTextField?.stringValue = feed?.homePageURL?.decodedURLString ?? ""
 	}
 
 	func updateFeedURL() {
-		urlTextField?.stringValue = feed?.url ?? ""
+		urlTextField?.stringValue = feed?.url.decodedURLString ?? ""
 	}
 	
 	func updateNotifyAboutNewArticles() {

--- a/Mac/MainWindow/AddFeed/AddWebFeedWindowController.swift
+++ b/Mac/MainWindow/AddFeed/AddWebFeedWindowController.swift
@@ -91,7 +91,7 @@ class AddWebFeedWindowController : NSWindowController, AddFeedWindowController {
 			cancelSheet()
 			return;
 		}
-		guard let url = URL(string: normalizedURLString) else {
+		guard let url = URL(unicodeString: normalizedURLString) else {
 			cancelSheet()
 			return
 		}

--- a/Mac/MainWindow/Sidebar/SidebarViewController+ContextualMenus.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController+ContextualMenus.swift
@@ -145,16 +145,16 @@ private extension SidebarViewController {
 		}
 
 		if let homePageURL = webFeed.homePageURL, let _ = URL(string: homePageURL) {
-			let item = menuItem(NSLocalizedString("Open Home Page", comment: "Command"), #selector(openHomePageFromContextualMenu(_:)), homePageURL)
+			let item = menuItem(NSLocalizedString("Open Home Page", comment: "Command"), #selector(openHomePageFromContextualMenu(_:)), homePageURL.decodedURLString ?? homePageURL)
 			menu.addItem(item)
 			menu.addItem(NSMenuItem.separator())
 		}
 
-		let copyFeedURLItem = menuItem(NSLocalizedString("Copy Feed URL", comment: "Command"), #selector(copyURLFromContextualMenu(_:)), webFeed.url)
+		let copyFeedURLItem = menuItem(NSLocalizedString("Copy Feed URL", comment: "Command"), #selector(copyURLFromContextualMenu(_:)), webFeed.url.decodedURLString ?? webFeed.url)
 		menu.addItem(copyFeedURLItem)
 
 		if let homePageURL = webFeed.homePageURL {
-			let item = menuItem(NSLocalizedString("Copy Home Page URL", comment: "Command"), #selector(copyURLFromContextualMenu(_:)), homePageURL)
+			let item = menuItem(NSLocalizedString("Copy Home Page URL", comment: "Command"), #selector(copyURLFromContextualMenu(_:)), homePageURL.decodedURLString ?? homePageURL)
 			menu.addItem(item)
 		}
 		menu.addItem(NSMenuItem.separator())

--- a/iOS/Add/AddWebFeedViewController.swift
+++ b/iOS/Add/AddWebFeedViewController.swift
@@ -92,7 +92,7 @@ class AddWebFeedViewController: UITableViewController, AddContainerViewControlle
 		let urlString = urlTextField.text ?? ""
 		let normalizedURLString = urlString.normalizedURL
 		
-		guard !normalizedURLString.isEmpty, let url = URL(string: normalizedURLString) else {
+		guard !normalizedURLString.isEmpty, let url = URL(unicodeString: normalizedURLString) else {
 			delegate?.processingDidCancel()
 			return
 		}

--- a/iOS/Inspector/WebFeedInspectorViewController.swift
+++ b/iOS/Inspector/WebFeedInspectorViewController.swift
@@ -50,8 +50,8 @@ class WebFeedInspectorViewController: UITableViewController {
 		notifyAboutNewArticlesSwitch.setOn(webFeed.isNotifyAboutNewArticles ?? false, animated: false)
 		alwaysShowReaderViewSwitch.setOn(webFeed.isArticleExtractorAlwaysOn ?? false, animated: false)
 
-		homePageLabel.text = webFeed.homePageURL
-		feedURLLabel.text = webFeed.url
+		homePageLabel.text = webFeed.homePageURL?.decodedURLString
+		feedURLLabel.text = webFeed.url.decodedURLString
 		
 		NotificationCenter.default.addObserver(self, selector: #selector(webFeedIconDidBecomeAvailable(_:)), name: .WebFeedIconDidBecomeAvailable, object: nil)
 		


### PR DESCRIPTION
Displays IDN URLs with correct unicode characters to the user, etc. URLs are still stored as plain-ASCII so nothing should break (and any feeds added with a `xn--foo` domain will automatically display correctly decoded to the user).