### PR TITLE
Fixes context menu logic

### DIFF
--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -4430,7 +4430,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if ! command -v swiftgen &> /dev/null\nthen\n    echo \"swiftgen could not be found\"\n    exit\nfi\n\nswiftgen run strings -t structured-swift5 \"$PROJECT_DIR/Widget/Resources/en.lproj/Localizable.strings\" \"$PROJECT_DIR/Widget/Resources/Localizable.stringsdict\" --output \"$PROJECT_DIR/Widget/Resources/Localized.swift\";\n";
+			shellScript = "if ! command -v swiftgen &> /dev/null\nthen\n    echo \"swiftgen could not be found\"\n    exit\nfi\n\narch -x86_64 swiftgen run strings -t structured-swift5 \"$PROJECT_DIR/Widget/Resources/en.lproj/Localizable.strings\" \"$PROJECT_DIR/Widget/Resources/Localizable.stringsdict\" --output \"$PROJECT_DIR/Widget/Resources/Localized.swift\";\n";
 		};
 		51327793259101E50064F1E7 /* Delete Unnecessary Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -477,6 +477,7 @@ class MasterTimelineViewController: UITableViewController, UndoableCommandRunner
 			resetEstimatedRowHeight()
 			reloadAllVisibleCells()
 		}
+		updateToolbar()
 	}
 	
 	@objc func contentSizeCategoryDidChange(_ note: Notification) {
@@ -675,8 +676,8 @@ private extension MasterTimelineViewController {
 				let settingsAction = UIAction(title: NSLocalizedString("Settings", comment: "Settings"), image: UIImage(systemName: "gear")!, discoverabilityTitle: NSLocalizedString("You can turn this confirmation off in Settings.", comment: "You can turn this confirmation off in Settings.")) { [weak self] action in
 					self?.coordinator.showSettings(scrollToArticlesSection: true)
 				}
-				
 				markAllAsReadButton.menu = UIMenu(title: NSLocalizedString(title, comment: title), image: nil, identifier: nil, children: [settingsAction, markAsReadAction])
+				markAllAsReadButton.action = nil
 			} else {
 				markAllAsReadButton.action = #selector(MasterTimelineViewController.markAllAsRead(_:))
 			}


### PR DESCRIPTION
Prevents both a menu and action being attached to the `markAllAsRead` button. This caused issues on iPad where the popover would show instead of the menu. When the user changes the preference the toolbar is now rebuilt.

This commit also fixes the widget building on M1 where SwiftGen is available.

Fixes #2777 