### PR TITLE
Fixes #2058: Defer request for Notifications permissions on macOS until necessary

### DIFF
--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -231,8 +231,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		refreshTimer = AccountRefreshTimer()
 		syncTimer = ArticleStatusSyncTimer()
 		
-		UNUserNotificationCenter.current().requestAuthorization(options:[.badge, .sound, .alert]) { (granted, error) in }
-        NSApplication.shared.registerForRemoteNotifications()
+		UNUserNotificationCenter.current().getNotificationSettings { (settings) in
+			if settings.authorizationStatus == .authorized {
+				DispatchQueue.main.async {
+					NSApplication.shared.registerForRemoteNotifications()
+				}
+			}
+		}
 
 		UNUserNotificationCenter.current().delegate = self
 		userNotificationManager = UserNotificationManager()

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -178,7 +178,7 @@ private extension WebFeedInspectorViewController {
 		let updateAlert = NSAlert()
 		updateAlert.alertStyle = .informational
 		updateAlert.messageText = NSLocalizedString("Enable Notifications", comment: "Notifications")
-		updateAlert.informativeText = NSLocalizedString("Notifications need to be enabled in System Preferences > Notifications.", comment: "Notifications need to be enabled in System Preferences > Notifications.")
+		updateAlert.informativeText = NSLocalizedString("To enable notifications, open Notifications in System Preferences, then find NetNewsWire in the list.", comment: "To enable notifications, open Notifications in System Preferences, then find NetNewsWire in the list.")
 		updateAlert.addButton(withTitle: NSLocalizedString("Open System Preferences", comment: "Open System Preferences"))
 		updateAlert.addButton(withTitle: NSLocalizedString("Close", comment: "Close"))
 		let modalResponse = updateAlert.runModal()

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -56,7 +56,40 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 	
 	// MARK: Actions
 	@IBAction func isNotifyAboutNewArticlesChanged(_ sender: Any) {
-		feed?.isNotifyAboutNewArticles = (isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
+		guard let settings = userNotificationSettings else  {
+			// Something went wront fetching the user notification settings,
+			// so toggle the checkbox back to its original state and return.
+			isNotifyAboutNewArticlesCheckBox.setNextState()
+			return
+		}
+		if settings.authorizationStatus == .denied {
+			// Notifications are not authorized, so toggle the checkbox back
+			// to its original state...
+			isNotifyAboutNewArticlesCheckBox.setNextState()
+			// ...and then alert the user to the issue
+			// TODO: present alert to user
+		} else if settings.authorizationStatus == .authorized {
+			// Notifications are authorized, so set the feed's isNotifyAboutNewArticles
+			// property to match the state of isNotifyAboutNewArticlesCheckbox.
+			feed?.isNotifyAboutNewArticles = (isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
+		} else {
+			// We're not sure what the status may be but we've /probably/ not requested
+			// permission to send notifications, so do that:
+			UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .sound, .alert]) { (granted, error) in
+				self.updateNotificationSettings()
+				if granted {
+					// We've been given permission, so set the feed's isNotifyAboutNewArticles
+					// property to match the state of isNotifyAboutNewArticlesCheckbox and then
+					// register for remote notifications.
+					self.feed?.isNotifyAboutNewArticles = (self.isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
+					NSApplication.shared.registerForRemoteNotifications()
+				} else {
+					// We weren't given permission, so toggle the checkbox back to its
+					// original state.
+					self.isNotifyAboutNewArticlesCheckBox.setNextState()
+				}
+			}
+		}
 	}
 	
 	@IBAction func isReaderViewAlwaysOnChanged(_ sender: Any) {

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -56,8 +56,10 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 	
 	// MARK: Actions
 	@IBAction func isNotifyAboutNewArticlesChanged(_ sender: Any) {
-		guard let settings = userNotificationSettings else  {
-			isNotifyAboutNewArticlesCheckBox.setNextState()
+		guard userNotificationSettings != nil else  {
+			DispatchQueue.main.async {
+				self.isNotifyAboutNewArticlesCheckBox.setNextState()
+			}
 			return
 		}
 		

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -57,36 +57,26 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 	// MARK: Actions
 	@IBAction func isNotifyAboutNewArticlesChanged(_ sender: Any) {
 		guard let settings = userNotificationSettings else  {
-			// Something went wront fetching the user notification settings,
-			// so toggle the checkbox back to its original state and return.
 			isNotifyAboutNewArticlesCheckBox.setNextState()
 			return
 		}
 		if settings.authorizationStatus == .denied {
-			// Notifications are not authorized, so toggle the checkbox back
-			// to its original state...
 			isNotifyAboutNewArticlesCheckBox.setNextState()
-			// ...then alert the user to the issue...
 			showNotificationsDeniedError()
 		} else if settings.authorizationStatus == .authorized {
-			// Notifications are authorized, so set the feed's isNotifyAboutNewArticles
-			// property to match the state of isNotifyAboutNewArticlesCheckbox.
 			feed?.isNotifyAboutNewArticles = (isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
 		} else {
-			// We're not sure what the status may be but we've /probably/ not requested
-			// permission to send notifications, so do that:
 			UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .sound, .alert]) { (granted, error) in
 				self.updateNotificationSettings()
 				if granted {
-					// We've been given permission, so set the feed's isNotifyAboutNewArticles
-					// property to match the state of isNotifyAboutNewArticlesCheckbox and then
-					// register for remote notifications.
-					self.feed?.isNotifyAboutNewArticles = (self.isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
-					NSApplication.shared.registerForRemoteNotifications()
+					DispatchQueue.main.async {
+						self.feed?.isNotifyAboutNewArticles = (self.isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
+						NSApplication.shared.registerForRemoteNotifications()
+					}
 				} else {
-					// We weren't given permission, so toggle the checkbox back to its
-					// original state.
-					self.isNotifyAboutNewArticlesCheckBox.setNextState()
+					DispatchQueue.main.async {
+						self.isNotifyAboutNewArticlesCheckBox.setNextState()
+					}
 				}
 			}
 		}

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -60,22 +60,31 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 			isNotifyAboutNewArticlesCheckBox.setNextState()
 			return
 		}
-		if settings.authorizationStatus == .denied {
-			isNotifyAboutNewArticlesCheckBox.setNextState()
-			showNotificationsDeniedError()
-		} else if settings.authorizationStatus == .authorized {
-			feed?.isNotifyAboutNewArticles = (isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
-		} else {
-			UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .sound, .alert]) { (granted, error) in
-				self.updateNotificationSettings()
-				if granted {
-					DispatchQueue.main.async {
-						self.feed?.isNotifyAboutNewArticles = (self.isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
-						NSApplication.shared.registerForRemoteNotifications()
-					}
-				} else {
-					DispatchQueue.main.async {
-						self.isNotifyAboutNewArticlesCheckBox.setNextState()
+		
+		UNUserNotificationCenter.current().getNotificationSettings { (settings) in
+			self.updateNotificationSettings()
+			
+			if settings.authorizationStatus == .denied {
+				DispatchQueue.main.async {
+					self.isNotifyAboutNewArticlesCheckBox.setNextState()
+					self.showNotificationsDeniedError()
+				}
+			} else if settings.authorizationStatus == .authorized {
+				DispatchQueue.main.async {
+					self.feed?.isNotifyAboutNewArticles = (self.isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
+				}
+			} else {
+				UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .sound, .alert]) { (granted, error) in
+					self.updateNotificationSettings()
+					if granted {
+						DispatchQueue.main.async {
+							self.feed?.isNotifyAboutNewArticles = (self.isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
+							NSApplication.shared.registerForRemoteNotifications()
+						}
+					} else {
+						DispatchQueue.main.async {
+							self.isNotifyAboutNewArticlesCheckBox.setNextState()
+						}
 					}
 				}
 			}

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -191,9 +191,8 @@ private extension WebFeedInspectorViewController {
 		updateAlert.addButton(withTitle: NSLocalizedString("Close", comment: "Close"))
 		let modalResponse = updateAlert.runModal()
 		if modalResponse == .alertFirstButtonReturn {
-			NSWorkspace.shared.open(URL(fileURLWithPath: "x-apple.systempreferences:com.apple.preference"))
+			NSWorkspace.shared.open(URL(fileURLWithPath: "x-apple.systempreferences:com.apple.preference.notifications"))
 		}
-	}
 	}
 
 }

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -66,8 +66,8 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 			// Notifications are not authorized, so toggle the checkbox back
 			// to its original state...
 			isNotifyAboutNewArticlesCheckBox.setNextState()
-			// ...and then alert the user to the issue
-			// TODO: present alert to user
+			// ...then alert the user to the issue...
+			showNotificationsDeniedError()
 		} else if settings.authorizationStatus == .authorized {
 			// Notifications are authorized, so set the feed's isNotifyAboutNewArticles
 			// property to match the state of isNotifyAboutNewArticlesCheckbox.
@@ -181,6 +181,19 @@ private extension WebFeedInspectorViewController {
 					NSApplication.shared.registerForRemoteNotifications()
 				}
 			}
+		}
+	}
+
+	func showNotificationsDeniedError() {
+		let updateAlert = NSAlert()
+		updateAlert.alertStyle = .informational
+		updateAlert.messageText = NSLocalizedString("Enable Notifications", comment: "Notifications")
+		updateAlert.informativeText = NSLocalizedString("Notifications need to be enabled in System Preferences > Notifications.", comment: "Notifications need to be enabled in System Preferences > Notifications.")
+		updateAlert.addButton(withTitle: NSLocalizedString("Open System Preferences", comment: "Open System Preferences"))
+		updateAlert.addButton(withTitle: NSLocalizedString("Close", comment: "Close"))
+		let modalResponse = updateAlert.runModal()
+		if modalResponse == .alertFirstButtonReturn {
+			NSWorkspace.shared.open(URL(fileURLWithPath: "x-apple.systempreferences:com.apple.preference"))
 		}
 	}
 

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -9,6 +9,7 @@
 import AppKit
 import Articles
 import Account
+import UserNotifications
 
 final class WebFeedInspectorViewController: NSViewController, Inspector {
 
@@ -26,6 +27,8 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 			}
 		}
 	}
+
+	private var userNotificationSettings: UNNotificationSettings?
 
 	// MARK: Inspector
 

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -49,7 +49,11 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 		updateUI()
 		NotificationCenter.default.addObserver(self, selector: #selector(imageDidBecomeAvailable(_:)), name: .ImageDidBecomeAvailable, object: nil)
 	}
-
+	
+	override func viewDidAppear() {
+		updateNotificationSettings()
+	}
+	
 	// MARK: Actions
 	@IBAction func isNotifyAboutNewArticlesChanged(_ sender: Any) {
 		feed?.isNotifyAboutNewArticles = (isNotifyAboutNewArticlesCheckBox?.state ?? .off) == .on ? true : false
@@ -135,7 +139,18 @@ private extension WebFeedInspectorViewController {
 	func updateFeedURL() {
 		urlTextField?.stringValue = feed?.url ?? ""
 	}
-	
+
+	func updateNotificationSettings() {
+		UNUserNotificationCenter.current().getNotificationSettings { (settings) in
+			DispatchQueue.main.async {
+				self.userNotificationSettings = settings
+				if settings.authorizationStatus == .authorized {
+					NSApplication.shared.registerForRemoteNotifications()
+				}
+			}
+		}
+	}
+
 	func updateNotifyAboutNewArticles() {
 		isNotifyAboutNewArticlesCheckBox?.state = (feed?.isNotifyAboutNewArticles ?? false) ? .on : .off
 	}

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -173,9 +173,9 @@ private extension WebFeedInspectorViewController {
 
 	func updateNotificationSettings() {
 		UNUserNotificationCenter.current().getNotificationSettings { (settings) in
-			DispatchQueue.main.async {
-				self.userNotificationSettings = settings
-				if settings.authorizationStatus == .authorized {
+			self.userNotificationSettings = settings
+			if settings.authorizationStatus == .authorized {
+				DispatchQueue.main.async {
 					NSApplication.shared.registerForRemoteNotifications()
 				}
 			}

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -163,6 +163,14 @@ private extension WebFeedInspectorViewController {
 		urlTextField?.stringValue = feed?.url ?? ""
 	}
 
+	func updateNotifyAboutNewArticles() {
+		isNotifyAboutNewArticlesCheckBox?.state = (feed?.isNotifyAboutNewArticles ?? false) ? .on : .off
+	}
+
+	func updateIsReaderViewAlwaysOn() {
+		isReaderViewAlwaysOnCheckBox?.state = (feed?.isArticleExtractorAlwaysOn ?? false) ? .on : .off
+	}
+
 	func updateNotificationSettings() {
 		UNUserNotificationCenter.current().getNotificationSettings { (settings) in
 			DispatchQueue.main.async {
@@ -186,12 +194,6 @@ private extension WebFeedInspectorViewController {
 			NSWorkspace.shared.open(URL(fileURLWithPath: "x-apple.systempreferences:com.apple.preference"))
 		}
 	}
-
-	func updateNotifyAboutNewArticles() {
-		isNotifyAboutNewArticlesCheckBox?.state = (feed?.isNotifyAboutNewArticles ?? false) ? .on : .off
 	}
 
-	func updateIsReaderViewAlwaysOn() {
-		isReaderViewAlwaysOnCheckBox?.state = (feed?.isArticleExtractorAlwaysOn ?? false) ? .on : .off
-	}
 }


### PR DESCRIPTION
Fixes #2058.

This PR essentially replicates the iOS app's behaviour in the macOS app. However, it departs slightly from the approach taken by the iOS code to prevent a race condition between _getting_ and _checking_ `userNotificationSettings` when the notification checkbox is toggled in the web feed inspector.

The iOS app calls `updateNotificationSettings()` in the web feed inspector's `viewDidAppear()` method, which fires when we dismiss a modal to return to the view (or round-trip over to the Settings app and back to NetNewsWire). On the Mac, it doesn't.

Simply calling `updateNotificationSettings()` at the top of the `isNotifyAboutNewArticlesChanged(_:)` action isn't sufficient, since fetching the user's notification settings happens asynchronously, so by the time we've retrieved the `authorizationStatus`, the code has already moved on to checking what that (now stale) `authorizationStatus` is.

To get around that, then, we first call `UNUserNotificationCenter.current().getNotifications()` to get the settings, and then run the checking logic and flip the relevant bits in that method's the completion handler.


---

_Replaces PR #2314_