### PR TITLE
Make system messages unselectable

### DIFF
--- a/Shared/Article Rendering/shared.css
+++ b/Shared/Article Rendering/shared.css
@@ -25,6 +25,8 @@ a:hover {
 	top: 45%;
 	left: 50%;
 	transform: translateX(-55%) translateY(-50%);
+	-webkit-user-select: none;
+	cursor: default;
 }
 
 :root {


### PR DESCRIPTION
This includes “No selection,” “Multiple selection,” and “Loading…” It also changes the cursor into the regular arrow cursor to discourage the user from trying to select the text.