### PR TITLE
Set window title based on type of Inspector being shown

### DIFF
--- a/Frameworks/Account/Account.swift
+++ b/Frameworks/Account/Account.swift
@@ -250,7 +250,7 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 		return delegate.refreshProgress
 	}
 
-	init?(dataFolder: String, type: AccountType, accountID: String, transport: Transport? = nil) {
+	init(dataFolder: String, type: AccountType, accountID: String, transport: Transport? = nil) {
 		switch type {
 		case .onMyMac:
 			self.delegate = LocalAccountDelegate()

--- a/Frameworks/Account/AccountManager.swift
+++ b/Frameworks/Account/AccountManager.swift
@@ -103,7 +103,7 @@ public final class AccountManager: UnreadCountProvider {
 			abort()
 		}
 
-		defaultAccount = Account(dataFolder: localAccountFolder, type: .onMyMac, accountID: defaultAccountIdentifier)!
+		defaultAccount = Account(dataFolder: localAccountFolder, type: .onMyMac, accountID: defaultAccountIdentifier)
         accountsDictionary[defaultAccount.accountID] = defaultAccount
 
 		readAccountsFromDisk()
@@ -130,7 +130,7 @@ public final class AccountManager: UnreadCountProvider {
 			abort()
 		}
 		
-		let account = Account(dataFolder: accountFolder, type: type, accountID: accountID)!
+		let account = Account(dataFolder: accountFolder, type: type, accountID: accountID)
 		accountsDictionary[accountID] = account
 		
 		var userInfo = [String: Any]()

--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -194,7 +194,12 @@ final class AppDefaults {
  	}
 
 	var hideDockUnreadCount: Bool {
-		return AppDefaults.bool(for: Key.hideDockUnreadCount)
+		get {
+			return AppDefaults.bool(for: Key.hideDockUnreadCount)
+		}
+		set {
+			AppDefaults.setBool(for: Key.hideDockUnreadCount, newValue)
+		}
 	}
 
 	#if !MAC_APP_STORE

--- a/Mac/Base.lproj/Preferences.storyboard
+++ b/Mac/Base.lproj/Preferences.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="mPU-HG-I4u">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="mPU-HG-I4u">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -138,18 +139,7 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
-                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.JustinMillerHideDockUnreadCount" id="J0i-eh-Rqq">
-                                                <dictionary key="options">
-                                                    <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                    <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                    <integer key="NSMultipleValuesPlaceholder" value="1"/>
-                                                    <integer key="NSNoSelectionPlaceholder" value="1"/>
-                                                    <integer key="NSNotApplicablePlaceholder" value="1"/>
-                                                    <integer key="NSNullPlaceholder" value="1"/>
-                                                    <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                                </dictionary>
-                                            </binding>
+                                            <action selector="toggleShowingUnreadCount:" target="iuH-lz-18x" id="CfQ-Pv-9d2"/>
                                         </connections>
                                     </button>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="j0t-Wa-UTL">
@@ -198,6 +188,7 @@
                     </view>
                     <connections>
                         <outlet property="defaultBrowserPopup" destination="Ci4-fW-KjU" id="7Nh-nU-Sbc"/>
+                        <outlet property="showUnreadCountCheckbox" destination="mwT-nY-TrX" id="ZH9-P5-JkT"/>
                     </connections>
                 </viewController>
                 <customObject id="bSQ-tq-wd3" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -383,16 +374,16 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="7UM-iq-OLB" customClass="PreferencesTableViewBackgroundView" customModule="NetNewsWire" customModuleProvider="target">
-                                <rect key="frame" x="20" y="44" width="160" height="219"/>
+                                <rect key="frame" x="20" y="44" width="160" height="234"/>
                                 <subviews>
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="PaF-du-r3c">
-                                        <rect key="frame" x="1" y="0.0" width="158" height="218"/>
+                                        <rect key="frame" x="1" y="0.0" width="158" height="233"/>
                                         <clipView key="contentView" id="cil-Gq-akO">
-                                            <rect key="frame" x="0.0" y="0.0" width="158" height="218"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="158" height="233"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" viewBased="YES" id="aTp-KR-y6b">
-                                                    <rect key="frame" x="0.0" y="0.0" width="159" height="218"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="188" height="233"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -411,7 +402,7 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="Cell" id="h2e-5a-qNO">
-                                                                    <rect key="frame" x="1" y="1" width="156" height="17"/>
+                                                                    <rect key="frame" x="11" y="1" width="165" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
                                                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="27f-p8-Wnt">
@@ -423,7 +414,7 @@
                                                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="lKA-xK-bHU"/>
                                                                         </imageView>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hR2-bm-0wE">
-                                                                            <rect key="frame" x="26" y="1" width="126" height="16"/>
+                                                                            <rect key="frame" x="26" y="1" width="135" height="16"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="CcS-BO-sdv">
                                                                                 <font key="font" metaFont="system"/>
                                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -499,7 +490,7 @@
                                 <rect key="frame" x="83" y="20" width="97" height="24"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="Y7D-xQ-wep">
-                                <rect key="frame" x="188" y="20" width="242" height="243"/>
+                                <rect key="frame" x="188" y="20" width="242" height="258"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -554,16 +545,16 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="pjs-G4-byk" customClass="PreferencesTableViewBackgroundView" customModule="NetNewsWire" customModuleProvider="target">
-                                <rect key="frame" x="20" y="44" width="160" height="212"/>
+                                <rect key="frame" x="20" y="44" width="160" height="227"/>
                                 <subviews>
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="29T-r2-ckC">
-                                        <rect key="frame" x="1" y="0.0" width="158" height="211"/>
+                                        <rect key="frame" x="1" y="0.0" width="158" height="226"/>
                                         <clipView key="contentView" id="dXw-GY-TP8">
-                                            <rect key="frame" x="0.0" y="0.0" width="158" height="211"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="158" height="226"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" viewBased="YES" id="dfn-Vn-oDp">
-                                                    <rect key="frame" x="0.0" y="0.0" width="159" height="211"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="188" height="226"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -582,7 +573,7 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="Cell" id="xQs-6E-Kpy">
-                                                                    <rect key="frame" x="1" y="1" width="156" height="17"/>
+                                                                    <rect key="frame" x="11" y="1" width="165" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
                                                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kmG-vw-CbN">
@@ -594,7 +585,7 @@
                                                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="OVD-Jo-TXU"/>
                                                                         </imageView>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6cr-cB-qAN">
-                                                                            <rect key="frame" x="26" y="1" width="126" height="16"/>
+                                                                            <rect key="frame" x="26" y="1" width="135" height="16"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="goO-QG-kk7">
                                                                                 <font key="font" metaFont="system"/>
                                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -666,7 +657,7 @@
                                 <rect key="frame" x="83" y="20" width="97" height="24"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="N1N-pE-gBL">
-                                <rect key="frame" x="188" y="20" width="242" height="236"/>
+                                <rect key="frame" x="188" y="20" width="242" height="251"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -701,8 +692,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="NSActionTemplate" width="14" height="14"/>
-        <image name="NSAddTemplate" width="11" height="11"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="NSActionTemplate" width="15" height="15"/>
+        <image name="NSAddTemplate" width="14" height="13"/>
+        <image name="NSRemoveTemplate" width="14" height="4"/>
     </resources>
 </document>

--- a/Mac/Inspector/BuiltinSmartFeedInspectorViewController.swift
+++ b/Mac/Inspector/BuiltinSmartFeedInspectorViewController.swift
@@ -26,6 +26,7 @@ final class BuiltinSmartFeedInspectorViewController: NSViewController, Inspector
 			updateSmartFeed()
 		}
 	}
+	var windowTitle: String = NSLocalizedString("Smart Feed Inspector", comment: "Smart Feed Inspector window title")
 
 	func canInspect(_ objects: [Any]) -> Bool {
 

--- a/Mac/Inspector/BuiltinSmartFeedInspectorViewController.swift
+++ b/Mac/Inspector/BuiltinSmartFeedInspectorViewController.swift
@@ -63,5 +63,6 @@ private extension BuiltinSmartFeedInspectorViewController {
 	func updateUI() {
 
 		nameTextField?.stringValue = smartFeed?.nameForDisplay ?? ""
+		windowTitle = smartFeed?.nameForDisplay ?? NSLocalizedString("Smart Feed Inspector", comment: "Smart Feed Inspector window title")
 	}
 }

--- a/Mac/Inspector/FolderInspectorViewController.swift
+++ b/Mac/Inspector/FolderInspectorViewController.swift
@@ -104,5 +104,6 @@ private extension FolderInspectorViewController {
 		if nameTextField.stringValue != name {
 			nameTextField.stringValue = name
 		}
+		windowTitle = folder?.nameForDisplay ?? NSLocalizedString("Folder Inspector", comment: "Folder Inspector window title")
 	}
 }

--- a/Mac/Inspector/FolderInspectorViewController.swift
+++ b/Mac/Inspector/FolderInspectorViewController.swift
@@ -30,6 +30,7 @@ final class FolderInspectorViewController: NSViewController, Inspector {
 			updateFolder()
 		}
 	}
+	var windowTitle: String = NSLocalizedString("Folder Inspector", comment: "Folder Inspector window title")
 
 	func canInspect(_ objects: [Any]) -> Bool {
 

--- a/Mac/Inspector/InspectorWindowController.swift
+++ b/Mac/Inspector/InspectorWindowController.swift
@@ -111,7 +111,9 @@ private extension InspectorWindowController {
 			return
 		}
 
-		window.title = inspector.windowTitle
+		DispatchQueue.main.async {
+			window.title = inspector.windowTitle
+		}	
 
 		let flippedOrigin = window.flippedOrigin
 

--- a/Mac/Inspector/InspectorWindowController.swift
+++ b/Mac/Inspector/InspectorWindowController.swift
@@ -108,7 +108,32 @@ private extension InspectorWindowController {
 		guard let window = window else {
 			return
 		}
-		
+
+		switch inspector {
+		case is NothingInspectorViewController:
+			window.title = NSLocalizedString("Inspector", comment: "Inspector window title")
+		case is FolderInspectorViewController:
+			if let folderName = (inspector as? FolderInspectorViewController)?.nameTextField?.stringValue {
+				window.title = folderName
+			} else {
+				window.title = NSLocalizedString("Folder Inspector", comment: "Folder Inspector window title")
+			}
+		case is WebFeedInspectorViewController:
+			if let feedName = (inspector as? WebFeedInspectorViewController)?.nameTextField?.stringValue {
+				window.title = feedName
+			} else {
+				window.title = NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
+			}
+		case is BuiltinSmartFeedInspectorViewController:
+			if let smartFeedName = (inspector as? BuiltinSmartFeedInspectorViewController)?.nameTextField?.stringValue {
+				window.title = smartFeedName
+			} else {
+				window.title = NSLocalizedString("Smart Feed Inspector", comment: "Smart Feed Inspector window title")
+			}
+		default:
+			window.title = NSLocalizedString("Inspector", comment: "Inspector window title")
+		}
+
 		let flippedOrigin = window.flippedOrigin
 
 		if window.contentViewController != inspector {

--- a/Mac/Inspector/InspectorWindowController.swift
+++ b/Mac/Inspector/InspectorWindowController.swift
@@ -12,6 +12,7 @@ protocol Inspector: class {
 
 	var objects: [Any]? { get set }
 	var isFallbackInspector: Bool { get } // Can handle nothing-to-inspect or unexpected type of objects.
+	var windowTitle: String { get }
 
 	func canInspect(_ objects: [Any]) -> Bool
 }
@@ -62,6 +63,7 @@ final class InspectorWindowController: NSWindowController {
 
 		inspectors = [feedInspector, folderInspector, builtinSmartFeedInspector, nothingInspector]
 		currentInspector = nothingInspector
+		window?.title = currentInspector.windowTitle
 
 		if let savedOrigin = originFromDefaults() {
 			window?.setFlippedOriginAdjustingForScreen(savedOrigin)
@@ -109,30 +111,7 @@ private extension InspectorWindowController {
 			return
 		}
 
-		switch inspector {
-		case is NothingInspectorViewController:
-			window.title = NSLocalizedString("Inspector", comment: "Inspector window title")
-		case is FolderInspectorViewController:
-			if let folderName = (inspector as? FolderInspectorViewController)?.nameTextField?.stringValue {
-				window.title = folderName
-			} else {
-				window.title = NSLocalizedString("Folder Inspector", comment: "Folder Inspector window title")
-			}
-		case is WebFeedInspectorViewController:
-			if let feedName = (inspector as? WebFeedInspectorViewController)?.nameTextField?.stringValue {
-				window.title = feedName
-			} else {
-				window.title = NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
-			}
-		case is BuiltinSmartFeedInspectorViewController:
-			if let smartFeedName = (inspector as? BuiltinSmartFeedInspectorViewController)?.nameTextField?.stringValue {
-				window.title = smartFeedName
-			} else {
-				window.title = NSLocalizedString("Smart Feed Inspector", comment: "Smart Feed Inspector window title")
-			}
-		default:
-			window.title = NSLocalizedString("Inspector", comment: "Inspector window title")
-		}
+		window.title = inspector.windowTitle
 
 		let flippedOrigin = window.flippedOrigin
 

--- a/Mac/Inspector/NothingInspectorViewController.swift
+++ b/Mac/Inspector/NothingInspectorViewController.swift
@@ -19,6 +19,7 @@ final class NothingInspectorViewController: NSViewController, Inspector {
 			updateTextFields()
 		}
 	}
+	var windowTitle: String = NSLocalizedString("Inspector", comment: "Inspector window title")
 
 	func canInspect(_ objects: [Any]) -> Bool {
 

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -134,7 +134,7 @@ private extension WebFeedInspectorViewController {
 		updateFeedURL()
 		updateNotifyAboutNewArticles()
 		updateIsReaderViewAlwaysOn()
-		
+		windowTitle = feed?.nameForDisplay ?? NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
 		view.needsLayout = true
 	}
 

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -38,6 +38,7 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 			updateFeed()
 		}
 	}
+	var windowTitle: String = NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
 
 	func canInspect(_ objects: [Any]) -> Bool {
 		return objects.count == 1 && objects.first is WebFeed

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -113,6 +113,7 @@ extension WebFeedInspectorViewController: NSTextFieldDelegate {
 			return
 		}
 		feed.editedName = nameTextField.stringValue
+		windowTitle = feed.editedName ?? NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
 	}
 	
 }

--- a/Mac/Preferences/General/GeneralPrefencesViewController.swift
+++ b/Mac/Preferences/General/GeneralPrefencesViewController.swift
@@ -9,11 +9,15 @@
 import AppKit
 import RSCore
 import RSWeb
+import UserNotifications
 
 final class GeneralPreferencesViewController: NSViewController {
 
-	@IBOutlet var defaultBrowserPopup: NSPopUpButton!
+	private var userNotificationSettings: UNNotificationSettings?
 
+	@IBOutlet var defaultBrowserPopup: NSPopUpButton!
+    @IBOutlet weak var showUnreadCountCheckbox: NSButton!
+    
 	public override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
 		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 		commonInit()
@@ -27,6 +31,7 @@ final class GeneralPreferencesViewController: NSViewController {
 	override func viewWillAppear() {
 		super.viewWillAppear()
 		updateUI()
+		updateNotificationSettings()
 	}
 
 	// MARK: - Notifications
@@ -45,6 +50,47 @@ final class GeneralPreferencesViewController: NSViewController {
 		AppDefaults.shared.defaultBrowserID = bundleID
 		updateUI()
 	}
+
+    
+    @IBAction func toggleShowingUnreadCount(_ sender: Any) {
+        guard let checkbox = sender as? NSButton else { return }
+
+		guard userNotificationSettings != nil else {
+			DispatchQueue.main.async {
+				self.showUnreadCountCheckbox.setNextState()
+			}
+			return
+		}
+
+		UNUserNotificationCenter.current().getNotificationSettings { (settings) in
+			self.updateNotificationSettings()
+
+			if settings.authorizationStatus == .denied {
+				DispatchQueue.main.async {
+					self.showUnreadCountCheckbox.setNextState()
+					self.showNotificationsDeniedError()
+				}
+			} else if settings.authorizationStatus == .authorized {
+				DispatchQueue.main.async {
+					AppDefaults.shared.hideDockUnreadCount = (checkbox.state.rawValue == 0)
+				}
+			} else {
+				UNUserNotificationCenter.current().requestAuthorization(options: [.badge]) { (granted, error) in
+					self.updateNotificationSettings()
+					if granted {
+						DispatchQueue.main.async {
+							AppDefaults.shared.hideDockUnreadCount = checkbox.state.rawValue == 0
+							NSApplication.shared.registerForRemoteNotifications()
+						}
+					} else {
+						DispatchQueue.main.async {
+							self.showUnreadCountCheckbox.setNextState()
+						}
+					}
+				}
+			}
+		}
+    }
 }
 
 // MARK: - Private
@@ -57,6 +103,7 @@ private extension GeneralPreferencesViewController {
 
 	func updateUI() {
 		updateBrowserPopup()
+        updateHideUnreadCountCheckbox()
 	}
 
 	func updateBrowserPopup() {
@@ -89,4 +136,33 @@ private extension GeneralPreferencesViewController {
 
 		defaultBrowserPopup.selectItem(at: defaultBrowserPopup.indexOfItem(withRepresentedObject: AppDefaults.shared.defaultBrowserID))
 	}
+
+    func updateHideUnreadCountCheckbox() {
+        showUnreadCountCheckbox.state = AppDefaults.shared.hideDockUnreadCount ? .off : .on
+    }
+
+	func updateNotificationSettings() {
+		UNUserNotificationCenter.current().getNotificationSettings { (settings) in
+			self.userNotificationSettings = settings
+			if settings.authorizationStatus == .authorized {
+				DispatchQueue.main.async {
+					NSApplication.shared.registerForRemoteNotifications()
+				}
+			}
+		}
+	}
+
+	func showNotificationsDeniedError() {
+		let updateAlert = NSAlert()
+		updateAlert.alertStyle = .informational
+		updateAlert.messageText = NSLocalizedString("Enable Notifications", comment: "Notifications")
+		updateAlert.informativeText = NSLocalizedString("To enable notifications, open Notifications in System Preferences, then find NetNewsWire in the list.", comment: "To enable notifications, open Notifications in System Preferences, then find NetNewsWire in the list.")
+		updateAlert.addButton(withTitle: NSLocalizedString("Open System Preferences", comment: "Open System Preferences"))
+		updateAlert.addButton(withTitle: NSLocalizedString("Close", comment: "Close"))
+		let modalResponse = updateAlert.runModal()
+		if modalResponse == .alertFirstButtonReturn {
+			NSWorkspace.shared.open(URL(fileURLWithPath: "x-apple.systempreferences:com.apple.preference.notifications"))
+		}
+	}
+
 }


### PR DESCRIPTION
This PR closes #2354.

Before showing the inspector window, this change checks what subclass of InspectorViewController class is being shown, then sets the window title accordingly:

- A `NothingInspectorViewController` (or unknown case) gets the window title "Inspector".
- A `FolderInspectorViewController`, `WebFeedInspectorViewController`, or `BuiltinSmartFeedInspectorViewController` gets the window title from the subclassed view controller's `nameTextField` property, if it exists; if it doesn't, it gets a generally-descriptive title like "Folder Inspector", "Feed Inspector", or "Smart Feed Inspector" instead.

Probably worth verifying:

- [ ] Clicking on a feed, folder, or smartfeed while the inspector is open changes the inspector's window title as expected
- [ ] Closing the inspector, clicking on another sidebar item, and then opening the inspector shows the correct window title.
- [ ] Opening the inspector and changing the name of the sidebar item (where possible) updates the inspector window's title.

👆 "Works on my machine" but please let me know if it doesn't for you!