### PR TITLE
Feedly fixes

### DIFF
--- a/Mac/Preferences/Accounts/AccountsAddViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsAddViewController.swift
@@ -148,6 +148,12 @@ extension AccountsAddViewController: AccountsAddTableCellViewDelegate {
 extension AccountsAddViewController: OAuthAccountAuthorizationOperationDelegate {
 	
 	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didCreate account: Account) {
+		// `OAuthAccountAuthorizationOperation` is using `ASWebAuthenticationSession` which bounces the user
+		// to their browser on macOS for authorizing NetNewsWire to access the user's Feedly account.
+		// When this authorization is granted, the browser remains the foreground app which is unfortunate
+		// because the user probably wants to see the result of authorizing NetNewsWire to act on their behalf.
+		NSApp.activate(ignoringOtherApps: true)
+		
 		account.refreshAll { [weak self] result in
 			switch result {
 			case .success:
@@ -159,6 +165,10 @@ extension AccountsAddViewController: OAuthAccountAuthorizationOperationDelegate 
 	}
 	
 	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didFailWith error: Error) {
+		// `OAuthAccountAuthorizationOperation` is using `ASWebAuthenticationSession` which bounces the user
+		// to their browser on macOS for authorizing NetNewsWire to access the user's Feedly account.
+		NSApp.activate(ignoringOtherApps: true)
+		
 		view.window?.presentError(error)
 	}
 }

--- a/Multiplatform/macOS/Preferences/Preference Panes/Accounts/Account Preferences/Add Account/AddAccountModel.swift
+++ b/Multiplatform/macOS/Preferences/Preference Panes/Accounts/Account Preferences/Add Account/AddAccountModel.swift
@@ -277,8 +277,14 @@ extension AddAccountModel {
 // MARK:- OAuthAccountAuthorizationOperationDelegate
 extension AddAccountModel: OAuthAccountAuthorizationOperationDelegate {
 	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didCreate account: Account) {
+		
 		accountIsAuthenticating = false
 		accountAdded = true
+		
+		// macOS only: `ASWebAuthenticationSession` leaves the browser in the foreground.
+		// Ensure the app is in the foreground so the user can see their Feedly account load.
+		NSApplication.shared.activate(ignoringOtherApps: true)
+		
 		account.refreshAll { [weak self] result in
 			switch result {
 			case .success:
@@ -291,6 +297,11 @@ extension AddAccountModel: OAuthAccountAuthorizationOperationDelegate {
 	
 	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didFailWith error: Error) {
 		accountIsAuthenticating = false
+		
+		// macOS only: `ASWebAuthenticationSession` leaves the browser in the foreground.
+		// Ensure the app is in the foreground so the user can see the error.
+		NSApplication.shared.activate(ignoringOtherApps: true)
+		
 		addAccountError = .other(error: error)
 	}
 }


### PR DESCRIPTION
Contains changes in these PRs:
https://github.com/Ranchero-Software/NetNewsWire/pull/2450
https://github.com/Ranchero-Software/NetNewsWire/pull/2453

The former already in `mac-candidate` and the latter proposed for `mac-candidate` but they should be going into `mac-release`.