### PR TITLE
Widget layout fix

### DIFF
--- a/Shared/Widget/WidgetDataEncoder.swift
+++ b/Shared/Widget/WidgetDataEncoder.swift
@@ -16,8 +16,10 @@ import Articles
 @available(iOS 14, *)
 struct WidgetDataEncoder {
 	
+	private static var log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "Application")
+	
 	static func encodeWidgetData() {
-		os_log(.debug, "Starting encoding widget data.")
+		os_log(.debug, log: log, "Starting encoding widget data.")
 		do {
 			// Unread Articles
 			let unreadArticles = try SmartFeedsController.shared.unreadFeed.fetchArticles().sorted(by: { $0.datePublished ?? .distantPast > $1.datePublished ?? .distantPast  })
@@ -70,16 +72,16 @@ struct WidgetDataEncoder {
 										lastUpdateTime: Date())
 			
 			let encodedData = try JSONEncoder().encode(latestData)
-			os_log(.debug, "Finished encoding widget data.")
+			os_log(.debug, log: log, "Finished encoding widget data.")
 			let appGroup = Bundle.main.object(forInfoDictionaryKey: "AppGroup") as! String
 			let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup)
 			let dataURL = containerURL?.appendingPathComponent("widget-data.json")
 			if FileManager.default.fileExists(atPath: dataURL!.path) {
 				try FileManager.default.removeItem(at: dataURL!)
-				os_log(.debug, "Removed widget data from container.")
+				os_log(.debug, log: log, "Removed widget data from container.")
 			}
 			if FileManager.default.createFile(atPath: dataURL!.path, contents: encodedData, attributes: nil) {
-				os_log(.debug, "Wrote widget data to container.")
+				os_log(.debug, log: log, "Wrote widget data to container.")
 				WidgetCenter.shared.reloadAllTimelines()
 			}
 		} catch {

--- a/Shared/Widget/WidgetDataEncoder.swift
+++ b/Shared/Widget/WidgetDataEncoder.swift
@@ -32,7 +32,7 @@ struct WidgetDataEncoder {
 												  feedIcon: article.iconImage()?.image.dataRepresentation(),
 												  pubDate: article.datePublished!.description)
 				unread.append(latestArticle)
-				if unread.count == 8 { break }
+				if unread.count == 7 { break }
 			}
 			
 			// Starred Articles
@@ -46,7 +46,7 @@ struct WidgetDataEncoder {
 												  feedIcon: article.iconImage()?.image.dataRepresentation(),
 												  pubDate: article.datePublished!.description)
 				starred.append(latestArticle)
-				if starred.count == 8 { break }
+				if starred.count == 7 { break }
 			}
 			
 			// Today Articles
@@ -60,7 +60,7 @@ struct WidgetDataEncoder {
 												  feedIcon: article.iconImage()?.image.dataRepresentation(),
 												  pubDate: article.datePublished!.description)
 				today.append(latestArticle)
-				if today.count == 8 { break }
+				if today.count == 7 { break }
 			}
 			
 			let latestData = WidgetData(currentUnreadCount: SmartFeedsController.shared.unreadFeed.unreadCount,

--- a/Widget/Widget Views/StarredWidget.swift
+++ b/Widget/Widget Views/StarredWidget.swift
@@ -25,7 +25,7 @@ struct StarredWidgetView : View {
 					VStack(alignment: .leading) {
 						starredImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentStarredCount)).bold().font(Font.system(.footnote, design: .rounded))
+						Text(L10n.localizedCount(entry.widgetData.currentStarredCount)).bold().font(Font.system(.footnote, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.starred.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)
@@ -37,7 +37,8 @@ struct StarredWidgetView : View {
 								Divider()
 								ArticleItemView(article: entry.widgetData.starredArticles[i],
 												deepLink: WidgetDeepLink.starredArticle(id: entry.widgetData.starredArticles[i].id).url)
-									.padding(.vertical, 6)
+									.padding(.top, 8)
+									.padding(.bottom, 4)
 							} else {
 								ArticleItemView(article: entry.widgetData.starredArticles[i],
 												deepLink: WidgetDeepLink.starredArticle(id: entry.widgetData.starredArticles[i].id).url)
@@ -70,7 +71,7 @@ struct StarredWidgetView : View {
 	
 	func maxCount() -> Int {
 		if family == .systemLarge {
-			return entry.widgetData.currentStarredCount > 8 ? 8 : entry.widgetData.currentStarredCount
+			return entry.widgetData.currentStarredCount > 7 ? 7 : entry.widgetData.currentStarredCount
 		}
 		return entry.widgetData.currentStarredCount > 3 ? 3 : entry.widgetData.currentStarredCount
 	}

--- a/Widget/Widget Views/StarredWidget.swift
+++ b/Widget/Widget Views/StarredWidget.swift
@@ -25,7 +25,7 @@ struct StarredWidgetView : View {
 					VStack(alignment: .leading) {
 						starredImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentStarredCount)).bold().font(Font.system(.footnote, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
+						Text(L10n.localizedCount(entry.widgetData.currentStarredCount)).bold().font(Font.system(.callout, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.starred.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)

--- a/Widget/Widget Views/TodayWidget.swift
+++ b/Widget/Widget Views/TodayWidget.swift
@@ -25,11 +25,12 @@ struct TodayWidgetView : View {
 					VStack(alignment: .leading) {
 						todayImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentTodayCount)).bold().font(Font.system(.footnote, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
+						Text(L10n.localizedCount(entry.widgetData.currentTodayCount)).bold().font(Font.system(.callout, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.today.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)
 					.padding(.trailing, 4)
+					
 					
 					VStack(alignment:.leading, spacing: 0) {
 						ForEach(0..<maxCount(), content: { i in

--- a/Widget/Widget Views/TodayWidget.swift
+++ b/Widget/Widget Views/TodayWidget.swift
@@ -25,7 +25,7 @@ struct TodayWidgetView : View {
 					VStack(alignment: .leading) {
 						todayImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentTodayCount)).bold().font(Font.system(.footnote, design: .rounded))
+						Text(L10n.localizedCount(entry.widgetData.currentTodayCount)).bold().font(Font.system(.footnote, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.today.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)
@@ -37,7 +37,8 @@ struct TodayWidgetView : View {
 								Divider()
 								ArticleItemView(article: entry.widgetData.todayArticles[i],
 												deepLink: WidgetDeepLink.todayArticle(id: entry.widgetData.todayArticles[i].id).url)
-									.padding(.vertical, 6)
+									.padding(.top, 8)
+									.padding(.bottom, 4)
 							} else {
 								ArticleItemView(article: entry.widgetData.unreadArticles[i],
 												deepLink: WidgetDeepLink.todayArticle(id: entry.widgetData.todayArticles[i].id).url)
@@ -69,7 +70,7 @@ struct TodayWidgetView : View {
 	
 	func maxCount() -> Int {
 		if family == .systemLarge {
-			return entry.widgetData.todayArticles.count > 8 ? 8 : entry.widgetData.todayArticles.count
+			return entry.widgetData.todayArticles.count > 7 ? 7 : entry.widgetData.todayArticles.count
 		}
 		return entry.widgetData.todayArticles.count > 3 ? 3 : entry.widgetData.todayArticles.count
 	}

--- a/Widget/Widget Views/UnreadWidget.swift
+++ b/Widget/Widget Views/UnreadWidget.swift
@@ -25,7 +25,7 @@ struct UnreadWidgetView : View {
 					VStack(alignment: .leading) {
 						unreadImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentUnreadCount)).bold().font(Font.system(.footnote, design: .rounded))
+						Text(L10n.localizedCount(entry.widgetData.currentUnreadCount)).bold().font(Font.system(.footnote, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.unread.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)
@@ -37,7 +37,8 @@ struct UnreadWidgetView : View {
 								Divider()
 								ArticleItemView(article: entry.widgetData.unreadArticles[i],
 												deepLink: WidgetDeepLink.unreadArticle(id: entry.widgetData.unreadArticles[i].id).url)
-									.padding(.vertical, 6)
+									.padding(.top, 8)
+									.padding(.bottom, 4)
 							} else {
 								ArticleItemView(article: entry.widgetData.unreadArticles[i],
 												deepLink: WidgetDeepLink.unreadArticle(id: entry.widgetData.unreadArticles[i].id).url)
@@ -69,7 +70,7 @@ struct UnreadWidgetView : View {
 	
 	func maxCount() -> Int {
 		if family == .systemLarge {
-			return entry.widgetData.unreadArticles.count > 8 ? 8 : entry.widgetData.unreadArticles.count
+			return entry.widgetData.unreadArticles.count > 7 ? 7 : entry.widgetData.unreadArticles.count
 		}
 		return entry.widgetData.unreadArticles.count > 3 ? 3 : entry.widgetData.unreadArticles.count
 	}

--- a/Widget/Widget Views/UnreadWidget.swift
+++ b/Widget/Widget Views/UnreadWidget.swift
@@ -25,7 +25,7 @@ struct UnreadWidgetView : View {
 					VStack(alignment: .leading) {
 						unreadImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentUnreadCount)).bold().font(Font.system(.footnote, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
+						Text(L10n.localizedCount(entry.widgetData.currentUnreadCount)).bold().font(Font.system(.callout, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.unread.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)


### PR DESCRIPTION
• Ensure high number counts do not wrap
• Reduces number of articles displayed on large widget due to increased spacing as they were going out-of-visible bounds.
• Consistent vertical spacing between articles and dividers
• Reduces encoded article count
• Increased count font size