### PR TITLE
Multiplatform Mac: Adds sidebar toggling from toolbar.

### DIFF
--- a/Multiplatform/Shared/AppAssets.swift
+++ b/Multiplatform/Shared/AppAssets.swift
@@ -301,6 +301,10 @@ struct AppAssets {
 		return IconImage(coloredImage, isSymbol: true)
 		#endif
 	}
+	
+	static var sidebarToggleImage: Image {
+		return Image(systemName: "sidebar.left")
+	}
 
 	#if os(macOS)
 	static var webStatusBarBackground: NSColor = {

--- a/Multiplatform/Shared/MainApp.swift
+++ b/Multiplatform/Shared/MainApp.swift
@@ -110,6 +110,7 @@ struct MainApp: App {
 					}
 					.tag(MacPreferencePane.advanced)
 			}
+			.preferredColorScheme(AppDefaults.userInterfaceColorScheme)
 			.frame(width: 500)
 			.padding()
 		}

--- a/Multiplatform/Shared/SceneNavigationView.swift
+++ b/Multiplatform/Shared/SceneNavigationView.swift
@@ -109,7 +109,7 @@ struct SceneNavigationView: View {
 				} label: {
 					Image(systemName: "sidebar.left")
 				}
-				.help("Toggle Sidebar").padding(.trailing, 40)
+				.help("Toggle Sidebar")
 			}
 			ToolbarItem() {
 				Menu {

--- a/Multiplatform/Shared/SceneNavigationView.swift
+++ b/Multiplatform/Shared/SceneNavigationView.swift
@@ -107,7 +107,7 @@ struct SceneNavigationView: View {
 					#warning("Use of AppKit in SwiftUI.")
 					NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
 				} label: {
-					Image(systemName: "sidebar.left")
+					AppAssets.sidebarToggleImage
 				}
 				.help("Toggle Sidebar")
 			}

--- a/Multiplatform/Shared/SceneNavigationView.swift
+++ b/Multiplatform/Shared/SceneNavigationView.swift
@@ -8,6 +8,9 @@
 
 import SwiftUI
 import Account
+#if os(macOS)
+import AppKit
+#endif
 
 struct SceneNavigationView: View {
 
@@ -99,6 +102,14 @@ struct SceneNavigationView: View {
 		.toolbar {
 			
 			#if os(macOS)
+			ToolbarItem(placement: .navigation) {
+				Button {
+					NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
+				} label: {
+					Image(systemName: "sidebar.left")
+				}
+				.help("Toggle Sidebar").padding(.trailing, 40)
+			}
 			ToolbarItem() {
 				Menu {
 					Button("Add Web Feed", action: { sheetToShow = .web })
@@ -111,8 +122,6 @@ struct SceneNavigationView: View {
 			}
 			ToolbarItem {
 				Button {
-//					AccountManager.shared.refreshAll(errorHandler: handleRefreshError)
-					
 					AccountManager.shared.refreshAll(completion: nil)
 					
 				} label: {
@@ -130,10 +139,10 @@ struct SceneNavigationView: View {
 				.disabled(sceneModel.markAllAsReadButtonState == nil)
 				.help("Mark All as Read")
 			}
-			ToolbarItem {
-				MacSearchField()
-					.frame(width: 200)
-			}
+//			ToolbarItem {
+//				MacSearchField()
+//					.frame(width: 200)
+//			}
 			ToolbarItem {
 				Button {
 					sceneModel.goToNextUnread()

--- a/Multiplatform/Shared/SceneNavigationView.swift
+++ b/Multiplatform/Shared/SceneNavigationView.swift
@@ -104,6 +104,7 @@ struct SceneNavigationView: View {
 			#if os(macOS)
 			ToolbarItem(placement: .navigation) {
 				Button {
+					#warning("Use of AppKit in SwiftUI.")
 					NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
 				} label: {
 					Image(systemName: "sidebar.left")

--- a/Multiplatform/Shared/SceneNavigationView.swift
+++ b/Multiplatform/Shared/SceneNavigationView.swift
@@ -104,7 +104,6 @@ struct SceneNavigationView: View {
 			#if os(macOS)
 			ToolbarItem(placement: .navigation) {
 				Button {
-					#warning("Use of AppKit in SwiftUI.")
 					NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
 				} label: {
 					AppAssets.sidebarToggleImage


### PR DESCRIPTION
This adds one too many items to the `.toolbar`, so the search bar is hidden for the time being. 