### PR TITLE
2390 check notifications permissions for unread count

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -194,7 +194,12 @@ final class AppDefaults {
  	}
 
 	var hideDockUnreadCount: Bool {
-		return AppDefaults.bool(for: Key.hideDockUnreadCount)
+		get {
+			return AppDefaults.bool(for: Key.hideDockUnreadCount)
+		}
+		set {
+			AppDefaults.setBool(for: Key.hideDockUnreadCount, newValue)
+		}
 	}
 
 	#if !MAC_APP_STORE

--- a/Mac/Base.lproj/Preferences.storyboard
+++ b/Mac/Base.lproj/Preferences.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="mPU-HG-I4u">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="mPU-HG-I4u">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -138,18 +139,7 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
-                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.JustinMillerHideDockUnreadCount" id="J0i-eh-Rqq">
-                                                <dictionary key="options">
-                                                    <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                    <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                    <integer key="NSMultipleValuesPlaceholder" value="1"/>
-                                                    <integer key="NSNoSelectionPlaceholder" value="1"/>
-                                                    <integer key="NSNotApplicablePlaceholder" value="1"/>
-                                                    <integer key="NSNullPlaceholder" value="1"/>
-                                                    <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                                </dictionary>
-                                            </binding>
+                                            <action selector="toggleShowingUnreadCount:" target="iuH-lz-18x" id="CfQ-Pv-9d2"/>
                                         </connections>
                                     </button>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="j0t-Wa-UTL">
@@ -198,6 +188,7 @@
                     </view>
                     <connections>
                         <outlet property="defaultBrowserPopup" destination="Ci4-fW-KjU" id="7Nh-nU-Sbc"/>
+                        <outlet property="showUnreadCountCheckbox" destination="mwT-nY-TrX" id="ZH9-P5-JkT"/>
                     </connections>
                 </viewController>
                 <customObject id="bSQ-tq-wd3" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -383,16 +374,16 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="7UM-iq-OLB" customClass="PreferencesTableViewBackgroundView" customModule="NetNewsWire" customModuleProvider="target">
-                                <rect key="frame" x="20" y="44" width="160" height="219"/>
+                                <rect key="frame" x="20" y="44" width="160" height="234"/>
                                 <subviews>
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="PaF-du-r3c">
-                                        <rect key="frame" x="1" y="0.0" width="158" height="218"/>
+                                        <rect key="frame" x="1" y="0.0" width="158" height="233"/>
                                         <clipView key="contentView" id="cil-Gq-akO">
-                                            <rect key="frame" x="0.0" y="0.0" width="158" height="218"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="158" height="233"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" viewBased="YES" id="aTp-KR-y6b">
-                                                    <rect key="frame" x="0.0" y="0.0" width="159" height="218"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="188" height="233"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -411,7 +402,7 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="Cell" id="h2e-5a-qNO">
-                                                                    <rect key="frame" x="1" y="1" width="156" height="17"/>
+                                                                    <rect key="frame" x="11" y="1" width="165" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
                                                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="27f-p8-Wnt">
@@ -423,7 +414,7 @@
                                                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="lKA-xK-bHU"/>
                                                                         </imageView>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hR2-bm-0wE">
-                                                                            <rect key="frame" x="26" y="1" width="126" height="16"/>
+                                                                            <rect key="frame" x="26" y="1" width="135" height="16"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="CcS-BO-sdv">
                                                                                 <font key="font" metaFont="system"/>
                                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -499,7 +490,7 @@
                                 <rect key="frame" x="83" y="20" width="97" height="24"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="Y7D-xQ-wep">
-                                <rect key="frame" x="188" y="20" width="242" height="243"/>
+                                <rect key="frame" x="188" y="20" width="242" height="258"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -554,16 +545,16 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="pjs-G4-byk" customClass="PreferencesTableViewBackgroundView" customModule="NetNewsWire" customModuleProvider="target">
-                                <rect key="frame" x="20" y="44" width="160" height="212"/>
+                                <rect key="frame" x="20" y="44" width="160" height="227"/>
                                 <subviews>
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" hasHorizontalScroller="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="29T-r2-ckC">
-                                        <rect key="frame" x="1" y="0.0" width="158" height="211"/>
+                                        <rect key="frame" x="1" y="0.0" width="158" height="226"/>
                                         <clipView key="contentView" id="dXw-GY-TP8">
-                                            <rect key="frame" x="0.0" y="0.0" width="158" height="211"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="158" height="226"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" viewBased="YES" id="dfn-Vn-oDp">
-                                                    <rect key="frame" x="0.0" y="0.0" width="159" height="211"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="188" height="226"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -582,7 +573,7 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="Cell" id="xQs-6E-Kpy">
-                                                                    <rect key="frame" x="1" y="1" width="156" height="17"/>
+                                                                    <rect key="frame" x="11" y="1" width="165" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
                                                                         <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kmG-vw-CbN">
@@ -594,7 +585,7 @@
                                                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="OVD-Jo-TXU"/>
                                                                         </imageView>
                                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6cr-cB-qAN">
-                                                                            <rect key="frame" x="26" y="1" width="126" height="16"/>
+                                                                            <rect key="frame" x="26" y="1" width="135" height="16"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="goO-QG-kk7">
                                                                                 <font key="font" metaFont="system"/>
                                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -666,7 +657,7 @@
                                 <rect key="frame" x="83" y="20" width="97" height="24"/>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="N1N-pE-gBL">
-                                <rect key="frame" x="188" y="20" width="242" height="236"/>
+                                <rect key="frame" x="188" y="20" width="242" height="251"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -701,8 +692,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="NSActionTemplate" width="14" height="14"/>
-        <image name="NSAddTemplate" width="11" height="11"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="NSActionTemplate" width="15" height="15"/>
+        <image name="NSAddTemplate" width="14" height="13"/>
+        <image name="NSRemoveTemplate" width="14" height="4"/>
     </resources>
 </document>

--- a/Mac/Preferences/General/GeneralPrefencesViewController.swift
+++ b/Mac/Preferences/General/GeneralPrefencesViewController.swift
@@ -13,7 +13,8 @@ import RSWeb
 final class GeneralPreferencesViewController: NSViewController {
 
 	@IBOutlet var defaultBrowserPopup: NSPopUpButton!
-
+    @IBOutlet weak var showUnreadCountCheckbox: NSButton!
+    
 	public override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
 		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 		commonInit()
@@ -45,6 +46,12 @@ final class GeneralPreferencesViewController: NSViewController {
 		AppDefaults.shared.defaultBrowserID = bundleID
 		updateUI()
 	}
+
+    
+    @IBAction func toggleShowingUnreadCount(_ sender: Any) {
+        guard let checkbox = sender as? NSButton else { return }
+        AppDefaults.shared.hideDockUnreadCount = checkbox.state.rawValue == 0
+    }
 }
 
 // MARK: - Private
@@ -57,6 +64,7 @@ private extension GeneralPreferencesViewController {
 
 	func updateUI() {
 		updateBrowserPopup()
+        updateHideUnreadCountCheckbox()
 	}
 
 	func updateBrowserPopup() {
@@ -89,4 +97,8 @@ private extension GeneralPreferencesViewController {
 
 		defaultBrowserPopup.selectItem(at: defaultBrowserPopup.indexOfItem(withRepresentedObject: AppDefaults.shared.defaultBrowserID))
 	}
+
+    func updateHideUnreadCountCheckbox() {
+        showUnreadCountCheckbox.state = AppDefaults.shared.hideDockUnreadCount ? .off : .on
+    }
 }


### PR DESCRIPTION
This PR closes #2390.

It removes the binding from the GeneralPreferencesViewController in favour of an IBOutlet (`showUnreadCountCheckbox`) and IBAction (`toggleShowingUnreadCount()`).

The rest of the work replicates what was done in WebFeedInspectorViewController in #2315 — when the user toggles the checkbox in the General preferences pane, we check to see if Notifications are authorized, and take action accordingly:

- if `.authorized`, toggle the checkbox and update the user default `JustinMillerHideDockUnreadCount` to show/hide the unread-count badge on the dock icon
- if `.denied`, discard the change to the UI and prompt the user to allow Notifications in an alert, including a button to take them to the correct System Preferences pane.
- if neither, we re-prompt the user to allow notifications.

## How to test this PR

- [ ] Launch NNW with Notifications enabled, open Preferences, and toggle the unread-count checkbox. You should see your dock icon's badge appear and disappear in relation to the state of the checkbox.
- [ ] Launch NNW with Notifications disabled, open Preferences, and toggle the unread-count checkbox. You should get an alert about needing to enable Notifications.
- [ ] Launch NNW, then go to System Preferences > Notifications, select NetNewsWire from the list, and press Delete on your keyboard to remove it. Go back to NNW, open Preferences, and toggle the unread-count checkbox. You should get a notification to allow Notifications for NNW.