### PR TITLE
Widget Performance

### DIFF
--- a/Shared/Widget/WidgetDataEncoder.swift
+++ b/Shared/Widget/WidgetDataEncoder.swift
@@ -27,7 +27,7 @@ public final class WidgetDataEncoder {
 	private init () {}
 	
 	@available(iOS 14, *)
-	func encodeWidgetData(refreshTimeline: Bool = true) throws {
+	func encodeWidgetData() throws {
 		os_log(.debug, log: log, "Starting encoding widget data.")
 		
 		do {
@@ -100,14 +100,9 @@ public final class WidgetDataEncoder {
 				}
 				if FileManager.default.createFile(atPath: self.dataURL!.path, contents: encodedData, attributes: nil) {
 					os_log(.debug, log: self.log, "Wrote widget data to container.")
-					if refreshTimeline == true {
-						WidgetCenter.shared.reloadAllTimelines()
-						UIApplication.shared.endBackgroundTask(self.backgroundTaskID!)
-						self.backgroundTaskID = .invalid
-					} else {
-						UIApplication.shared.endBackgroundTask(self.backgroundTaskID!)
-						self.backgroundTaskID = .invalid
-					}
+					WidgetCenter.shared.reloadAllTimelines()
+					UIApplication.shared.endBackgroundTask(self.backgroundTaskID!)
+					self.backgroundTaskID = .invalid
 				} else {
 					UIApplication.shared.endBackgroundTask(self.backgroundTaskID!)
 					self.backgroundTaskID = .invalid

--- a/Technotes/Widgets.md
+++ b/Technotes/Widgets.md
@@ -9,11 +9,10 @@ There are _currently_ seven widgets available for iOS:
 ## Widget Data
 The widget does not have access to the parent app's database. To surface data to the widget, a small amount of article data is encoded to JSON (see `WidgetDataEncoder`) and saved to the AppGroup container. 
 
-Widget data is written at three points:
+Widget data is written at two points:
 
-1. After applicationDidFinishLaunching
-2. As part of a background refresh
-3. When the scene enters the background
+1. As part of a background refresh
+2. When the scene enters the background
 
 The widget timeline is refreshed—via `WidgetCenter.shared.reloadAllTimelines()`—after each of the above.
 

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -115,11 +115,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 		syncTimer!.update()
 		#endif
 		
-		if #available(iOS 14, *) {
-			WidgetDataEncoder.encodeWidgetData(refreshTimeline: false)
-		}
-		
-		
 		return true
 		
 	}
@@ -382,7 +377,7 @@ private extension AppDelegate {
 			AccountManager.shared.refreshAll(errorHandler: ErrorHandler.log) { [unowned self] in
 				if !AccountManager.shared.isSuspended {
 					if #available(iOS 14, *) {
-						WidgetDataEncoder.encodeWidgetData()
+						try? WidgetDataEncoder.shared.encodeWidgetData()
 					}
 					self.suspendApplication()
 					os_log("Account refresh operation completed.", log: self.log, type: .info)

--- a/iOS/SceneDelegate.swift
+++ b/iOS/SceneDelegate.swift
@@ -66,7 +66,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	
 	func sceneDidEnterBackground(_ scene: UIScene) {
 		if #available(iOS 14, *) {
-			WidgetDataEncoder.encodeWidgetData()
+			try? WidgetDataEncoder.shared.encodeWidgetData()
 		}
 		ArticleStringFormatter.emptyCaches()
 		appDelegate.prepareAccountsForBackground()


### PR DESCRIPTION
Fixes #2625 

- The encode that was done as part of the launch sequence has been removed.

- Article fetching, conversion to `LatestArticle`, and then to the `WidgetData` struct continues to be done on the main thread. However, JSON encoding and writing to disk is now moved to the background and given extra time to complete. This may help on older devices with larger databases.