### PR TITLE
Feature/widget tweaks

### DIFF
--- a/NetNewsWire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NetNewsWire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/Ranchero-Software/RSCore.git",
         "state": {
           "branch": null,
-          "revision": "1017fe09c61bd9f75aa713381894aef979c994ef",
-          "version": "1.0.0-beta6"
+          "revision": "dce76a4070ed24f148bb1673c308962dbdbf01ef",
+          "version": "1.0.0-beta9"
         }
       },
       {
@@ -96,7 +96,7 @@
         "repositoryURL": "https://github.com/Ranchero-Software/Sparkle-Binary.git",
         "state": {
           "branch": "main",
-          "revision": "6b6d1d4b4864af7b56dd6f2ba148d752724e80d7",
+          "revision": "67cd26321bdf4e77954cf6de7d9e6a20544f2030",
           "version": null
         }
       },

--- a/Widget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Widget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.945",
-          "green" : "0.502",
-          "red" : "0.176"
+          "blue" : "0.929",
+          "green" : "0.611",
+          "red" : "0.426"
         }
       },
       "idiom" : "universal"

--- a/Widget/Resources/Localized.swift
+++ b/Widget/Resources/Localized.swift
@@ -22,20 +22,24 @@ internal enum L10n {
   internal static let starred = L10n.tr("Localizable", "Starred")
   /// A sneak peek at your starred articles.
   internal static let starredWidgetDescription = L10n.tr("Localizable", "Starred_Widget_Description")
-  /// You've not starred any artices.
+  /// When you mark articles as Starred, they'll appear here.
   internal static let starredWidgetNoItems = L10n.tr("Localizable", "Starred_Widget_NoItems")
+  /// Starred
+  internal static let starredWidgetNoItemsTitle = L10n.tr("Localizable", "Starred_Widget_NoItemsTitle")
   /// Your Starred Articles
   internal static let starredWidgetTitle = L10n.tr("Localizable", "Starred_Widget_Title")
   /// Plural format key: "%#@starred_count@"
   internal static func starredCount(_ p1: Int) -> String {
     return L10n.tr("Localizable", "StarredCount", p1)
   }
-  /// Today
+  /// Today  
   internal static let today = L10n.tr("Localizable", "Today")
   /// A sneak peek at recently published unread articles.
   internal static let todayWidgetDescription = L10n.tr("Localizable", "Today_Widget_Description")
-  /// There are no recent articles to read.
+  /// There are no recent unread articles left to read.
   internal static let todayWidgetNoItems = L10n.tr("Localizable", "Today_Widget_NoItems")
+  /// Today
+  internal static let todayWidgetNoItemsTitle = L10n.tr("Localizable", "Today_Widget_NoItemsTitle")
   /// Your Today Articles
   internal static let todayWidgetTitle = L10n.tr("Localizable", "Today_Widget_Title")
   /// Plural format key: "%#@today_count@"
@@ -46,8 +50,10 @@ internal enum L10n {
   internal static let unread = L10n.tr("Localizable", "Unread")
   /// A sneak peek at your unread articles.
   internal static let unreadWidgetDescription = L10n.tr("Localizable", "Unread_Widget_Description")
-  /// There's nothing to read right now.
+  /// There are no unread articles left to read.
   internal static let unreadWidgetNoItems = L10n.tr("Localizable", "Unread_Widget_NoItems")
+  /// Unread
+  internal static let unreadWidgetNoItemsTitle = L10n.tr("Localizable", "Unread_Widget_NoItemsTitle")
   /// Your Unread Articles
   internal static let unreadWidgetTitle = L10n.tr("Localizable", "Unread_Widget_Title")
   /// Plural format key: "%#@unread_count@"

--- a/Widget/Resources/en.lproj/Localizable.strings
+++ b/Widget/Resources/en.lproj/Localizable.strings
@@ -20,15 +20,18 @@
 "SmartFeedSummary_Widget_Description" = "Your smart feeds, summarized.";
 
 /* Unread Widget */
-"Unread_Widget_NoItems" = "There's nothing to read right now.";
+"Unread_Widget_NoItemsTitle" = "Unread";
+"Unread_Widget_NoItems" = "There are no unread articles left to read.";
 
 /* Today Widget */
-"Today_Widget_NoItems" = "There are no recent articles to read.";
+"Today_Widget_NoItemsTitle" = "Today";
+"Today_Widget_NoItems" = "There are no recent unread articles left to read.";
 
 /* Starred Widget */
-"Starred_Widget_NoItems" = "You've not starred any artices.";
+"Starred_Widget_NoItemsTitle" = "Starred";
+"Starred_Widget_NoItems" = "When you mark articles as Starred, they'll appear here.";
 
 /* Smart Feed Summary Widget */
 "Unread" = "Unread";
-"Today" = "Today";
+"Today" = "Today  ";
 "Starred" = "Starred";

--- a/Widget/Shared Views/ArticleItemView.swift
+++ b/Widget/Shared Views/ArticleItemView.swift
@@ -19,7 +19,7 @@ struct ArticleItemView: View {
 				// Feed Icon
 				Image(uiImage: thumbnail(article.feedIcon))
 					.resizable()
-					.frame(width: 25, height: 25)
+					.frame(width: 30, height: 30)
 					.cornerRadius(4)
 				
 				// Title and Feed Name

--- a/Widget/Widget Views/StarredWidget.swift
+++ b/Widget/Widget Views/StarredWidget.swift
@@ -26,7 +26,7 @@ struct StarredWidgetView : View {
 					VStack(alignment: .leading) {
 						starredImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentStarredCount)).bold().font(Font.system(.callout, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
+						Text(L10n.localizedCount(entry.widgetData.currentStarredCount)).bold().font(.callout).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.starred.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)
@@ -63,13 +63,6 @@ struct StarredWidgetView : View {
 			.foregroundColor(.yellow)
 	}
 	
-	var nnwImage: some View {
-		Image("CornerIcon")
-			.resizable()
-			.frame(width: 25, height: 25, alignment: .center)
-			.cornerRadius(4)
-	}
-	
 	func maxCount() -> Int {
 		if family == .systemLarge {
 			return entry.widgetData.currentStarredCount > 7 ? 7 : entry.widgetData.currentStarredCount
@@ -78,24 +71,26 @@ struct StarredWidgetView : View {
 	}
 	
 	var inboxZero: some View {
-		VStack {
+		VStack(alignment: .center) {
 			Spacer()
-			Image(systemName: "checkmark.circle")
-				.foregroundColor(.accentColor)
-				.font(.title)
-			
-			Spacer()
-			HStack {
-				Image("CornerIcon")
-					.resizable()
-					.frame(width: 15, height: 15, alignment: .center)
-					.cornerRadius(4)
+			Image(systemName: "star.fill")
+				.resizable()
+				.aspectRatio(contentMode: .fit)
+				.frame(width: 30)
+				.foregroundColor(.yellow)
 				
-				Text(L10n.starredWidgetNoItems)
-					.font(.caption2)
-					.foregroundColor(.gray)
-			}
-		}.padding()
+
+			Text(L10n.starredWidgetNoItemsTitle)
+				.font(.headline)
+				.foregroundColor(.primary)
+			
+			Text(L10n.starredWidgetNoItems)
+				.font(.caption)
+				.foregroundColor(.gray)
+			Spacer()
+		}
+		.multilineTextAlignment(.center)
+		.padding()
 	}
 	
 }

--- a/Widget/Widget Views/TodayWidget.swift
+++ b/Widget/Widget Views/TodayWidget.swift
@@ -26,12 +26,11 @@ struct TodayWidgetView : View {
 					VStack(alignment: .leading) {
 						todayImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentTodayCount)).bold().font(Font.system(.callout, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
+						Text(L10n.localizedCount(entry.widgetData.currentTodayCount)).bold().font(.callout).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.today.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)
 					.padding(.trailing, 4)
-					
 					
 					VStack(alignment:.leading, spacing: 0) {
 						ForEach(0..<maxCount(), content: { i in
@@ -63,13 +62,6 @@ struct TodayWidgetView : View {
 			.foregroundColor(.orange)
 	}
 	
-	var nnwImage: some View {
-		Image("CornerIcon")
-			.resizable()
-			.frame(width: 25, height: 25, alignment: .center)
-			.cornerRadius(4)
-	}
-	
 	func maxCount() -> Int {
 		if family == .systemLarge {
 			return entry.widgetData.todayArticles.count > 7 ? 7 : entry.widgetData.todayArticles.count
@@ -78,24 +70,26 @@ struct TodayWidgetView : View {
 	}
 	
 	var inboxZero: some View {
-		VStack {
+		VStack(alignment: .center) {
 			Spacer()
-			Image(systemName: "checkmark.circle")
-				.foregroundColor(.accentColor)
-				.font(.title)
-			
-			Spacer()
-			HStack {
-				Image("CornerIcon")
-					.resizable()
-					.frame(width: 15, height: 15, alignment: .center)
-					.cornerRadius(4)
+			Image(systemName: "sun.max.fill")
+				.resizable()
+				.aspectRatio(contentMode: .fit)
+				.frame(width: 30)
+				.foregroundColor(.orange)
 				
-				Text(L10n.todayWidgetNoItems)
-					.font(.caption2)
-					.foregroundColor(.gray)
-			}
-		}.padding()
+
+			Text(L10n.todayWidgetNoItemsTitle)
+				.font(.headline)
+				.foregroundColor(.primary)
+			
+			Text(L10n.todayWidgetNoItems)
+				.font(.caption)
+				.foregroundColor(.gray)
+			Spacer()
+		}
+		.multilineTextAlignment(.center)
+		.padding()
 	}
 	
 }

--- a/Widget/Widget Views/UnreadWidget.swift
+++ b/Widget/Widget Views/UnreadWidget.swift
@@ -26,7 +26,7 @@ struct UnreadWidgetView : View {
 					VStack(alignment: .leading) {
 						unreadImage
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentUnreadCount)).bold().font(Font.system(.callout, design: .rounded)).minimumScaleFactor(0.5).lineLimit(1)
+						Text(L10n.localizedCount(entry.widgetData.currentUnreadCount)).bold().font(.callout).minimumScaleFactor(0.5).lineLimit(1)
 						Text(L10n.unread.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
 					}
 					.frame(width: metrics.size.width * 0.15)
@@ -62,13 +62,6 @@ struct UnreadWidgetView : View {
 			.foregroundColor(.accentColor)
 	}
 	
-	var nnwImage: some View {
-		Image("CornerIcon")
-			.resizable()
-			.frame(width: 25, height: 25, alignment: .center)
-			.cornerRadius(4)
-	}
-	
 	func maxCount() -> Int {
 		if family == .systemLarge {
 			return entry.widgetData.unreadArticles.count > 7 ? 7 : entry.widgetData.unreadArticles.count
@@ -77,24 +70,25 @@ struct UnreadWidgetView : View {
 	}
 	
 	var inboxZero: some View {
-		VStack {
+		VStack(alignment: .center) {
 			Spacer()
-			Image(systemName: "checkmark.circle")
+			Image(systemName: "largecircle.fill.circle")
+				.resizable()
+				.aspectRatio(contentMode: .fit)
 				.foregroundColor(.accentColor)
-				.font(.title)
+				.frame(width: 30)
+
+			Text(L10n.unreadWidgetNoItemsTitle)
+				.font(.headline)
+				.foregroundColor(.primary)
 			
+			Text(L10n.unreadWidgetNoItems)
+				.font(.caption)
+				.foregroundColor(.gray)
 			Spacer()
-			HStack {
-				Image("CornerIcon")
-					.resizable()
-					.frame(width: 15, height: 15, alignment: .center)
-					.cornerRadius(4)
-				
-				Text(L10n.unreadWidgetNoItems)
-					.font(.caption2)
-					.foregroundColor(.gray)
-			}
-		}.padding()
+		}
+		.multilineTextAlignment(.center)
+		.padding()
 	}
 	
 }

--- a/Widget/WidgetBundle.swift
+++ b/Widget/WidgetBundle.swift
@@ -89,7 +89,6 @@ struct SmartFeedSummaryWidget: Widget {
 struct NetNewsWireWidgets: WidgetBundle {
 	@WidgetBundleBuilder
 	var body: some Widget {
-		SmartFeedSummaryWidget()
 		UnreadWidget()
 		TodayWidget()
 		StarredWidget()


### PR DESCRIPTION
• Feed favicons now sized to match the height of the `ArticleItemView`
• Rounded font removed in lieu of default font
• `accentColor` corrected for dark mode
• Fixes a ~3pt alignment issue on the Today widget’s left `VStack` 
• No content views have been updated with bigger icons, text and explainers
• The small summary widget has been disabled

![Screenshots](https://user-images.githubusercontent.com/7046652/102212384-189e8280-3f10-11eb-98e3-e434c84af4a1.png)
