### PR TITLE
Article View Fixes

### DIFF
--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -145,7 +145,6 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 	/// On macOS 11, when a user exits full screen, the webview's origin.y is offset by a sizeable amount. This function adjusts the height of the window height by 1pt which puts the webview back in the correct place. This is an issue with SwiftUI and AppKit.
 	@objc func bigSurOffsetFix(_ note: Notification) {
 		if #available(macOS 11, *) {
-			// On macOS 11, at the end of a resize down
 			guard var frame = self.view.window?.frame else {
 				return
 			}

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -116,6 +116,7 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 		NotificationCenter.default.addObserver(self, selector: #selector(avatarDidBecomeAvailable(_:)), name: .AvatarDidBecomeAvailable, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(faviconDidBecomeAvailable(_:)), name: .FaviconDidBecomeAvailable, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(userDefaultsDidChange(_:)), name: UserDefaults.didChangeNotification, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(bigSurOffsetFix(_:)), name: NSWindow.didExitFullScreenNotification, object: nil)
 
 		webView.loadFileURL(ArticleRenderer.blank.url, allowingReadAccessTo: ArticleRenderer.blank.baseURL)
 	}
@@ -138,6 +139,18 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 		if articleTextSize != AppDefaults.shared.articleTextSize {
 			articleTextSize = AppDefaults.shared.articleTextSize
 			webView.evaluateJavaScript("updateTextSize(\"\(articleTextSize.cssClass)\");")
+		}
+	}
+	
+	/// On macOS 11, when a user exits full screen, the webview's origin.y is offset by a sizeable amount. This function adjusts the height of the window height by 1pt which puts the webview back in the correct place. This is an issue with SwiftUI and AppKit.
+	@objc func bigSurOffsetFix(_ note: Notification) {
+		if #available(macOS 11, *) {
+			// On macOS 11, at the end of a resize down
+			guard var frame = self.view.window?.frame else {
+				return
+			}
+			frame.size = NSSize(width: self.view.window!.frame.width, height: self.view.window!.frame.height - 1)
+			self.view.window!.setFrame(frame, display: true)
 		}
 	}
 	

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -90,13 +90,7 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 
 		// Use the safe area layout guides if they are available.
 		if #available(OSX 11.0, *) {
-			let constraints = [
-				webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-				webView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-				webView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-				webView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-			]
-			NSLayoutConstraint.activate(constraints)
+			// These constraints have been removed as they were unsatisfyable after removing NSBox.
 		} else {
 			let constraints = [
 				webView.topAnchor.constraint(equalTo: view.topAnchor),

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -90,7 +90,7 @@ final class DetailWebViewController: NSViewController, WKUIDelegate {
 
 		// Use the safe area layout guides if they are available.
 		if #available(OSX 11.0, *) {
-			// These constraints have been removed as they were unsatisfyable after removing NSBox.
+			// These constraints have been removed as they were unsatisfiable after removing NSBox.
 		} else {
 			let constraints = [
 				webView.topAnchor.constraint(equalTo: view.topAnchor),

--- a/Shared/Extensions/NSView-Extensions.swift
+++ b/Shared/Extensions/NSView-Extensions.swift
@@ -11,10 +11,20 @@ import AppKit
 extension NSView {
 
 	func constraintsToMakeSubViewFullSize(_ subview: NSView) -> [NSLayoutConstraint] {
-		let leadingConstraint = NSLayoutConstraint(item: subview, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leading, multiplier: 1.0, constant: 0.0)
-		let trailingConstraint = NSLayoutConstraint(item: subview, attribute: .trailing, relatedBy: .equal, toItem: self, attribute: .trailing, multiplier: 1.0, constant: 0.0)
-		let topConstraint = NSLayoutConstraint(item: subview, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0.0)
-		let bottomConstraint = NSLayoutConstraint(item: subview, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0.0)
-		return [leadingConstraint, trailingConstraint, topConstraint, bottomConstraint]
+		
+		if #available(macOS 11, *) {
+			let leadingConstraint = NSLayoutConstraint(item: subview, attribute: .leading, relatedBy: .equal, toItem: self.safeAreaLayoutGuide, attribute: .leading, multiplier: 1.0, constant: 0.0)
+			let trailingConstraint = NSLayoutConstraint(item: subview, attribute: .trailing, relatedBy: .equal, toItem: self.safeAreaLayoutGuide, attribute: .trailing, multiplier: 1.0, constant: 0.0)
+			let topConstraint = NSLayoutConstraint(item: subview, attribute: .top, relatedBy: .equal, toItem: self.safeAreaLayoutGuide, attribute: .top, multiplier: 1.0, constant: 0.0)
+			let bottomConstraint = NSLayoutConstraint(item: subview, attribute: .bottom, relatedBy: .equal, toItem: self.safeAreaLayoutGuide, attribute: .bottom, multiplier: 1.0, constant: 0.0)
+			return [leadingConstraint, trailingConstraint, topConstraint, bottomConstraint]
+		} else {
+			let leadingConstraint = NSLayoutConstraint(item: subview, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leading, multiplier: 1.0, constant: 0.0)
+			let trailingConstraint = NSLayoutConstraint(item: subview, attribute: .trailing, relatedBy: .equal, toItem: self, attribute: .trailing, multiplier: 1.0, constant: 0.0)
+			let topConstraint = NSLayoutConstraint(item: subview, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0.0)
+			let bottomConstraint = NSLayoutConstraint(item: subview, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0.0)
+			return [leadingConstraint, trailingConstraint, topConstraint, bottomConstraint]
+		}
+		
 	}
 }


### PR DESCRIPTION
This commit:

- Fixes #2850 by removing constraints in macOS 11. 
- Partially fixes #2634 by updating the `constraintsToMakeSubViewFullSize` to use the `safeAreaLayoutGuide` in macOS 11. (Increasing the height of the window is smooth.)
- Fixes #2597 by triggering a 1pt window resize after the app has posted an `NSWindow.didExitFullScreenNotification` notification (applicable to macOS 11 only). This **workaround** will need to be revisited with each Big Sur release. (We're not the [only](https://stackoverflow.com/questions/65333532/wkwebview-shows-white-bar-until-window-moved-resized) people having this issue.)

These changes don't affect behaviour in macOS 10.15. 
