### PR TITLE
Handle +’s in the query items

### DIFF
--- a/Account/Sources/Account/FeedWrangler/FeedWranglerAPICaller.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerAPICaller.swift
@@ -111,13 +111,17 @@ final class FeedWranglerAPICaller: NSObject {
 	}
 	
 	func renameSubscription(feedID: String, newName: String, completion: @escaping (Result<Void, Error>) -> Void) {
-		let url = FeedWranglerConfig.clientURL
-			.appendingPathComponent("subscriptions/rename_feed")
-			.appendingQueryItems([
-				URLQueryItem(name: "feed_id", value: feedID),
-				URLQueryItem(name: "feed_name", value: newName),
-			])
-		
+        var postData = URLComponents(url: FeedWranglerConfig.clientURL, resolvingAgainstBaseURL: false)
+        postData?.path += "subscriptions/rename_feed"
+        postData?.queryItems = [
+            URLQueryItem(name: "feed_id", value: feedID),
+            URLQueryItem(name: "feed_name", value: newName),
+        ]
+        
+        guard let url = postData?.urlWithEnhancedPercentEncodedQuery else {
+            fatalError() // something has gone terribly wrong
+        }
+        
 		standardSend(url: url, resultType: FeedWranglerSubscriptionsRequest.self) { result in
 			switch result {
 			case .success:
@@ -289,4 +293,17 @@ final class FeedWranglerAPICaller: NSObject {
 		transport.send(request: request, resultType: resultType, completion: completion)
 	}
 
+}
+
+private extension URLComponents {
+    
+    var urlWithEnhancedPercentEncodedQuery: URL? {
+        guard let tempQueryItems = self.queryItems, !tempQueryItems.isEmpty else {
+            return self.url
+        }
+        
+        var tempComponents = self
+        tempComponents.percentEncodedQuery = self.enhancedPercentEncodedQuery
+        return tempComponents.url
+    }
 }

--- a/Account/Sources/Account/FeedWrangler/FeedWranglerAPICaller.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerAPICaller.swift
@@ -119,7 +119,8 @@ final class FeedWranglerAPICaller: NSObject {
         ]
         
         guard let url = postData?.urlWithEnhancedPercentEncodedQuery else {
-            fatalError() // something has gone terribly wrong
+            completion(.failure(FeedWranglerError.general(message: "Could not encode name")))
+            return
         }
         
 		standardSend(url: url, resultType: FeedWranglerSubscriptionsRequest.self) { result in


### PR DESCRIPTION
It looks like the FeedWrangler service doesn't handle the %2B correctly, which I've emailed them about, but this update at least has us creating the correct URL for the request.

This private extension might be worth moving into RSWeb.

Fixes #2544