### PR TITLE
: class changed to : AnyObject for protocols

### DIFF
--- a/Account/Sources/Account/AccountMetadata.swift
+++ b/Account/Sources/Account/AccountMetadata.swift
@@ -9,7 +9,7 @@
 import Foundation
 import RSWeb
 
-protocol AccountMetadataDelegate: class {
+protocol AccountMetadataDelegate: AnyObject {
 	func valueDidChange(_ accountMetadata: AccountMetadata, key: AccountMetadata.CodingKeys)
 }
 

--- a/Account/Sources/Account/Container.swift
+++ b/Account/Sources/Account/Container.swift
@@ -16,7 +16,7 @@ extension Notification.Name {
 	public static let ChildrenDidChange = Notification.Name("ChildrenDidChange")
 }
 
-public protocol Container: class, ContainerIdentifiable {
+public protocol Container: AnyObject, ContainerIdentifiable {
 
 	var account: Account? { get }
 	var topLevelWebFeeds: Set<WebFeed> { get set }

--- a/Account/Sources/Account/FeedProvider/FeedProviderManager.swift
+++ b/Account/Sources/Account/FeedProvider/FeedProviderManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol FeedProviderManagerDelegate: class {
+public protocol FeedProviderManagerDelegate: AnyObject {
 	var activeFeedProviders: [FeedProvider] { get }
 }
 

--- a/Account/Sources/Account/FeedProvider/Reddit/RedditFeedProviderTokenRefreshOperation.swift
+++ b/Account/Sources/Account/FeedProvider/Reddit/RedditFeedProviderTokenRefreshOperation.swift
@@ -11,7 +11,7 @@ import RSCore
 import OAuthSwift
 import Secrets
 
-protocol RedditFeedProviderTokenRefreshOperationDelegate: class {
+protocol RedditFeedProviderTokenRefreshOperationDelegate: AnyObject {
 	var username: String? { get }
 	var oauthTokenLastRefresh: Date? { get set }
 	var oauthToken: String { get set }

--- a/Account/Sources/Account/Feedly/FeedlyAPICaller.swift
+++ b/Account/Sources/Account/Feedly/FeedlyAPICaller.swift
@@ -10,7 +10,7 @@ import Foundation
 import RSWeb
 import Secrets
 
-protocol FeedlyAPICallerDelegate: class {
+protocol FeedlyAPICallerDelegate: AnyObject {
 	/// Implemented by the `FeedlyAccountDelegate` reauthorize the client with a fresh OAuth token so the client can retry the unauthorized request.
 	/// Pass `true` to the completion handler if the failing request should be retried with a fresh token or `false` if the unauthorized request should complete with the original failure error.
 	func reauthorizeFeedlyAPICaller(_ caller: FeedlyAPICaller, completionHandler: @escaping (Bool) -> ())

--- a/Account/Sources/Account/Feedly/Models/FeedlyEntryIdentifierProviding.swift
+++ b/Account/Sources/Account/Feedly/Models/FeedlyEntryIdentifierProviding.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol FeedlyEntryIdentifierProviding: class {
+protocol FeedlyEntryIdentifierProviding: AnyObject {
 	var entryIds: Set<String> { get }
 }
 

--- a/Account/Sources/Account/Feedly/OAuthAccountAuthorizationOperation.swift
+++ b/Account/Sources/Account/Feedly/OAuthAccountAuthorizationOperation.swift
@@ -10,7 +10,7 @@ import Foundation
 import AuthenticationServices
 import RSCore
 
-public protocol OAuthAccountAuthorizationOperationDelegate: class {
+public protocol OAuthAccountAuthorizationOperationDelegate: AnyObject {
 	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didCreate account: Account)
 	func oauthAccountAuthorizationOperation(_ operation: OAuthAccountAuthorizationOperation, didFailWith error: Error)
 }

--- a/Account/Sources/Account/Feedly/OAuthAcessTokenRefreshing.swift
+++ b/Account/Sources/Account/Feedly/OAuthAcessTokenRefreshing.swift
@@ -40,7 +40,7 @@ public protocol OAuthAcessTokenRefreshRequesting {
 }
 
 /// Implemented by concrete types to perform the actual request.
-protocol OAuthAccessTokenRefreshing: class {
+protocol OAuthAccessTokenRefreshing: AnyObject {
 	
 	func refreshAccessToken(with refreshToken: String, client: OAuthAuthorizationClient, completion: @escaping (Result<OAuthAuthorizationGrant, Error>) -> ())
 }

--- a/Account/Sources/Account/Feedly/Operations/FeedlyCheckpointOperation.swift
+++ b/Account/Sources/Account/Feedly/Operations/FeedlyCheckpointOperation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol FeedlyCheckpointOperationDelegate: class {
+protocol FeedlyCheckpointOperationDelegate: AnyObject {
 	func feedlyCheckpointOperationDidReachCheckpoint(_ operation: FeedlyCheckpointOperation)
 }
 

--- a/Account/Sources/Account/Feedly/Operations/FeedlyGetCollectionsOperation.swift
+++ b/Account/Sources/Account/Feedly/Operations/FeedlyGetCollectionsOperation.swift
@@ -9,7 +9,7 @@
 import Foundation
 import os.log
 
-protocol FeedlyCollectionProviding: class {
+protocol FeedlyCollectionProviding: AnyObject {
 	var collections: [FeedlyCollection] { get }
 }
 

--- a/Account/Sources/Account/Feedly/Operations/FeedlyGetStreamContentsOperation.swift
+++ b/Account/Sources/Account/Feedly/Operations/FeedlyGetStreamContentsOperation.swift
@@ -19,7 +19,7 @@ protocol FeedlyParsedItemProviding {
 	var parsedEntries: Set<ParsedItem> { get }
 }
 
-protocol FeedlyGetStreamContentsOperationDelegate: class {
+protocol FeedlyGetStreamContentsOperationDelegate: AnyObject {
 	func feedlyGetStreamContentsOperation(_ operation: FeedlyGetStreamContentsOperation, didGetContentsOf stream: FeedlyStream)
 }
 

--- a/Account/Sources/Account/Feedly/Operations/FeedlyGetStreamIdsOperation.swift
+++ b/Account/Sources/Account/Feedly/Operations/FeedlyGetStreamIdsOperation.swift
@@ -9,7 +9,7 @@
 import Foundation
 import os.log
 
-protocol FeedlyGetStreamIdsOperationDelegate: class {
+protocol FeedlyGetStreamIdsOperationDelegate: AnyObject {
 	func feedlyGetStreamIdsOperation(_ operation: FeedlyGetStreamIdsOperation, didGet streamIds: FeedlyStreamIds)
 }
 

--- a/Account/Sources/Account/Feedly/Operations/FeedlyOperation.swift
+++ b/Account/Sources/Account/Feedly/Operations/FeedlyOperation.swift
@@ -10,7 +10,7 @@ import Foundation
 import RSWeb
 import RSCore
 
-protocol FeedlyOperationDelegate: class {
+protocol FeedlyOperationDelegate: AnyObject {
 	func feedlyOperation(_ operation: FeedlyOperation, didFailWith error: Error)
 }
 

--- a/Account/Sources/Account/Feedly/Operations/FeedlyRequestStreamsOperation.swift
+++ b/Account/Sources/Account/Feedly/Operations/FeedlyRequestStreamsOperation.swift
@@ -9,7 +9,7 @@
 import Foundation
 import os.log
 
-protocol FeedlyRequestStreamsOperationDelegate: class {
+protocol FeedlyRequestStreamsOperationDelegate: AnyObject {
 	func feedlyRequestStreamsOperation(_ operation: FeedlyRequestStreamsOperation, enqueue collectionStreamOperation: FeedlyGetStreamContentsOperation)
 }
 

--- a/Account/Sources/Account/Feedly/Operations/FeedlySearchOperation.swift
+++ b/Account/Sources/Account/Feedly/Operations/FeedlySearchOperation.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-protocol FeedlySearchService: class {
+protocol FeedlySearchService: AnyObject {
 	func getFeeds(for query: String, count: Int, locale: String, completion: @escaping (Result<FeedlyFeedsSearchResponse, Error>) -> ())
 }
 
-protocol FeedlySearchOperationDelegate: class {
+protocol FeedlySearchOperationDelegate: AnyObject {
 	func feedlySearchOperation(_ operation: FeedlySearchOperation, didGet response: FeedlyFeedsSearchResponse)
 }
 

--- a/Account/Sources/Account/Feedly/Services/FeedlyGetCollectionsService.swift
+++ b/Account/Sources/Account/Feedly/Services/FeedlyGetCollectionsService.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-protocol FeedlyGetCollectionsService: class {
+protocol FeedlyGetCollectionsService: AnyObject {
 	func getCollections(completion: @escaping (Result<[FeedlyCollection], Error>) -> ())
 }

--- a/Account/Sources/Account/Feedly/Services/FeedlyGetEntriesService.swift
+++ b/Account/Sources/Account/Feedly/Services/FeedlyGetEntriesService.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-protocol FeedlyGetEntriesService: class {
+protocol FeedlyGetEntriesService: AnyObject {
 	func getEntries(for ids: Set<String>, completion: @escaping (Result<[FeedlyEntry], Error>) -> ())
 }

--- a/Account/Sources/Account/Feedly/Services/FeedlyGetStreamContentsService.swift
+++ b/Account/Sources/Account/Feedly/Services/FeedlyGetStreamContentsService.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-protocol FeedlyGetStreamContentsService: class {
+protocol FeedlyGetStreamContentsService: AnyObject {
 	func getStreamContents(for resource: FeedlyResourceId, continuation: String?, newerThan: Date?, unreadOnly: Bool?, completion: @escaping (Result<FeedlyStream, Error>) -> ())
 }

--- a/Account/Sources/Account/Feedly/Services/FeedlyGetStreamIdsService.swift
+++ b/Account/Sources/Account/Feedly/Services/FeedlyGetStreamIdsService.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-protocol FeedlyGetStreamIdsService: class {
+protocol FeedlyGetStreamIdsService: AnyObject {
 	func getStreamIds(for resource: FeedlyResourceId, continuation: String?, newerThan: Date?, unreadOnly: Bool?, completion: @escaping (Result<FeedlyStreamIds, Error>) -> ())
 }

--- a/Account/Sources/Account/Feedly/Services/FeedlyMarkArticlesService.swift
+++ b/Account/Sources/Account/Feedly/Services/FeedlyMarkArticlesService.swift
@@ -30,6 +30,6 @@ enum FeedlyMarkAction: String {
 	 }
  }
 
-protocol FeedlyMarkArticlesService: class {
+protocol FeedlyMarkArticlesService: AnyObject {
 	func mark(_ articleIds: Set<String>, as action: FeedlyMarkAction, completion: @escaping (Result<Void, Error>) -> ())
 }

--- a/Account/Sources/Account/WebFeedMetadata.swift
+++ b/Account/Sources/Account/WebFeedMetadata.swift
@@ -10,7 +10,7 @@ import Foundation
 import RSWeb
 import Articles
 
-protocol WebFeedMetadataDelegate: class {
+protocol WebFeedMetadataDelegate: AnyObject {
 	func valueDidChange(_ feedMetadata: WebFeedMetadata, key: WebFeedMetadata.CodingKeys)
 }
 

--- a/Account/Tests/AccountTests/TestTransport.swift
+++ b/Account/Tests/AccountTests/TestTransport.swift
@@ -10,7 +10,7 @@ import Foundation
 import RSWeb
 import XCTest
 
-protocol TestTransportMockResponseProviding: class {
+protocol TestTransportMockResponseProviding: AnyObject {
 	func mockResponseFileUrl(for components: URLComponents) -> URL?
 }
 

--- a/Mac/Inspector/InspectorWindowController.swift
+++ b/Mac/Inspector/InspectorWindowController.swift
@@ -8,7 +8,7 @@
 
 import AppKit
 
-protocol Inspector: class {
+protocol Inspector: AnyObject {
 
 	var objects: [Any]? { get set }
 	var isFallbackInspector: Bool { get } // Can handle nothing-to-inspect or unexpected type of objects.

--- a/Mac/MainWindow/AddFeed/AddFeedWIndowController.swift
+++ b/Mac/MainWindow/AddFeed/AddFeedWIndowController.swift
@@ -15,7 +15,7 @@ enum AddFeedWindowControllerType {
 	case twitterFeed
 }
 
-protocol AddFeedWindowControllerDelegate: class {
+protocol AddFeedWindowControllerDelegate: AnyObject {
 
 	// userEnteredURL will have already been validated and normalized.
 	func addFeedWindowController(_: AddFeedWindowController, userEnteredURL: URL, userEnteredTitle: String?, container: Container)

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -12,7 +12,7 @@ import RSCore
 import RSWeb
 import Articles
 
-protocol DetailWebViewControllerDelegate: class {
+protocol DetailWebViewControllerDelegate: AnyObject {
 	func mouseDidEnter(_: DetailWebViewController, link: String)
 	func mouseDidExit(_: DetailWebViewController, link: String)
 }

--- a/Mac/MainWindow/Sidebar/SidebarViewController.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController.swift
@@ -16,7 +16,7 @@ extension Notification.Name {
 	static let appleSideBarDefaultIconSizeChanged = Notification.Name("AppleSideBarDefaultIconSizeChanged")
 }
 
-protocol SidebarDelegate: class {
+protocol SidebarDelegate: AnyObject {
 	func sidebarSelectionDidChange(_: SidebarViewController, selectedObjects: [AnyObject]?)
 	func unreadCount(for: AnyObject) -> Int
 	func sidebarInvalidatedRestorationState(_: SidebarViewController)

--- a/Mac/MainWindow/Timeline/TimelineContainerViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineContainerViewController.swift
@@ -10,7 +10,7 @@ import AppKit
 import Account
 import Articles
 
-protocol TimelineContainerViewControllerDelegate: class {
+protocol TimelineContainerViewControllerDelegate: AnyObject {
 	func timelineSelectionDidChange(_: TimelineContainerViewController, articles: [Article]?, mode: TimelineSourceMode)
 	func timelineRequestedWebFeedSelection(_: TimelineContainerViewController, webFeed: WebFeed)
 	func timelineInvalidatedRestorationState(_: TimelineContainerViewController)

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -12,7 +12,7 @@ import Articles
 import Account
 import os.log
 
-protocol TimelineDelegate: class  {
+protocol TimelineDelegate: AnyObject  {
 	func timelineSelectionDidChange(_: TimelineViewController, selectedArticles: [Article]?)
 	func timelineRequestedWebFeedSelection(_: TimelineViewController, webFeed: WebFeed)
 	func timelineInvalidatedRestorationState(_: TimelineViewController)

--- a/Mac/Preferences/ExtensionPoints/ExtensionPointPreferencesViewController.swift
+++ b/Mac/Preferences/ExtensionPoints/ExtensionPointPreferencesViewController.swift
@@ -12,7 +12,7 @@ import AuthenticationServices
 import OAuthSwift
 import Secrets
 
-protocol ExtensionPointPreferencesEnabler: class {
+protocol ExtensionPointPreferencesEnabler: AnyObject {
 	func enable(_ extensionPointType: ExtensionPoint.Type)
 }
 

--- a/Multiplatform/Shared/Sidebar/SidebarModel.swift
+++ b/Multiplatform/Shared/Sidebar/SidebarModel.swift
@@ -12,7 +12,7 @@ import RSCore
 import Account
 import Articles
 
-protocol SidebarModelDelegate: class {
+protocol SidebarModelDelegate: AnyObject {
 	func unreadCount(for: Feed) -> Int
 }
 

--- a/Multiplatform/Shared/Timeline/TimelineModel.swift
+++ b/Multiplatform/Shared/Timeline/TimelineModel.swift
@@ -16,7 +16,7 @@ import RSCore
 import Account
 import Articles
 
-protocol TimelineModelDelegate: class {
+protocol TimelineModelDelegate: AnyObject {
 	var selectedFeedsPublisher: AnyPublisher<[Feed], Never>? { get }
 	func timelineRequestedWebFeedSelection(_: TimelineModel, webFeed: WebFeed)
 }

--- a/Multiplatform/iOS/Article/WebViewController.swift
+++ b/Multiplatform/iOS/Article/WebViewController.swift
@@ -14,7 +14,7 @@ import Articles
 import SafariServices
 import MessageUI
 
-protocol WebViewControllerDelegate: class {
+protocol WebViewControllerDelegate: AnyObject {
 	func webViewController(_: WebViewController, articleExtractorButtonStateDidUpdate: ArticleExtractorButtonState)
 }
 

--- a/Multiplatform/macOS/Article/WebViewController.swift
+++ b/Multiplatform/macOS/Article/WebViewController.swift
@@ -11,7 +11,7 @@ import Combine
 import RSCore
 import Articles
 
-protocol WebViewControllerDelegate: class {
+protocol WebViewControllerDelegate: AnyObject {
 	func webViewController(_: WebViewController, articleExtractorButtonStateDidUpdate: ArticleExtractorButtonState)
 }
 

--- a/Shared/SmartFeeds/PseudoFeed.swift
+++ b/Shared/SmartFeeds/PseudoFeed.swift
@@ -13,7 +13,7 @@ import Articles
 import Account
 import RSCore
 
-protocol PseudoFeed: class, Feed, SmallIconProvider, PasteboardWriterOwner {
+protocol PseudoFeed: AnyObject, Feed, SmallIconProvider, PasteboardWriterOwner {
 
 }
 
@@ -24,7 +24,7 @@ import Articles
 import Account
 import RSCore
 
-protocol PseudoFeed: class, Feed, SmallIconProvider {
+protocol PseudoFeed: AnyObject, Feed, SmallIconProvider {
 	
 }
 

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -14,7 +14,7 @@ import Articles
 import SafariServices
 import MessageUI
 
-protocol WebViewControllerDelegate: class {
+protocol WebViewControllerDelegate: AnyObject {
 	func webViewController(_: WebViewController, articleExtractorButtonStateDidUpdate: ArticleExtractorButtonState)
 }
 

--- a/iOS/MasterFeed/Cell/MasterFeedTableViewCell.swift
+++ b/iOS/MasterFeed/Cell/MasterFeedTableViewCell.swift
@@ -11,7 +11,7 @@ import RSCore
 import Account
 import RSTree
 
-protocol MasterFeedTableViewCellDelegate: class {
+protocol MasterFeedTableViewCellDelegate: AnyObject {
 	func masterFeedTableViewCellDisclosureDidToggle(_ sender: MasterFeedTableViewCell, expanding: Bool)
 }
 

--- a/iOS/ShareExtension/ShareFolderPickerController.swift
+++ b/iOS/ShareExtension/ShareFolderPickerController.swift
@@ -10,7 +10,7 @@ import UIKit
 import Account
 import RSCore
 
-protocol ShareFolderPickerControllerDelegate: class {
+protocol ShareFolderPickerControllerDelegate: AnyObject {
 	func shareFolderPickerDidSelect(_ container: ExtensionContainer)
 }
 


### PR DESCRIPTION
`: class` is deprecated in 5.4 but the change to `: AnyObject` can be done now. 