### PR TITLE
Explainer text for accounts and extensions

### DIFF
--- a/Mac/Preferences/Accounts/AccountsPreferencesViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsPreferencesViewController.swift
@@ -226,7 +226,7 @@ private extension AccountsPreferencesViewController {
 	
 	func showController(_ controller: NSViewController) {
 		hideController()
-		
+	
 		addChild(controller)
 		controller.view.translatesAutoresizingMaskIntoConstraints = false
 		detailView.addSubview(controller.view)
@@ -238,6 +238,21 @@ private extension AccountsPreferencesViewController {
 		if let controller = children.first {
 			children.removeAll()
 			controller.view.removeFromSuperview()
+		}
+		
+		if tableView.selectedRow == -1 {
+			var helpText = ""
+			if sortedAccounts.count == 0 {
+				helpText = NSLocalizedString("Add an account by clicking the + button.", comment: "Add Account Explainer")
+			} else {
+				helpText = NSLocalizedString("Select an account or add a new account by clicking the + button.", comment: "Add Account Explainer")
+			}
+			
+			let textHostingController = NSHostingController(rootView: Text(helpText).multilineTextAlignment(.center))
+			addChild(textHostingController)
+			textHostingController.view.translatesAutoresizingMaskIntoConstraints = false
+			detailView.addSubview(textHostingController.view)
+			detailView.addFullSizeConstraints(forSubview: textHostingController.view)
 		}
 	}
 	

--- a/Mac/Preferences/Accounts/AccountsPreferencesViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsPreferencesViewController.swift
@@ -231,7 +231,6 @@ private extension AccountsPreferencesViewController {
 		controller.view.translatesAutoresizingMaskIntoConstraints = false
 		detailView.addSubview(controller.view)
 		detailView.addFullSizeConstraints(forSubview: controller.view)
-		
 	}
 	
 	func hideController() {
@@ -252,7 +251,12 @@ private extension AccountsPreferencesViewController {
 			addChild(textHostingController)
 			textHostingController.view.translatesAutoresizingMaskIntoConstraints = false
 			detailView.addSubview(textHostingController.view)
-			detailView.addFullSizeConstraints(forSubview: textHostingController.view)
+			detailView.addConstraints([
+										NSLayoutConstraint(item: textHostingController.view, attribute: .top, relatedBy: .equal, toItem: detailView, attribute: .top, multiplier: 1, constant: 1),
+										NSLayoutConstraint(item: textHostingController.view, attribute: .bottom, relatedBy: .equal, toItem: detailView, attribute: .bottom, multiplier: 1, constant: -deleteButton.frame.height),
+				NSLayoutConstraint(item: textHostingController.view, attribute: .width, relatedBy: .equal, toItem: detailView, attribute: .width, multiplier: 1, constant: 1)
+			])
+			
 		}
 	}
 	

--- a/Mac/Preferences/ExtensionPoints/ExtensionPointPreferencesViewController.swift
+++ b/Mac/Preferences/ExtensionPoints/ExtensionPointPreferencesViewController.swift
@@ -179,6 +179,21 @@ private extension ExtensionPointPreferencesViewController {
 	func showDefaultView() {
 		activeExtensionPoints = Array(ExtensionPointManager.shared.activeExtensionPoints.values).sorted(by: { $0.title < $1.title })
 		tableView.reloadData()
+		
+		if tableView.selectedRow == -1 {
+			var helpText = ""
+			if activeExtensionPoints.count == 0 {
+				helpText = NSLocalizedString("Add an extension point by clicking the + button.", comment: "Extension Explainer")
+			} else {
+				helpText = NSLocalizedString("Select an extension point or add a new extension point by clicking the + button.", comment: "Extension Explainer")
+			}
+			
+			let textHostingController = NSHostingController(rootView: Text(helpText).multilineTextAlignment(.center))
+			addChild(textHostingController)
+			textHostingController.view.translatesAutoresizingMaskIntoConstraints = false
+			detailView.addSubview(textHostingController.view)
+			detailView.addFullSizeConstraints(forSubview: textHostingController.view)
+		}
 	}
 	
 	func showController(_ controller: NSViewController) {
@@ -194,6 +209,21 @@ private extension ExtensionPointPreferencesViewController {
 		if let controller = children.first {
 			children.removeAll()
 			controller.view.removeFromSuperview()
+		}
+		
+		if tableView.selectedRow == -1 {
+			var helpText = ""
+			if activeExtensionPoints.count == 0 {
+				helpText = NSLocalizedString("Add an extension point by clicking the + button.", comment: "Extension Explainer")
+			} else {
+				helpText = NSLocalizedString("Select an extension point or add a new extension point by clicking the + button.", comment: "Extension Explainer")
+			}
+			
+			let textHostingController = NSHostingController(rootView: Text(helpText).multilineTextAlignment(.center))
+			addChild(textHostingController)
+			textHostingController.view.translatesAutoresizingMaskIntoConstraints = false
+			detailView.addSubview(textHostingController.view)
+			detailView.addFullSizeConstraints(forSubview: textHostingController.view)
 		}
 	}
 

--- a/Mac/Preferences/ExtensionPoints/ExtensionPointPreferencesViewController.swift
+++ b/Mac/Preferences/ExtensionPoints/ExtensionPointPreferencesViewController.swift
@@ -192,7 +192,11 @@ private extension ExtensionPointPreferencesViewController {
 			addChild(textHostingController)
 			textHostingController.view.translatesAutoresizingMaskIntoConstraints = false
 			detailView.addSubview(textHostingController.view)
-			detailView.addFullSizeConstraints(forSubview: textHostingController.view)
+			detailView.addConstraints([
+										NSLayoutConstraint(item: textHostingController.view, attribute: .top, relatedBy: .equal, toItem: detailView, attribute: .top, multiplier: 1, constant: 1),
+										NSLayoutConstraint(item: textHostingController.view, attribute: .bottom, relatedBy: .equal, toItem: detailView, attribute: .bottom, multiplier: 1, constant: -deleteButton.frame.height),
+				NSLayoutConstraint(item: textHostingController.view, attribute: .width, relatedBy: .equal, toItem: detailView, attribute: .width, multiplier: 1, constant: 1)
+			])
 		}
 	}
 	


### PR DESCRIPTION
Explainer text will display when no account/extension is selected.

<img width="624" alt="Screenshot 2020-11-02 at 11 06 16 AM" src="https://user-images.githubusercontent.com/7046652/97826186-e63c1b80-1cfb-11eb-9ba8-85ffbff4d2c8.png">
<img width="624" alt="Screenshot 2020-11-02 at 11 06 21 AM" src="https://user-images.githubusercontent.com/7046652/97826196-ea683900-1cfb-11eb-8a39-b33ce62a8808.png">
