### PR TITLE
Text position on widgets

### DIFF
--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -134,6 +134,8 @@
 		17D5F19524B0C1DD00375168 /* SidebarToolbarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172199F024AB716900A31D04 /* SidebarToolbarModifier.swift */; };
 		17E0084625941887000C23F0 /* SizeCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E0084525941887000C23F0 /* SizeCategories.swift */; };
 		17E4DBD624BFC53E00FE462A /* AdvancedPreferencesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E4DBD524BFC53E00FE462A /* AdvancedPreferencesModel.swift */; };
+		17EF6A2125C4E5B4002C9F81 /* RSWeb in Frameworks */ = {isa = PBXBuildFile; productRef = 17EF6A2025C4E5B4002C9F81 /* RSWeb */; };
+		17EF6A2225C4E5B4002C9F81 /* RSWeb in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 17EF6A2025C4E5B4002C9F81 /* RSWeb */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		27B86EEB25A53AAB00264340 /* Account in Frameworks */ = {isa = PBXBuildFile; productRef = 51BC2F4A24D343A500E90810 /* Account */; };
 		27B86EEC25A53AAB00264340 /* Articles in Frameworks */ = {isa = PBXBuildFile; productRef = 17E0080E25936DF6000C23F0 /* Articles */; };
 		27B86EED25A53AAB00264340 /* ArticlesDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = 17E0081125936DF6000C23F0 /* ArticlesDatabase */; };
@@ -1232,6 +1234,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		17EF6A1725C4E59D002C9F81 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				17EF6A2225C4E5B4002C9F81 /* RSWeb in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5102AE7324D17FAA0050839C /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2045,6 +2058,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				17EF6A2125C4E5B4002C9F81 /* RSWeb in Frameworks */,
 				176813F72564BB2C00D98635 /* SwiftUI.framework in Frameworks */,
 				176813F52564BB2C00D98635 /* WidgetKit.framework in Frameworks */,
 			);
@@ -3705,12 +3719,16 @@
 				176813F02564BB2C00D98635 /* Frameworks */,
 				176813F12564BB2C00D98635 /* Resources */,
 				1701E1BF25689B44009453D8 /* SwiftGen Localization */,
+				17EF6A1725C4E59D002C9F81 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = "NetNewsWire iOS Widget Extension";
+			packageProductDependencies = (
+				17EF6A2025C4E5B4002C9F81 /* RSWeb */,
+			);
 			productName = "NetNewsWire WidgetExtension";
 			productReference = 176813F32564BB2C00D98635 /* NetNewsWire iOS Widget Extension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -6212,6 +6230,11 @@
 		17E0081725936DFF000C23F0 /* SyncDatabase */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SyncDatabase;
+		};
+		17EF6A2025C4E5B4002C9F81 /* RSWeb */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 51383A3024D1F90E0027E272 /* XCRemoteSwiftPackageReference "RSWeb" */;
+			productName = RSWeb;
 		};
 		5102AE6824D17F7C0050839C /* RSCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/NetNewsWire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NetNewsWire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
-          "revision": "4a80ebe93b6966d5083394fcaaaff57a2fcec935",
-          "version": "5.2.3"
+          "revision": "c657fb9f5827ef138068215c76ad0bb62bbc92da",
+          "version": "5.2.4"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/Ranchero-Software/RSParser.git",
         "state": {
           "branch": null,
-          "revision": "a4467cb6ab32d67fa8b09fcef8b234c7f96b7f9c",
-          "version": "2.0.0-beta3"
+          "revision": "fd9b9c974d551a9c94d970da90a42571d234efd6",
+          "version": "2.0.0-beta4"
         }
       },
       {

--- a/NetNewsWire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NetNewsWire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
-          "revision": "c657fb9f5827ef138068215c76ad0bb62bbc92da",
-          "version": "5.2.4"
+          "revision": "4a80ebe93b6966d5083394fcaaaff57a2fcec935",
+          "version": "5.2.3"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/Ranchero-Software/RSParser.git",
         "state": {
           "branch": null,
-          "revision": "fd9b9c974d551a9c94d970da90a42571d234efd6",
-          "version": "2.0.0-beta4"
+          "revision": "a4467cb6ab32d67fa8b09fcef8b234c7f96b7f9c",
+          "version": "2.0.0-beta3"
         }
       },
       {

--- a/Shared/Widget/WidgetDataEncoder.swift
+++ b/Shared/Widget/WidgetDataEncoder.swift
@@ -44,7 +44,7 @@ public final class WidgetDataEncoder {
 			for article in unreadArticles {
 				let latestArticle = LatestArticle(id: article.sortableArticleID,
 												  feedTitle: article.sortableName,
-												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? article.contentHTML?.strippingHTML().trimmingWhitespace : ArticleStringFormatter.truncatedTitle(article),
+												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
 												  articleSummary: article.summary,
 												  feedIcon: article.iconImage()?.image.dataRepresentation(),
 												  pubDate: article.datePublished!.description)
@@ -55,7 +55,7 @@ public final class WidgetDataEncoder {
 			for article in starredArticles {
 				let latestArticle = LatestArticle(id: article.sortableArticleID,
 												  feedTitle: article.sortableName,
-												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? article.contentHTML?.strippingHTML().trimmingWhitespace : ArticleStringFormatter.truncatedTitle(article),
+												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
 												  articleSummary: article.summary,
 												  feedIcon: article.iconImage()?.image.dataRepresentation(),
 												  pubDate: article.datePublished!.description)
@@ -66,7 +66,7 @@ public final class WidgetDataEncoder {
 			for article in todayArticles {
 				let latestArticle = LatestArticle(id: article.sortableArticleID,
 												  feedTitle: article.sortableName,
-												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? article.contentHTML?.strippingHTML().trimmingWhitespace : ArticleStringFormatter.truncatedTitle(article),
+												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
 												  articleSummary: article.summary,
 												  feedIcon: article.iconImage()?.image.dataRepresentation(),
 												  pubDate: article.datePublished!.description)

--- a/Widget/Shared Views/ArticleItemView.swift
+++ b/Widget/Shared Views/ArticleItemView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import RSWeb
 
 struct ArticleItemView: View {
 	

--- a/Widget/Widget Views/StarredWidget.swift
+++ b/Widget/Widget Views/StarredWidget.swift
@@ -23,34 +23,53 @@ struct StarredWidgetView : View {
 		}
 		else {
 			GeometryReader { metrics in
-				HStack(alignment: .top, spacing: 4) {
-					VStack(alignment: .leading, spacing: -4) {
+				HStack {
+					VStack {
 						starredImage
+							.padding(.vertical, 12)
+							.padding(.leading, 8)
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentStarredCount)).bold().font(.callout).minimumScaleFactor(0.5).lineLimit(1)
-						Text(L10n.starred.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
-					}
-					.frame(width: metrics.size.width * 0.15)
-					.padding(.trailing, 4)
 					
-					VStack(alignment:.leading, spacing: 0) {
-						ForEach(0..<maxCount(), content: { i in
-							if i != 0 {
-								Divider()
-								ArticleItemView(article: entry.widgetData.starredArticles[i],
-												deepLink: WidgetDeepLink.starredArticle(id: entry.widgetData.starredArticles[i].id).url)
-									.padding(.top, 8)
-									.padding(.bottom, 4)
-							} else {
-								ArticleItemView(article: entry.widgetData.starredArticles[i],
-												deepLink: WidgetDeepLink.starredArticle(id: entry.widgetData.starredArticles[i].id).url)
-									.padding(.bottom, 4)
-							}
-							
-						})
+					}
+				}
+				.frame(width: metrics.size.width * 0.15)
+				
+				Spacer()
+				
+				VStack(alignment:.leading, spacing: 0) {
+					ForEach(0..<maxCount(), content: { i in
+						if i != 0 {
+							Divider()
+							ArticleItemView(article: entry.widgetData.starredArticles[i],
+											deepLink: WidgetDeepLink.starredArticle(id: entry.widgetData.starredArticles[i].id).url)
+								.padding(.top, 8)
+								.padding(.bottom, 4)
+						} else {
+							ArticleItemView(article: entry.widgetData.starredArticles[i],
+											deepLink: WidgetDeepLink.starredArticle(id: entry.widgetData.starredArticles[i].id).url)
+								.padding(.bottom, 4)
+						}
+					})
+					Spacer()
+				}
+				.padding(.leading, metrics.size.width * 0.175)
+				.padding([.bottom, .trailing])
+				.padding(.top, 12)
+				.overlay(
+					 VStack {
 						Spacer()
-					}.padding(.leading, 4)
-				}.padding()
+						HStack {
+							Spacer()
+							Text(L10n.starredCount(entry.widgetData.currentStarredCount - maxCount()))
+								.font(.caption2)
+								.bold()
+								.foregroundColor(.secondary)
+						}
+					}
+					.padding(.horizontal)
+					.padding(.bottom, 6)
+				)
+			
 			}.widgetURL(WidgetDeepLink.starred.url)
 			
 		}

--- a/Widget/Widget Views/StarredWidget.swift
+++ b/Widget/Widget Views/StarredWidget.swift
@@ -60,10 +60,12 @@ struct StarredWidgetView : View {
 						Spacer()
 						HStack {
 							Spacer()
-							Text(L10n.starredCount(entry.widgetData.currentStarredCount - maxCount()))
-								.font(.caption2)
-								.bold()
-								.foregroundColor(.secondary)
+							if entry.widgetData.currentStarredCount - maxCount() > 0 {
+								Text(L10n.starredCount(entry.widgetData.currentStarredCount - maxCount()))
+									.font(.caption2)
+									.bold()
+									.foregroundColor(.secondary)
+							}
 						}
 					}
 					.padding(.horizontal)

--- a/Widget/Widget Views/TodayWidget.swift
+++ b/Widget/Widget Views/TodayWidget.swift
@@ -60,10 +60,12 @@ struct TodayWidgetView : View {
 						Spacer()
 						HStack {
 							Spacer()
-							Text(L10n.todayCount(entry.widgetData.currentTodayCount - maxCount()))
-								.font(.caption2)
-								.bold()
-								.foregroundColor(.secondary)
+							if entry.widgetData.currentTodayCount - maxCount() > 0 {
+								Text(L10n.todayCount(entry.widgetData.currentTodayCount - maxCount()))
+									.font(.caption2)
+									.bold()
+									.foregroundColor(.secondary)
+							}
 						}
 					}
 					.padding(.horizontal)

--- a/Widget/Widget Views/TodayWidget.swift
+++ b/Widget/Widget Views/TodayWidget.swift
@@ -23,34 +23,53 @@ struct TodayWidgetView : View {
 		}
 		else {
 			GeometryReader { metrics in
-				HStack(alignment: .top, spacing: 4) {
-					VStack(alignment: .leading, spacing: -4) {
+				HStack {
+					VStack {
 						todayImage
+							.padding(.vertical, 12)
+							.padding(.leading, 8)
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentTodayCount)).bold().font(.callout).minimumScaleFactor(0.5).lineLimit(1)
-						Text(L10n.today.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
-					}
-					.frame(width: metrics.size.width * 0.15)
-					.padding(.trailing, 4)
 					
-					VStack(alignment:.leading, spacing: 0) {
-						ForEach(0..<maxCount(), content: { i in
-							if i != 0 {
-								Divider()
-								ArticleItemView(article: entry.widgetData.todayArticles[i],
-												deepLink: WidgetDeepLink.todayArticle(id: entry.widgetData.todayArticles[i].id).url)
-									.padding(.top, 8)
-									.padding(.bottom, 4)
-							} else {
-								ArticleItemView(article: entry.widgetData.unreadArticles[i],
-												deepLink: WidgetDeepLink.todayArticle(id: entry.widgetData.todayArticles[i].id).url)
-									.padding(.bottom, 4)
-							}
-							
-						})
+					}
+				}
+				.frame(width: metrics.size.width * 0.15)
+				
+				Spacer()
+				
+				VStack(alignment:.leading, spacing: 0) {
+					ForEach(0..<maxCount(), content: { i in
+						if i != 0 {
+							Divider()
+							ArticleItemView(article: entry.widgetData.todayArticles[i],
+											deepLink: WidgetDeepLink.todayArticle(id: entry.widgetData.todayArticles[i].id).url)
+								.padding(.top, 8)
+								.padding(.bottom, 4)
+						} else {
+							ArticleItemView(article: entry.widgetData.todayArticles[i],
+											deepLink: WidgetDeepLink.todayArticle(id: entry.widgetData.todayArticles[i].id).url)
+								.padding(.bottom, 4)
+						}
+					})
+					Spacer()
+				}
+				.padding(.leading, metrics.size.width * 0.175)
+				.padding([.bottom, .trailing])
+				.padding(.top, 12)
+				.overlay(
+					 VStack {
 						Spacer()
-					}.padding(.leading, 4)
-				}.padding()
+						HStack {
+							Spacer()
+							Text(L10n.todayCount(entry.widgetData.currentTodayCount - maxCount()))
+								.font(.caption2)
+								.bold()
+								.foregroundColor(.secondary)
+						}
+					}
+					.padding(.horizontal)
+					.padding(.bottom, 6)
+				)
+			
 			}.widgetURL(WidgetDeepLink.today.url)
 		}
 	}

--- a/Widget/Widget Views/UnreadWidget.swift
+++ b/Widget/Widget Views/UnreadWidget.swift
@@ -23,43 +23,61 @@ struct UnreadWidgetView : View {
 		}
 		else {
 			GeometryReader { metrics in
-				HStack(alignment: .top, spacing: 4) {
-					VStack(alignment: .leading, spacing: -4) {
+				HStack {
+					VStack {
 						unreadImage
+							.padding(.vertical, 12)
+							.padding(.leading, 8)
 						Spacer()
-						Text(L10n.localizedCount(entry.widgetData.currentUnreadCount)).bold().font(.callout).minimumScaleFactor(0.5).lineLimit(1)
-						Text(L10n.unread.lowercased()).bold().font(Font.system(.footnote).lowercaseSmallCaps()).minimumScaleFactor(0.5).lineLimit(1)
-					}
-					.frame(width: metrics.size.width * 0.15)
-					.padding(.trailing, 4)
 					
-					VStack(alignment:.leading, spacing: 0) {
-						ForEach(0..<maxCount(), content: { i in
-							if i != 0 {
-								Divider()
-								ArticleItemView(article: entry.widgetData.unreadArticles[i],
-												deepLink: WidgetDeepLink.unreadArticle(id: entry.widgetData.unreadArticles[i].id).url)
-									.padding(.top, 8)
-									.padding(.bottom, 4)
-							} else {
-								ArticleItemView(article: entry.widgetData.unreadArticles[i],
-												deepLink: WidgetDeepLink.unreadArticle(id: entry.widgetData.unreadArticles[i].id).url)
-									.padding(.bottom, 4)
-							}
-							
-						})
+					}
+				}
+				.frame(width: metrics.size.width * 0.15)
+				
+				Spacer()
+				
+				VStack(alignment:.leading, spacing: 0) {
+					ForEach(0..<maxCount(), content: { i in
+						if i != 0 {
+							Divider()
+							ArticleItemView(article: entry.widgetData.unreadArticles[i],
+											deepLink: WidgetDeepLink.unreadArticle(id: entry.widgetData.unreadArticles[i].id).url)
+								.padding(.top, 8)
+								.padding(.bottom, 4)
+						} else {
+							ArticleItemView(article: entry.widgetData.unreadArticles[i],
+											deepLink: WidgetDeepLink.unreadArticle(id: entry.widgetData.unreadArticles[i].id).url)
+								.padding(.bottom, 4)
+						}
+					})
+					Spacer()
+				}
+				.padding(.leading, metrics.size.width * 0.175)
+				.padding([.bottom, .trailing])
+				.padding(.top, 12)
+				.overlay(
+					 VStack {
 						Spacer()
-					}.padding(.leading, 4)
-				}.padding()
-			}.widgetURL(WidgetDeepLink.unread.url)
+						HStack {
+							Spacer()
+							Text(L10n.unreadCount(entry.widgetData.currentUnreadCount - maxCount()))
+								.font(.caption2)
+								.bold()
+								.foregroundColor(.secondary)
+						}
+					}
+					.padding(.horizontal)
+					.padding(.bottom, 6)
+				)
+			}
+			.widgetURL(WidgetDeepLink.unread.url)
 		}
 	}
 	
 	var unreadImage: some View {
 		Image(systemName: "largecircle.fill.circle")
 			.resizable()
-			.frame(width: 30, height: 30, alignment: .center)
-			.cornerRadius(4)
+			.frame(width: 30, height: 30, alignment: .top)
 			.foregroundColor(.accentColor)
 	}
 	

--- a/Widget/Widget Views/UnreadWidget.swift
+++ b/Widget/Widget Views/UnreadWidget.swift
@@ -60,10 +60,12 @@ struct UnreadWidgetView : View {
 						Spacer()
 						HStack {
 							Spacer()
-							Text(L10n.unreadCount(entry.widgetData.currentUnreadCount - maxCount()))
-								.font(.caption2)
-								.bold()
-								.foregroundColor(.secondary)
+							if entry.widgetData.currentUnreadCount - maxCount() > 0 {
+								Text(L10n.unreadCount(entry.widgetData.currentUnreadCount - maxCount()))
+									.font(.caption2)
+									.bold()
+									.foregroundColor(.secondary)
+							}
 						}
 					}
 					.padding(.horizontal)


### PR DESCRIPTION
Count text is now placed under the article list. 

- This keeps the widget _icon_ leading `VStack` at a consistent size—it was previously changing based on Unread/Starred/Today text.
- It also stops the count text from moving based on the number of articles on display.

![Simulator Screen Shot - iPhone 12 Pro - 2021-01-29 at 22 43 18](https://user-images.githubusercontent.com/7046652/106288743-633b4a80-6283-11eb-8e73-cf7d32457b42.png)


Fixes #2737 