### PR TITLE
Retrieving the unread and starred items should only return the item id

### DIFF
--- a/Account/Sources/Account/FeedWrangler/FeedWranglerAPICaller.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerAPICaller.swift
@@ -190,40 +190,75 @@ final class FeedWranglerAPICaller: NSObject {
 		}
 	}
 	
-	func retrieveUnreadFeedItems(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
-		let url = FeedWranglerConfig.clientURL
-			.appendingPathComponent("feed_items/list")
-			.appendingQueryItems([
-				URLQueryItem(name: "read", value: "false"),
-				URLQueryItem(name: "offset", value: String(page * FeedWranglerConfig.pageSize)),
-			])
-		
-		standardSend(url: url, resultType: FeedWranglerFeedItemsRequest.self) { result in
-			switch result {
-			case .success(let (_, results)):
-				completion(.success(results?.feedItems ?? []))
+    func retrieveUnreadFeedItems(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
+        let url = FeedWranglerConfig.clientURL
+            .appendingPathComponent("feed_items/list")
+            .appendingQueryItems([
+                URLQueryItem(name: "read", value: "false"),
+                URLQueryItem(name: "offset", value: String(page * FeedWranglerConfig.pageSize)),
+            ])
+        
+        standardSend(url: url, resultType: FeedWranglerFeedItemsRequest.self) { result in
+            switch result {
+            case .success(let (_, results)):
+                completion(.success(results?.feedItems ?? []))
 
-			case .failure(let error):
-				completion(.failure(error))
-			}
-		}
-	}
-	
-	func retrieveAllUnreadFeedItems(foundItems: [FeedWranglerFeedItem] = [], page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
-		retrieveUnreadFeedItems(page: page) { result in
-			switch result {
-			case .success(let newItems):
-				if newItems.count > 0 {
-					self.retrieveAllUnreadFeedItems(foundItems: foundItems + newItems, page: (page + 1), completion: completion)
-				} else {
-					completion(.success(foundItems + newItems))
-				}
-				
-			case .failure(let error):
-				completion(.failure(error))
-			}
-		}
-	}
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    func retrieveAllUnreadFeedItems(foundItems: [FeedWranglerFeedItem] = [], page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
+        retrieveUnreadFeedItems(page: page) { result in
+            switch result {
+            case .success(let newItems):
+                if newItems.count > 0 {
+                    self.retrieveAllUnreadFeedItems(foundItems: foundItems + newItems, page: (page + 1), completion: completion)
+                } else {
+                    completion(.success(foundItems + newItems))
+                }
+                
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    func retrieveUnreadFeedItemIds(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItemId], Error>) -> Void) {
+        let url = FeedWranglerConfig.clientURL
+            .appendingPathComponent("feed_items/list_ids")
+            .appendingQueryItems([
+                URLQueryItem(name: "read", value: "false"),
+                URLQueryItem(name: "offset", value: String(page * FeedWranglerConfig.idsPageSize)),
+            ])
+        
+        standardSend(url: url, resultType: FeedWranglerFeedItemIdsRequest.self) { result in
+            switch result {
+            case .success(let (_, results)):
+                completion(.success(results?.feedItems ?? []))
+
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    func retrieveAllUnreadFeedItemIds(foundItems: [FeedWranglerFeedItemId] = [], page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItemId], Error>) -> Void) {
+        retrieveUnreadFeedItemIds(page: page) { result in
+            switch result {
+            case .success(let newItems):
+                if newItems.count > 0 {
+                    self.retrieveAllUnreadFeedItemIds(foundItems: foundItems + newItems, page: (page + 1), completion: completion)
+                } else {
+                    completion(.success(foundItems + newItems))
+                }
+                
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
 	
 	func retrieveStarredFeedItems(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
 		let url = FeedWranglerConfig.clientURL
@@ -259,6 +294,41 @@ final class FeedWranglerAPICaller: NSObject {
 			}
 		}
 	}
+    
+    func retrieveStarredFeedItemIds(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItemId], Error>) -> Void) {
+        let url = FeedWranglerConfig.clientURL
+            .appendingPathComponent("feed_items/list_ids")
+            .appendingQueryItems([
+                URLQueryItem(name: "starred", value: "true"),
+                URLQueryItem(name: "offset", value: String(page * FeedWranglerConfig.idsPageSize)),
+            ])
+        
+        standardSend(url: url, resultType: FeedWranglerFeedItemIdsRequest.self) { result in
+            switch result {
+            case .success(let (_, results)):
+                completion(.success(results?.feedItems ?? []))
+
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    func retrieveAllStarredFeedItemIds(foundItems: [FeedWranglerFeedItemId] = [], page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItemId], Error>) -> Void) {
+        retrieveStarredFeedItemIds(page: page) { result in
+            switch result {
+            case .success(let newItems):
+                if newItems.count > 0 {
+                    self.retrieveAllStarredFeedItemIds(foundItems: foundItems + newItems, page: (page + 1), completion: completion)
+                } else {
+                    completion(.success(foundItems + newItems))
+                }
+                
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
 	
 	func updateArticleStatus(_ articleID: String, _ statuses: [SyncStatus], completion: @escaping () -> Void) {
 		

--- a/Account/Sources/Account/FeedWrangler/FeedWranglerAPICaller.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerAPICaller.swift
@@ -189,41 +189,6 @@ final class FeedWranglerAPICaller: NSObject {
 			}
 		}
 	}
-	
-    func retrieveUnreadFeedItems(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
-        let url = FeedWranglerConfig.clientURL
-            .appendingPathComponent("feed_items/list")
-            .appendingQueryItems([
-                URLQueryItem(name: "read", value: "false"),
-                URLQueryItem(name: "offset", value: String(page * FeedWranglerConfig.pageSize)),
-            ])
-        
-        standardSend(url: url, resultType: FeedWranglerFeedItemsRequest.self) { result in
-            switch result {
-            case .success(let (_, results)):
-                completion(.success(results?.feedItems ?? []))
-
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
-    
-    func retrieveAllUnreadFeedItems(foundItems: [FeedWranglerFeedItem] = [], page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
-        retrieveUnreadFeedItems(page: page) { result in
-            switch result {
-            case .success(let newItems):
-                if newItems.count > 0 {
-                    self.retrieveAllUnreadFeedItems(foundItems: foundItems + newItems, page: (page + 1), completion: completion)
-                } else {
-                    completion(.success(foundItems + newItems))
-                }
-                
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
     
     func retrieveUnreadFeedItemIds(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItemId], Error>) -> Void) {
         let url = FeedWranglerConfig.clientURL
@@ -259,41 +224,6 @@ final class FeedWranglerAPICaller: NSObject {
             }
         }
     }
-	
-	func retrieveStarredFeedItems(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
-		let url = FeedWranglerConfig.clientURL
-			.appendingPathComponent("feed_items/list")
-			.appendingQueryItems([
-				URLQueryItem(name: "starred", value: "true"),
-				URLQueryItem(name: "offset", value: String(page * FeedWranglerConfig.pageSize)),
-			])
-		
-		standardSend(url: url, resultType: FeedWranglerFeedItemsRequest.self) { result in
-			switch result {
-			case .success(let (_, results)):
-				completion(.success(results?.feedItems ?? []))
-
-			case .failure(let error):
-				completion(.failure(error))
-			}
-		}
-	}
-	
-	func retrieveAllStarredFeedItems(foundItems: [FeedWranglerFeedItem] = [], page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItem], Error>) -> Void) {
-		retrieveStarredFeedItems(page: page) { result in
-			switch result {
-			case .success(let newItems):
-				if newItems.count > 0 {
-					self.retrieveAllStarredFeedItems(foundItems: foundItems + newItems, page: (page + 1), completion: completion)
-				} else {
-					completion(.success(foundItems + newItems))
-				}
-				
-			case .failure(let error):
-				completion(.failure(error))
-			}
-		}
-	}
     
     func retrieveStarredFeedItemIds(page: Int = 0, completion: @escaping (Result<[FeedWranglerFeedItemId], Error>) -> Void) {
         let url = FeedWranglerConfig.clientURL

--- a/Account/Sources/Account/FeedWrangler/FeedWranglerAccountDelegate.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerAccountDelegate.swift
@@ -249,7 +249,7 @@ final class FeedWranglerAccountDelegate: AccountDelegate {
 		let group = DispatchGroup()
 		
 		group.enter()
-		caller.retrieveAllUnreadFeedItems { result in
+		caller.retrieveAllUnreadFeedItemIds { result in
 			switch result {
 			case .success(let items):
 				self.syncArticleReadState(account, items)
@@ -263,7 +263,7 @@ final class FeedWranglerAccountDelegate: AccountDelegate {
 		
 		// starred
 		group.enter()
-		caller.retrieveAllStarredFeedItems { result in
+		caller.retrieveAllStarredFeedItemIds { result in
 			switch result {
 			case .success(let items):
 				self.syncArticleStarredState(account, items)
@@ -536,7 +536,7 @@ private extension FeedWranglerAccountDelegate {
 		}
 	}
 	
-	func syncArticleReadState(_ account: Account, _ unreadFeedItems: [FeedWranglerFeedItem]) {
+	func syncArticleReadState(_ account: Account, _ unreadFeedItems: [FeedWranglerFeedItemId]) {
 		let unreadServerItemIDs = Set(unreadFeedItems.map { String($0.feedItemID) })
 		account.fetchUnreadArticleIDs { articleIDsResult in
 			guard let unreadLocalItemIDs = try? articleIDsResult.get() else {
@@ -549,7 +549,7 @@ private extension FeedWranglerAccountDelegate {
 		}
 	}
 	
-	func syncArticleStarredState(_ account: Account, _ starredFeedItems: [FeedWranglerFeedItem]) {
+	func syncArticleStarredState(_ account: Account, _ starredFeedItems: [FeedWranglerFeedItemId]) {
 		let starredServerItemIDs = Set(starredFeedItems.map { String($0.feedItemID) })
 		account.fetchStarredArticleIDs { articleIDsResult in
 			guard let starredLocalItemIDs = try? articleIDsResult.get() else {

--- a/Account/Sources/Account/FeedWrangler/FeedWranglerAccountDelegate.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerAccountDelegate.swift
@@ -249,7 +249,7 @@ final class FeedWranglerAccountDelegate: AccountDelegate {
 		let group = DispatchGroup()
 		
 		group.enter()
-		caller.retrieveAllUnreadFeedItemIds { result in
+		caller.retrieveUnreadFeedItemIds { result in
 			switch result {
 			case .success(let items):
 				self.syncArticleReadState(account, items)
@@ -263,7 +263,7 @@ final class FeedWranglerAccountDelegate: AccountDelegate {
 		
 		// starred
 		group.enter()
-		caller.retrieveAllStarredFeedItemIds { result in
+		caller.retrieveStarredFeedItemIds { result in
 			switch result {
 			case .success(let items):
 				self.syncArticleStarredState(account, items)

--- a/Account/Sources/Account/FeedWrangler/FeedWranglerConfig.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerConfig.swift
@@ -11,6 +11,7 @@ import Secrets
 
 enum FeedWranglerConfig {
 	static let pageSize = 100
+    static let idsPageSize = 1000
 	static let clientPath = "https://feedwrangler.net/api/v2/"
 	static let clientURL = {
 		URL(string: FeedWranglerConfig.clientPath)!

--- a/Account/Sources/Account/FeedWrangler/FeedWranglerFeedItemId.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerFeedItemId.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by Jonathan Bennett on 2021-01-14.
+//
+
+
+import Foundation
+
+struct FeedWranglerFeedItemId: Hashable, Codable {
+    
+    let feedItemID: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case feedItemID = "feed_item_id"
+    }
+    
+}

--- a/Account/Sources/Account/FeedWrangler/FeedWranglerFeedItemIdsRequest.swift
+++ b/Account/Sources/Account/FeedWrangler/FeedWranglerFeedItemIdsRequest.swift
@@ -1,0 +1,25 @@
+//
+//  FeedWranglerFeedItemsRequest.swift
+//  Account
+//
+//  Created by Jonathan Bennett on 2021-01-14.
+//  Copyright © 2019 Ranchero Software, LLC. All rights reserved.
+//
+
+import Foundation
+
+struct FeedWranglerFeedItemIdsRequest: Hashable, Codable {
+    
+    let count: Int
+    let feedItems: [FeedWranglerFeedItemId]
+    let error: String?
+    let result: String
+    
+    enum CodingKeys: String, CodingKey {
+        case count = "count"
+        case feedItems = "feed_items"
+        case error = "error"
+        case result = "result"
+    }
+    
+}


### PR DESCRIPTION
Switch to the `list_ids` endpoint so we aren't downloading unnecessary data.

Closes #2545 