### PR TITLE
tweaks to pre/code css styles

### DIFF
--- a/Shared/Article Rendering/shared.css
+++ b/Shared/Article Rendering/shared.css
@@ -137,7 +137,6 @@ pre {
 	margin: 0;
 	overflow: auto;
 	overflow-y: hidden;
-
 	word-wrap: normal;
 	word-break: normal;
 }
@@ -145,10 +144,16 @@ pre {
 pre {
 	line-height: 1.4286em;
 }
+
 code, pre {
 	font-family: "SF Mono", Menlo, "Courier New", Courier, monospace;
-	font-size: .8235em;
+	font-size: 1em;
 	-webkit-hyphens: none;
+}
+
+pre code {
+	letter-spacing: -.027em;
+	font-size: 0.9375em;
 }
 
 .nnw-overflow {


### PR DESCRIPTION
Follows Apple’s example.

• `code` within normal text is sized to 1em
• `code` within `pre` is sized slightly smaller and the letter-spacing is tightened