### PR TITLE
iOS: Encode the + in Feedly collection URIs. Fixes #2443.

### DIFF
--- a/Frameworks/Account/Feedly/FeedlyAPICaller.swift
+++ b/Frameworks/Account/Feedly/FeedlyAPICaller.swift
@@ -47,10 +47,15 @@ final class FeedlyAPICaller {
 	
 	private let transport: Transport
 	private let baseUrlComponents: URLComponents
+	private let uriComponentAllowed: CharacterSet
 	
 	init(transport: Transport, api: API) {
 		self.transport = transport
 		self.baseUrlComponents = api.baseUrlComponents
+		
+		var urlHostAllowed = CharacterSet.urlHostAllowed
+		urlHostAllowed.remove("+")
+		uriComponentAllowed = urlHostAllowed
 	}
 	
 	weak var delegate: FeedlyAPICallerDelegate?
@@ -271,7 +276,7 @@ final class FeedlyAPICaller {
 	}
 	
 	private func encodeForURLPath(_ pathComponent: String) -> String? {
-		return pathComponent.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
+		return pathComponent.addingPercentEncoding(withAllowedCharacters: uriComponentAllowed)
 	}
 	
 	func deleteCollection(with id: String, completion: @escaping (Result<Void, Error>) -> ()) {


### PR DESCRIPTION
This is the iOS PR, the macOS PR is https://github.com/Ranchero-Software/NetNewsWire/pull/2478