### PR TITLE
Adds author name as a searchable field

### DIFF
--- a/ArticlesDatabase/Sources/ArticlesDatabase/ArticlesDatabase.swift
+++ b/ArticlesDatabase/Sources/ArticlesDatabase/ArticlesDatabase.swift
@@ -332,7 +332,7 @@ private extension ArticlesDatabase {
 
 	CREATE INDEX if not EXISTS statuses_starred_index on statuses (starred);
 
-	CREATE VIRTUAL TABLE if not EXISTS search using fts4(title, body);
+	CREATE VIRTUAL TABLE if not EXISTS search using fts4(title, body, authors);
 
 	CREATE TRIGGER if not EXISTS articles_after_delete_trigger_delete_search_text after delete on articles begin delete from search where rowid = OLD.searchRowID; end;
 	"""

--- a/ArticlesDatabase/Sources/ArticlesDatabase/ArticlesTable.swift
+++ b/ArticlesDatabase/Sources/ArticlesDatabase/ArticlesTable.swift
@@ -158,8 +158,8 @@ final class ArticlesTable: DatabaseTable {
             art.contentText,
             art.summary,
             art.searchRowID,
-            (SELECT GROUP_CONCAT(name SEPARATOR ' ')
-            FROM authorLookup as autL
+            (SELECT GROUP_CONCAT(name, ' ')
+            FROM authorsLookup as autL
             JOIN authors as aut ON autL.authorID = aut.authorID
             WHERE art.articleID = autL.articleID
             GROUP BY autl.articleID) as authors

--- a/ArticlesDatabase/Sources/ArticlesDatabase/SearchTable.swift
+++ b/ArticlesDatabase/Sources/ArticlesDatabase/SearchTable.swift
@@ -61,7 +61,7 @@ final class ArticleSearchInfo: Hashable {
 	// MARK: Equatable
 
 	static func == (lhs: ArticleSearchInfo, rhs: ArticleSearchInfo) -> Bool {
-		return lhs.articleID == rhs.articleID && lhs.title == rhs.title && lhs.contentHTML == rhs.contentHTML && lhs.contentText == rhs.contentText && lhs.summary == rhs.summary && lhs.searchRowID == rhs.searchRowID
+        return lhs.articleID == rhs.articleID && lhs.title == rhs.title && lhs.authorsNames == rhs.authorsNames && lhs.contentHTML == rhs.contentHTML && lhs.contentText == rhs.contentText && lhs.summary == rhs.summary && lhs.searchRowID == rhs.searchRowID
 	}
 }
 
@@ -203,7 +203,7 @@ private extension SearchTable {
 			return nil
 		}
 		let placeholders = NSString.rs_SQLValueList(withPlaceholders: UInt(searchRowIDs.count))!
-		let sql = "select rowid, title, body from \(name) where rowid in \(placeholders);"
+		let sql = "select rowid, title, body, authors from \(name) where rowid in \(placeholders);"
 		guard let resultSet = database.executeQuery(sql, withArgumentsIn: searchRowIDs) else {
 			return nil
 		}

--- a/ArticlesDatabase/Sources/ArticlesDatabase/SearchTable.swift
+++ b/ArticlesDatabase/Sources/ArticlesDatabase/SearchTable.swift
@@ -17,6 +17,7 @@ final class ArticleSearchInfo: Hashable {
 
 	let articleID: String
 	let title: String?
+    let authorsNames: String?
 	let contentHTML: String?
 	let contentText: String?
 	let summary: String?
@@ -37,9 +38,10 @@ final class ArticleSearchInfo: Hashable {
 		return s.strippingHTML().collapsingWhitespace
 	}()
 
-	init(articleID: String, title: String?, contentHTML: String?, contentText: String?, summary: String?, searchRowID: Int?) {
+    init(articleID: String, title: String?, authorsNames: String?, contentHTML: String?, contentText: String?, summary: String?, searchRowID: Int?) {
 		self.articleID = articleID
 		self.title = title
+        self.authorsNames = authorsNames
 		self.contentHTML = contentHTML
 		self.contentText = contentText
 		self.summary = summary
@@ -47,7 +49,7 @@ final class ArticleSearchInfo: Hashable {
 	}
 
 	convenience init(article: Article) {
-		self.init(articleID: article.articleID, title: article.title, contentHTML: article.contentHTML, contentText: article.contentText, summary: article.summary, searchRowID: nil)
+        self.init(articleID: article.articleID, title: article.title, authorsNames: article.authors?.map({ $0.name }).reduce("", { $0.appending("").appending($1 ?? "") }), contentHTML: article.contentHTML, contentText: article.contentText, summary: article.summary, searchRowID: nil)
 	}
 
 	// MARK: Hashable
@@ -127,7 +129,7 @@ private extension SearchTable {
 	}
 
 	func insert(_ article: ArticleSearchInfo, _ database: FMDatabase) -> Int {
-		let rowDictionary: DatabaseDictionary = [DatabaseKey.body: article.bodyForIndex, DatabaseKey.title: article.title ?? ""]
+        let rowDictionary: DatabaseDictionary = [DatabaseKey.body: article.bodyForIndex, DatabaseKey.title: article.title ?? "", DatabaseKey.authors: article.authorsNames ?? ""]
 		insertRow(rowDictionary, insertType: .normal, in: database)
 		return Int(database.lastInsertRowId())
 	}

--- a/ArticlesDatabase/Sources/ArticlesDatabase/SearchTable.swift
+++ b/ArticlesDatabase/Sources/ArticlesDatabase/SearchTable.swift
@@ -49,7 +49,8 @@ final class ArticleSearchInfo: Hashable {
 	}
 
 	convenience init(article: Article) {
-        self.init(articleID: article.articleID, title: article.title, authorsNames: article.authors?.map({ $0.name }).reduce("", { $0.appending("").appending($1 ?? "") }), contentHTML: article.contentHTML, contentText: article.contentText, summary: article.summary, searchRowID: nil)
+        let authorsNames = article.authors?.map({ $0.name }).reduce("", { $0.appending("").appending($1 ?? "") })
+        self.init(articleID: article.articleID, title: article.title, authorsNames: authorsNames, contentHTML: article.contentHTML, contentText: article.contentText, summary: article.summary, searchRowID: nil)
 	}
 
 	// MARK: Hashable


### PR DESCRIPTION
Fixes https://github.com/Ranchero-Software/NetNewsWire/issues/1695

Users are now able to search for an author name and get as results, articles by authors with that name

Did this by adding an `authors` column to the `search` table and filling it correctly when building the text index
Database also migrates correctly when coming from a previous version by recreating the `search` table and the index