### PR TITLE
Fix #2833: Titlebar is overlapped by toolbar in fullscreen

### DIFF
--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -98,14 +98,25 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 
 		box.addSubview(webView)
 
-		let constraints = [
-			webView.topAnchor.constraint(equalTo: view.topAnchor),
-			webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-			webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-			webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-		]
+		// Use the safe area layout guides if they are available.
+		if #available(OSX 11.0, *) {
+			let constraints = [
+				webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+				webView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+				webView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+				webView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+			]
+			NSLayoutConstraint.activate(constraints)
+		} else {
+			let constraints = [
+				webView.topAnchor.constraint(equalTo: view.topAnchor),
+				webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+				webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+				webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+			]
+			NSLayoutConstraint.activate(constraints)
+		}
 
-		NSLayoutConstraint.activate(constraints)
 
 		// Hide the web view until the first reload (navigation) is complete (plus some delay) to avoid the awful white flash that happens on the initial display in dark mode.
 		// See bug #901.


### PR DESCRIPTION
Fix issue where detail web view would be overlapped by the toolbar in full screen by setting web view constraints to use the `safeAreaLayoutGuide` in macOS 11+.