### PR TITLE
Widget improvements — iOS

### DIFF
--- a/Widget/TimelineProvider.swift
+++ b/Widget/TimelineProvider.swift
@@ -12,14 +12,23 @@ import SwiftUI
 struct Provider: TimelineProvider {
 	
 	func placeholder(in context: Context) -> WidgetTimelineEntry {
-		WidgetTimelineEntry(date: Date(), widgetData: WidgetDataDecoder.sampleData())
+		do {
+			let data = try WidgetDataDecoder.decodeWidgetData()
+			return WidgetTimelineEntry(date: Date(), widgetData: data)
+		} catch {
+			return WidgetTimelineEntry(date: Date(), widgetData: WidgetDataDecoder.sampleData())
+		}
 	}
 	
 	func getSnapshot(in context: Context, completion: @escaping (WidgetTimelineEntry) -> Void) {
 		if context.isPreview {
-			let entry = WidgetTimelineEntry(date: Date(),
-											widgetData: WidgetDataDecoder.sampleData())
-			completion(entry)
+			do {
+				let data = try WidgetDataDecoder.decodeWidgetData()
+				completion(WidgetTimelineEntry(date: Date(), widgetData: data))
+			} catch {
+				completion(WidgetTimelineEntry(date: Date(),
+											   widgetData: WidgetDataDecoder.sampleData()))
+			}
 		} else {
 			do {
 				let widgetData = try WidgetDataDecoder.decodeWidgetData()
@@ -27,7 +36,7 @@ struct Provider: TimelineProvider {
 				completion(entry)
 			} catch {
 				let entry = WidgetTimelineEntry(date: Date(),
-												widgetData: WidgetData(currentUnreadCount: 41, currentTodayCount: 40, currentStarredCount: 12, unreadArticles: [], starredArticles: [], todayArticles: [], lastUpdateTime: Date()) )
+												widgetData: WidgetDataDecoder.sampleData())
 				completion(entry)
 			}
 		}


### PR DESCRIPTION
• Widget previews will now use data from the parent app instead of the sample data in the bundle, if available. Otherwise, the preview falls back to the sample file.
• Additional logging.
• Removes unused task identifier. 