### PR TITLE
Partially fixes #566

### DIFF
--- a/Multiplatform/Shared/AppDefaults.swift
+++ b/Multiplatform/Shared/AppDefaults.swift
@@ -61,6 +61,9 @@ final class AppDefaults: ObservableObject {
 		static let timelineGroupByFeed = "timelineGroupByFeed"
 		static let timelineIconDimensions = "timelineIconDimensions"
 		static let timelineNumberOfLines = "timelineNumberOfLines"
+		
+		// Sidebar Defaults
+		static let sidebarConfirmDelete = "sidebarConfirmDelete"
 
 		// iOS Defaults
 		static let refreshClearsReadArticles = "refreshClearsReadArticles"
@@ -198,7 +201,7 @@ final class AppDefaults: ObservableObject {
 			objectWillChange.send()
 		}
 	}
-	
+
 	@AppStorage(wrappedValue: 40.0, Key.timelineIconDimensions, store: store) var timelineIconDimensions: Double {
 		didSet {
 			objectWillChange.send()
@@ -211,6 +214,14 @@ final class AppDefaults: ObservableObject {
 			objectWillChange.send()
 		}
 	}
+	
+	// MARK: Sidebar
+	@AppStorage(wrappedValue: true, Key.sidebarConfirmDelete, store: store) var sidebarConfirmDelete: Bool {
+		didSet {
+			objectWillChange.send()
+		}
+	}
+	
 	
 	// MARK: Refresh
 	@AppStorage(wrappedValue: false, Key.refreshClearsReadArticles, store: store) var refreshClearsReadArticles: Bool

--- a/Multiplatform/Shared/Sidebar/SidebarContextMenu.swift
+++ b/Multiplatform/Shared/Sidebar/SidebarContextMenu.swift
@@ -123,7 +123,12 @@ struct SidebarContextMenu: View {
 			}
 			Divider()
 			Button {
-				sidebarModel.deleteFromAccount.send(sidebarItem.feed!)
+				if AppDefaults.shared.sidebarConfirmDelete == false {
+					sidebarModel.deleteFromAccount.send(sidebarItem.feed!)
+				} else {
+					sidebarModel.sidebarItemToDelete = sidebarItem.feed!
+					sidebarModel.showDeleteConfirmation = true
+				}
 			} label: {
 				Text("Delete")
 				#if os(iOS)
@@ -153,15 +158,26 @@ struct SidebarContextMenu: View {
 				AppAssets.markAllAsReadImage
 				#endif
 			}
+			
+			/*
+				You cannot select folder level items in b4. Delete is disabled for the time being.
+			*/
+			/*
 			Divider()
 			Button {
-				sidebarModel.deleteFromAccount.send(sidebarItem.feed!)
+				if AppDefaults.shared.sidebarConfirmDelete == false {
+					sidebarModel.deleteFromAccount.send(sidebarItem.feed!)
+				} else {
+					sidebarModel.sidebarContextMenuItem = sidebarItem.feed
+					sidebarModel.showDeleteConfirmation = true
+				}
 			} label: {
 				Text("Delete")
 				#if os(iOS)
 				AppAssets.deleteImage
 				#endif
 			}
+			*/
 		}
 		
     }

--- a/Multiplatform/Shared/Sidebar/SidebarView.swift
+++ b/Multiplatform/Shared/Sidebar/SidebarView.swift
@@ -62,6 +62,23 @@ struct SidebarView: View {
 				.transition(.move(edge: .bottom))
 			}
 		}
+		.alert(isPresented: $sidebarModel.showDeleteConfirmation, content: {
+			Alert(title: sidebarModel.countOfFeedsToDelete() > 1 ?
+							(Text("Delete multiple items?")) :
+							(Text("Delete \(sidebarModel.namesOfFeedsToDelete())?")),
+						 message: Text("Are you sure you wish to delete \(sidebarModel.namesOfFeedsToDelete())?"),
+				  primaryButton: .destructive(Text("Delete"),
+											  action: {
+												sidebarModel.deleteFromAccount.send(sidebarModel.sidebarItemToDelete!)
+												sidebarModel.sidebarItemToDelete = nil
+												sidebarModel.selectedFeedIdentifiers.removeAll()
+												sidebarModel.showDeleteConfirmation = false
+				  }),
+				  secondaryButton: .cancel(Text("Cancel"), action: {
+						sidebarModel.sidebarItemToDelete = nil
+						sidebarModel.showDeleteConfirmation = false
+				  }))
+		})
 		#else
 		ZStack(alignment: .top) {
 			List {
@@ -76,6 +93,23 @@ struct SidebarView: View {
 				ProgressView().offset(y: -40)
 			}
 		}
+		.alert(isPresented: $sidebarModel.showDeleteConfirmation, content: {
+			Alert(title: sidebarModel.countOfFeedsToDelete() > 1 ?
+							(Text("Delete multiple items?")) :
+							(Text("Delete \(sidebarModel.namesOfFeedsToDelete())?")),
+						 message: Text("Are you sure you wish to delete \(sidebarModel.namesOfFeedsToDelete())?"),
+				  primaryButton: .destructive(Text("Delete"),
+											  action: {
+												sidebarModel.deleteFromAccount.send(sidebarModel.sidebarItemToDelete!)
+												sidebarModel.sidebarItemToDelete = nil
+												sidebarModel.selectedFeedIdentifiers.removeAll()
+												sidebarModel.showDeleteConfirmation = false
+				  }),
+				  secondaryButton: .cancel(Text("Cancel"), action: {
+						sidebarModel.sidebarItemToDelete = nil
+						sidebarModel.showDeleteConfirmation = false
+				  }))
+		})
 		#endif
 		
 //		.onAppear {

--- a/Multiplatform/iOS/Settings/SettingsView.swift
+++ b/Multiplatform/iOS/Settings/SettingsView.swift
@@ -26,7 +26,6 @@ struct SettingsView: View {
 				systemSettings
 				accounts
 				importExport
-				sidebarFeedManagement
 				timeline
 				articles
 				appearance
@@ -101,6 +100,7 @@ struct SettingsView: View {
 						.foregroundColor(.primary)
 				}
 			}
+			Toggle("Confirm When Deleting", isOn: $settings.sidebarConfirmDelete)
 		})
 		.alert(isPresented: $feedsSettingsModel.showError) {
 			Alert(
@@ -138,17 +138,14 @@ struct SettingsView: View {
 						Text(viewModel.accounts[i].nameForDisplay)
 					}
 				})
+				
 			})
 		}
 		.listStyle(InsetGroupedListStyle())
 		.navigationBarTitle("Export Subscriptions", displayMode: .inline)
 	}
 	
-	var sidebarFeedManagement: some View {
-		Section(header: Text("Feed Management")) {
-			Toggle("Confirm When Deleting Feeds and Folders", isOn: $settings.sidebarConfirmDelete)
-		}.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-	}
+	
 	
 	var timeline: some View {
 		Section(header: Text("Timeline"), content: {

--- a/Multiplatform/iOS/Settings/SettingsView.swift
+++ b/Multiplatform/iOS/Settings/SettingsView.swift
@@ -26,6 +26,7 @@ struct SettingsView: View {
 				systemSettings
 				accounts
 				importExport
+				sidebarFeedManagement
 				timeline
 				articles
 				appearance
@@ -141,6 +142,12 @@ struct SettingsView: View {
 		}
 		.listStyle(InsetGroupedListStyle())
 		.navigationBarTitle("Export Subscriptions", displayMode: .inline)
+	}
+	
+	var sidebarFeedManagement: some View {
+		Section(header: Text("Feed Management")) {
+			Toggle("Confirm When Deleting Feeds and Folders", isOn: $settings.sidebarConfirmDelete)
+		}.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 	}
 	
 	var timeline: some View {

--- a/Multiplatform/iOS/Settings/SettingsView.swift
+++ b/Multiplatform/iOS/Settings/SettingsView.swift
@@ -101,6 +101,7 @@ struct SettingsView: View {
 				}
 			}
 			Toggle("Confirm When Deleting", isOn: $settings.sidebarConfirmDelete)
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 		})
 		.alert(isPresented: $feedsSettingsModel.showError) {
 			Alert(

--- a/Multiplatform/macOS/Preferences/Preference Panes/General/GeneralPreferencesView.swift
+++ b/Multiplatform/macOS/Preferences/Preference Panes/General/GeneralPreferencesView.swift
@@ -35,6 +35,7 @@ struct GeneralPreferencesView: View {
 				})
 			})
 			
+			Toggle("Confirm when deleting feeds and folders", isOn: $defaults.sidebarConfirmDelete)
 			
 			Toggle("Open webpages in background in browser", isOn: $defaults.openInBrowserInBackground)
 			


### PR DESCRIPTION
- Adds a preference to show alerts to confirm deletion of feeds (default is true) and this is configurable in Settings / Preferences
- Supports single (iOS/macOS) and multiple selection (macOS) for deletion

Known Issues:
- Until folders are selectable (future beta, hopefully), selecting them for deletion is disabled.
- The macOS sidebar doesn't always refresh after a deletion.

![Delete confirms](https://user-images.githubusercontent.com/7046652/90302821-a2473080-dedb-11ea-996e-bcb8ed56732f.png)
