### PR TITLE
Support a new secret user default…

### DIFF
--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -323,13 +323,16 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 		NSCursor.setHiddenUntilMouseMoves(true)
 
 		// TODO: handle search mode
-		if timelineViewController.canGoToNextUnread() {
-			goToNextUnreadInTimeline()
+		if timelineViewController.canGoToNextUnread(wrappingToTop: false) {
+			goToNextUnreadInTimeline(wrappingToTop: false)
 		}
-		else if sidebarViewController.canGoToNextUnread() {
-			sidebarViewController.goToNextUnread()
-			if timelineViewController.canGoToNextUnread() {
-				goToNextUnreadInTimeline()
+		else if sidebarViewController.canGoToNextUnread(wrappingToTop: true) {
+			sidebarViewController.goToNextUnread(wrappingToTop: true)
+
+			// If we ended up on the same timelineViewController, we may need to wrap
+			// around to the top of its contents.
+			if timelineViewController.canGoToNextUnread(wrappingToTop: true) {
+				goToNextUnreadInTimeline(wrappingToTop: true)
 			}
 		}
 	}
@@ -995,13 +998,13 @@ private extension MainWindowController {
 
 	// MARK: - Command Validation
 
-	func canGoToNextUnread() -> Bool {
+	func canGoToNextUnread(wrappingToTop wrapping: Bool = false) -> Bool {
 		
 		guard let timelineViewController = currentTimelineViewController, let sidebarViewController = sidebarViewController else {
 			return false
 		}
 		// TODO: handle search mode
-		return timelineViewController.canGoToNextUnread() || sidebarViewController.canGoToNextUnread()
+		return timelineViewController.canGoToNextUnread(wrappingToTop: wrapping) || sidebarViewController.canGoToNextUnread(wrappingToTop: wrapping)
 	}
 	
 	func canMarkAllAsRead() -> Bool {
@@ -1188,14 +1191,14 @@ private extension MainWindowController {
 
 	// MARK: - Misc.
 
-	func goToNextUnreadInTimeline() {
+	func goToNextUnreadInTimeline(wrappingToTop wrapping: Bool) {
 
 		guard let timelineViewController = currentTimelineViewController else {
 			return
 		}
 
-		if timelineViewController.canGoToNextUnread() {
-			timelineViewController.goToNextUnread()
+		if timelineViewController.canGoToNextUnread(wrappingToTop: wrapping) {
+			timelineViewController.goToNextUnread(wrappingToTop: wrapping)
 			makeTimelineViewFirstResponder()
 		}
 	}

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -549,7 +549,7 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 		tableView.scrollTo(row: ix)
 	}
 	
-	func goToNextUnread() {
+	func goToNextUnread(wrappingToTop wrapping: Bool = false) {
 		guard let ix = indexOfNextUnreadArticle() else {
 			return
 		}
@@ -558,15 +558,15 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 		tableView.scrollTo(row: ix)
 	}
 	
-	func canGoToNextUnread() -> Bool {
-		guard let _ = indexOfNextUnreadArticle() else {
+	func canGoToNextUnread(wrappingToTop wrapping: Bool = false) -> Bool {
+		guard let _ = indexOfNextUnreadArticle(wrappingToTop: wrapping) else {
 			return false
 		}
 		return true
 	}
 	
-	func indexOfNextUnreadArticle() -> Int? {
-		return articles.rowOfNextUnreadArticle(tableView.selectedRow)
+	func indexOfNextUnreadArticle(wrappingToTop wrapping: Bool = false) -> Int? {
+		return articles.rowOfNextUnreadArticle(tableView.selectedRow, wrappingToTop: wrapping)
 	}
 
 	func focus() {

--- a/Shared/Timeline/ArticleArray.swift
+++ b/Shared/Timeline/ArticleArray.swift
@@ -20,18 +20,21 @@ extension Array where Element == Article {
 		return self[row]
 	}
 
-	func rowOfNextUnreadArticle(_ selectedRow: Int) -> Int? {
+	func orderedRowIndexes(fromIndex startIndex: Int, wrappingToTop wrapping: Bool) -> [Int] {
+		if startIndex >= self.count {
+			// Wrap around to the top if specified
+			return wrapping ? Array<Int>(0..<self.count) : []
+		} else {
+			// Start at the selection and wrap around to the beginning
+			return Array<Int>(startIndex..<self.count) + (wrapping ? Array<Int>(0..<startIndex) : [])
+		}
+	}
+	func rowOfNextUnreadArticle(_ selectedRow: Int, wrappingToTop wrapping: Bool) -> Int? {
 		if isEmpty {
 			return nil
 		}
 
-		var rowIndex = selectedRow
-		while(true) {
-
-			rowIndex = rowIndex + 1
-			if rowIndex >= count {
-				break
-			}
+		for rowIndex in orderedRowIndexes(fromIndex: selectedRow + 1, wrappingToTop: wrapping) {
 			let article = articleAtRow(rowIndex)!
 			if !article.status.read {
 				return rowIndex


### PR DESCRIPTION
Support a new user default "JalkutRespectFolderExpansionOnNextUnread" to support skipping over folder items in favor of their expanded children, when advancing to the next unread item. Also revise the "next unread" strategy so that whether the search for a next unread wraps around to the top or not is parameterized.