### PR TITLE
Remove CSS rule that was interfering with Newsfoot styling

### DIFF
--- a/Mac/MainWindow/Detail/styleSheet.css
+++ b/Mac/MainWindow/Detail/styleSheet.css
@@ -24,7 +24,7 @@ body {
 	}
 }
 
-body a, body a:link, body a:visited {
+body a, body a:visited {
 	color: var(--accent-color);
 }
 

--- a/iOS/Resources/styleSheet.css
+++ b/iOS/Resources/styleSheet.css
@@ -27,7 +27,7 @@ body {
 	}
 }
 
-body a, body a:link, body a:visited {
+body a, body a:visited {
 	color: var(--secondary-accent-color);
 }
 body .header {


### PR DESCRIPTION
Cherry-pick from `main`.

Fixes #2425.