### PR TITLE
Fix sidebar table column width

### DIFF
--- a/Mac/Base.lproj/MainWindow.storyboard
+++ b/Mac/Base.lproj/MainWindow.storyboard
@@ -315,7 +315,7 @@
                                             <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="208" minWidth="23" maxWidth="1000" id="ih9-mJ-EA7">
+                                                <tableColumn width="237" minWidth="23" maxWidth="1000" id="ih9-mJ-EA7">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
The sidebar's table column got sized to small again somehow, so it wasn't taking up the full table width on resize (at least on my 10.15 machine). This fixes that.