### PR TITLE
CSS fixes

### DIFF
--- a/Shared/Article Rendering/shared.css
+++ b/Shared/Article Rendering/shared.css
@@ -182,6 +182,9 @@ code, pre {
 	border: none;
 	padding: 0;
 }
+.nnw-overflow table[border="0"] {
+	border-width: 0;
+}
 
 img, figure, video, div, object {
 	max-width: 100%;

--- a/Shared/Article Rendering/shared.css
+++ b/Shared/Article Rendering/shared.css
@@ -52,7 +52,7 @@ a:hover {
 
 body {
 	color: var(--body-color);
-	background-color: var(--body-background-color);
+	background-color: var(--body-background-color) !important;
 }
 
 body .headerTable {


### PR DESCRIPTION
Make sure `table`s with `border="0"` have no border and force our `body` `background-color`.

Fixes #2489.