### PR TITLE
Set window title based on type of Inspector being shown

### DIFF
--- a/Mac/Inspector/BuiltinSmartFeedInspectorViewController.swift
+++ b/Mac/Inspector/BuiltinSmartFeedInspectorViewController.swift
@@ -26,6 +26,7 @@ final class BuiltinSmartFeedInspectorViewController: NSViewController, Inspector
 			updateSmartFeed()
 		}
 	}
+	var windowTitle: String = NSLocalizedString("Smart Feed Inspector", comment: "Smart Feed Inspector window title")
 
 	func canInspect(_ objects: [Any]) -> Bool {
 

--- a/Mac/Inspector/BuiltinSmartFeedInspectorViewController.swift
+++ b/Mac/Inspector/BuiltinSmartFeedInspectorViewController.swift
@@ -63,5 +63,6 @@ private extension BuiltinSmartFeedInspectorViewController {
 	func updateUI() {
 
 		nameTextField?.stringValue = smartFeed?.nameForDisplay ?? ""
+		windowTitle = smartFeed?.nameForDisplay ?? NSLocalizedString("Smart Feed Inspector", comment: "Smart Feed Inspector window title")
 	}
 }

--- a/Mac/Inspector/FolderInspectorViewController.swift
+++ b/Mac/Inspector/FolderInspectorViewController.swift
@@ -104,5 +104,6 @@ private extension FolderInspectorViewController {
 		if nameTextField.stringValue != name {
 			nameTextField.stringValue = name
 		}
+		windowTitle = folder?.nameForDisplay ?? NSLocalizedString("Folder Inspector", comment: "Folder Inspector window title")
 	}
 }

--- a/Mac/Inspector/FolderInspectorViewController.swift
+++ b/Mac/Inspector/FolderInspectorViewController.swift
@@ -30,6 +30,7 @@ final class FolderInspectorViewController: NSViewController, Inspector {
 			updateFolder()
 		}
 	}
+	var windowTitle: String = NSLocalizedString("Folder Inspector", comment: "Folder Inspector window title")
 
 	func canInspect(_ objects: [Any]) -> Bool {
 

--- a/Mac/Inspector/InspectorWindowController.swift
+++ b/Mac/Inspector/InspectorWindowController.swift
@@ -111,7 +111,9 @@ private extension InspectorWindowController {
 			return
 		}
 
-		window.title = inspector.windowTitle
+		DispatchQueue.main.async {
+			window.title = inspector.windowTitle
+		}	
 
 		let flippedOrigin = window.flippedOrigin
 

--- a/Mac/Inspector/InspectorWindowController.swift
+++ b/Mac/Inspector/InspectorWindowController.swift
@@ -108,7 +108,32 @@ private extension InspectorWindowController {
 		guard let window = window else {
 			return
 		}
-		
+
+		switch inspector {
+		case is NothingInspectorViewController:
+			window.title = NSLocalizedString("Inspector", comment: "Inspector window title")
+		case is FolderInspectorViewController:
+			if let folderName = (inspector as? FolderInspectorViewController)?.nameTextField?.stringValue {
+				window.title = folderName
+			} else {
+				window.title = NSLocalizedString("Folder Inspector", comment: "Folder Inspector window title")
+			}
+		case is WebFeedInspectorViewController:
+			if let feedName = (inspector as? WebFeedInspectorViewController)?.nameTextField?.stringValue {
+				window.title = feedName
+			} else {
+				window.title = NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
+			}
+		case is BuiltinSmartFeedInspectorViewController:
+			if let smartFeedName = (inspector as? BuiltinSmartFeedInspectorViewController)?.nameTextField?.stringValue {
+				window.title = smartFeedName
+			} else {
+				window.title = NSLocalizedString("Smart Feed Inspector", comment: "Smart Feed Inspector window title")
+			}
+		default:
+			window.title = NSLocalizedString("Inspector", comment: "Inspector window title")
+		}
+
 		let flippedOrigin = window.flippedOrigin
 
 		if window.contentViewController != inspector {

--- a/Mac/Inspector/InspectorWindowController.swift
+++ b/Mac/Inspector/InspectorWindowController.swift
@@ -12,6 +12,7 @@ protocol Inspector: class {
 
 	var objects: [Any]? { get set }
 	var isFallbackInspector: Bool { get } // Can handle nothing-to-inspect or unexpected type of objects.
+	var windowTitle: String { get }
 
 	func canInspect(_ objects: [Any]) -> Bool
 }
@@ -62,6 +63,7 @@ final class InspectorWindowController: NSWindowController {
 
 		inspectors = [feedInspector, folderInspector, builtinSmartFeedInspector, nothingInspector]
 		currentInspector = nothingInspector
+		window?.title = currentInspector.windowTitle
 
 		if let savedOrigin = originFromDefaults() {
 			window?.setFlippedOriginAdjustingForScreen(savedOrigin)
@@ -109,30 +111,7 @@ private extension InspectorWindowController {
 			return
 		}
 
-		switch inspector {
-		case is NothingInspectorViewController:
-			window.title = NSLocalizedString("Inspector", comment: "Inspector window title")
-		case is FolderInspectorViewController:
-			if let folderName = (inspector as? FolderInspectorViewController)?.nameTextField?.stringValue {
-				window.title = folderName
-			} else {
-				window.title = NSLocalizedString("Folder Inspector", comment: "Folder Inspector window title")
-			}
-		case is WebFeedInspectorViewController:
-			if let feedName = (inspector as? WebFeedInspectorViewController)?.nameTextField?.stringValue {
-				window.title = feedName
-			} else {
-				window.title = NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
-			}
-		case is BuiltinSmartFeedInspectorViewController:
-			if let smartFeedName = (inspector as? BuiltinSmartFeedInspectorViewController)?.nameTextField?.stringValue {
-				window.title = smartFeedName
-			} else {
-				window.title = NSLocalizedString("Smart Feed Inspector", comment: "Smart Feed Inspector window title")
-			}
-		default:
-			window.title = NSLocalizedString("Inspector", comment: "Inspector window title")
-		}
+		window.title = inspector.windowTitle
 
 		let flippedOrigin = window.flippedOrigin
 

--- a/Mac/Inspector/NothingInspectorViewController.swift
+++ b/Mac/Inspector/NothingInspectorViewController.swift
@@ -19,6 +19,7 @@ final class NothingInspectorViewController: NSViewController, Inspector {
 			updateTextFields()
 		}
 	}
+	var windowTitle: String = NSLocalizedString("Inspector", comment: "Inspector window title")
 
 	func canInspect(_ objects: [Any]) -> Bool {
 

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -134,7 +134,7 @@ private extension WebFeedInspectorViewController {
 		updateFeedURL()
 		updateNotifyAboutNewArticles()
 		updateIsReaderViewAlwaysOn()
-		
+		windowTitle = feed?.nameForDisplay ?? NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
 		view.needsLayout = true
 	}
 

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -38,6 +38,7 @@ final class WebFeedInspectorViewController: NSViewController, Inspector {
 			updateFeed()
 		}
 	}
+	var windowTitle: String = NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
 
 	func canInspect(_ objects: [Any]) -> Bool {
 		return objects.count == 1 && objects.first is WebFeed

--- a/Mac/Inspector/WebFeedInspectorViewController.swift
+++ b/Mac/Inspector/WebFeedInspectorViewController.swift
@@ -113,6 +113,7 @@ extension WebFeedInspectorViewController: NSTextFieldDelegate {
 			return
 		}
 		feed.editedName = nameTextField.stringValue
+		windowTitle = feed.editedName ?? NSLocalizedString("Feed Inspector", comment: "Feed Inspector window title")
 	}
 	
 }


### PR DESCRIPTION
This PR closes #2354.

Changes here add a `windowTitle` var to the Inspector class which InspectorWindowController can ask for, such that the following cases are true:

- A `NothingInspectorViewController` gets the window title "Inspector".
- A `FolderInspectorViewController`, `WebFeedInspectorViewController`, or `BuiltinSmartFeedInspectorViewController` set the window title according to the name of the folder, feed, or smart feed, or a generally-descriptive title like "Folder Inspector", "Feed Inspector", or "Smart Feed Inspector" if the name can't be found.

Probably worth verifying:

- [ ] Clicking on a feed, folder, or smartfeed while the inspector is open changes the inspector's window title as expected
- [ ] Closing the inspector, clicking on another sidebar item, and then opening the inspector shows the correct window title.
- [ ] Opening the inspector and changing the name of the sidebar item (where possible) updates the inspector window's title.

👆 "Works on my machine" but please let me know if it doesn't for you!

---

_This PR replaces #2396._