### PR TITLE
#2371 Checks footnote target before overriding browser default behavior

### DIFF
--- a/Shared/Article Rendering/newsfoot.js
+++ b/Shared/Article Rendering/newsfoot.js
@@ -140,12 +140,17 @@
 			if (targetId) break;
 		}
 		if (targetId === undefined) return;
-
+		
+		// Only override the default behaviour when we know we can find the
+		// target element
+		const targetElement = document.querySelector(`[id='${targetId}']`);
+		if (targetElement === null) return;
+				
 		ev.preventDefault();
 
 		installContainer(ev.target);
-		const content = document.querySelector(`[id='${targetId}']`).innerHTML;
-		void new Footnote(content, ev.target);
+				
+		void new Footnote(targetElement.innerHTML, ev.target);
     });
 										   
 	// Handle clicks on the footnote reverse link

--- a/Shared/Article Rendering/newsfoot.js
+++ b/Shared/Article Rendering/newsfoot.js
@@ -143,7 +143,7 @@
 		
 		// Only override the default behaviour when we know we can find the
 		// target element
-		const targetElement = document.querySelector(`[id='${targetId}']`);
+		const targetElement = document.getElementById(targetId);
 		if (targetElement === null) return;
 				
 		ev.preventDefault();


### PR DESCRIPTION
This change just checks the return value of the document query to find the footnote element; if not element is found then the browsers default behaviour (sending you to the link in your browser) is not overridden. 

Note that footnotes come with their own return links as part of the markup. These will also take you to the browser if you click on them as they suffer the same issues with missing attributes as the referring link.

