### PR TITLE
Clarify the UX of authorizing a Feedly account by directing users…

### DIFF
--- a/Frameworks/Account/Feedly/OAuthAccountAuthorizationOperation.swift
+++ b/Frameworks/Account/Feedly/OAuthAccountAuthorizationOperation.swift
@@ -64,10 +64,26 @@ public protocol OAuthAccountAuthorizationOperationDelegate: class {
 				self?.didEndAuthentication(url: url, error: error)
 			}
 		}
-		self.session = session
+		
 		session.presentationContextProvider = self
 		
-		session.start()
+		guard session.start() else {
+			
+			/// Documentation does not say on why `ASWebAuthenticationSession.start` or `canStart` might return false.
+			/// Perhaps it has something to do with an inter-process communication failure? No browsers installed? No browsers that support web authentication?
+			struct UnableToStartASWebAuthenticationSessionError: LocalizedError {
+				let errorDescription: String? = NSLocalizedString("Unable to start a web authentication session with the default web browser.",
+																  comment: "OAuth - error description - unable to authorize because ASWebAuthenticationSession did not start.")
+				let recoverySuggestion: String? = NSLocalizedString("Check your default web browser in System Preferences or change it to Safari and try again.",
+																	comment: "OAuth - recovery suggestion - ensure browser selected supports web authentication.")
+			}
+			
+			didFinish(UnableToStartASWebAuthenticationSessionError())
+			
+			return
+		}
+		
+		self.session = session
 	}
 	
 	public func cancel() {


### PR DESCRIPTION
…towards their default web browser #2444

Please check the `NSAlert` begin/end sheet dance. My AppKit is rusty.

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/567949/93966556-5758ec80-fda8-11ea-9b9e-4dfab729947d.png">
