### PR TITLE
NewsBlur: Fix renaming feed/folder not working with plus sign in name

### DIFF
--- a/Account/Sources/Account/NewsBlur/Models/NewsBlurFeedChange.swift
+++ b/Account/Sources/Account/NewsBlur/Models/NewsBlurFeedChange.swift
@@ -44,6 +44,10 @@ extension NewsBlurFeedChange: NewsBlurDataConvertible {
 			}
 		}()
 
-		return postData.percentEncodedQuery?.data(using: .utf8)
+		// `+` is a valid character in query component as per RFC 3986 (https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems)
+		// workaround:
+		// - http://www.openradar.me/24076063
+		// - https://stackoverflow.com/a/37314144
+		return postData.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B").replacingOccurrences(of: "%20", with: "+").data(using: .utf8)
 	}
 }

--- a/Account/Sources/Account/NewsBlur/Models/NewsBlurFolderChange.swift
+++ b/Account/Sources/Account/NewsBlur/Models/NewsBlurFolderChange.swift
@@ -42,6 +42,10 @@ extension NewsBlurFolderChange: NewsBlurDataConvertible {
 			}
 		}()
 
-		return postData.percentEncodedQuery?.data(using: .utf8)
+		// `+` is a valid character in query component as per RFC 3986 (https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems)
+		// workaround:
+		// - http://www.openradar.me/24076063
+		// - https://stackoverflow.com/a/37314144
+		return postData.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B").replacingOccurrences(of: "%20", with: "+").data(using: .utf8)
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Ranchero-Software/NetNewsWire/issues/2542

The bug was caused by `+` not being properly handled. 

From https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems:

> RFC 3986 specifies which characters must be percent-encoded in the query component of a URL, but not how those characters should be interpreted.

> One notable example of potential interoperability problems is how the plus sign (+) character is handled:

> According to RFC 3986, the plus sign is a valid character within a query, and doesn't need to be percent-encoded. However, according to the W3C recommendations for URI addressing, the plus sign is reserved as shorthand notation for a space within a query string (for example, ?greeting=hello+world).