### PR TITLE
Provide additional help to users with persistent Feedly authorization issues

### DIFF
--- a/Account/Sources/Account/Feedly/FeedlyAccountDelegateError.swift
+++ b/Account/Sources/Account/Feedly/FeedlyAccountDelegateError.swift
@@ -23,7 +23,7 @@ enum FeedlyAccountDelegateError: LocalizedError {
 	var errorDescription: String? {
 		switch self {
 		case .notLoggedIn:
-			return NSLocalizedString("Please add the Feedly account again.", comment: "Feedly – Credentials not found.")
+			return NSLocalizedString("Please add the Feedly account again. If this problem persists, open the KeyChain app, delete all feedly.com entries, then try again.", comment: "Feedly – Credentials not found.")
 			
 		case .unexpectedResourceId(let resourceId):
 			let template = NSLocalizedString("Could not encode the identifier “%@”.", comment: "Feedly – Could not encode resource id to send to Feedly.")

--- a/Account/Sources/Account/Feedly/FeedlyAccountDelegateError.swift
+++ b/Account/Sources/Account/Feedly/FeedlyAccountDelegateError.swift
@@ -23,7 +23,7 @@ enum FeedlyAccountDelegateError: LocalizedError {
 	var errorDescription: String? {
 		switch self {
 		case .notLoggedIn:
-			return NSLocalizedString("Please add the Feedly account again. If this problem persists, open the KeyChain app, delete all feedly.com entries, then try again.", comment: "Feedly – Credentials not found.")
+			return NSLocalizedString("Please add the Feedly account again. If this problem persists, open Keychain Access and delete all feedly.com entries, then try again.", comment: "Feedly – Credentials not found.")
 			
 		case .unexpectedResourceId(let resourceId):
 			let template = NSLocalizedString("Could not encode the identifier “%@”.", comment: "Feedly – Could not encode resource id to send to Feedly.")


### PR DESCRIPTION
Feedly account authorization can get stuck when older KeyChain entries (e.g. from NetNewsWire 5) interfere with proper authorization, even when removing and re-adding a Feedly account.  This change gives the user more information, i.e. to delete `feedly.com` entries from their KeyChain if they encounter a persistent problem.

This closes issue #2875