### PR TITLE
RTL support for articles

### DIFF
--- a/Mac/MainWindow/Detail/page.html
+++ b/Mac/MainWindow/Detail/page.html
@@ -1,4 +1,4 @@
-<html>
+<html dir="auto">
 	<head>
 		<title>[[title]]</title>
 		<style>

--- a/Multiplatform/Shared/Article/page.html
+++ b/Multiplatform/Shared/Article/page.html
@@ -1,4 +1,4 @@
-<html>
+<html dir="auto">
 	<head>
 		<title>[[title]]</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/Shared/Article Rendering/shared.css
+++ b/Shared/Article Rendering/shared.css
@@ -88,10 +88,10 @@ body > .systemMessage {
 	border-radius: 4px;
 }
 .rightAlign {
-	text-align: right;
+	text-align: end;
 }
 .leftAlign {
-	text-align: left;
+	text-align: start;
 }
 
 .articleTitle a:link, .articleTitle a:visited {
@@ -258,8 +258,8 @@ hr {
 blockquote {
 	margin-inline-start: 0;
 	margin-inline-end: 0;
-	padding-left: 15px;
-	border-left: 3px solid var(--block-quote-border-color);
+	padding-inline-start: 15px;
+	border-inline-start: 3px solid var(--block-quote-border-color);
 }
 
 /* Feed Specific */

--- a/iOS/Resources/page.html
+++ b/iOS/Resources/page.html
@@ -1,4 +1,4 @@
-<html>
+<html dir="auto">
 	<head>
 		<title>[[title]]</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Example feed: https://www.ha-makom.co.il/feed/

Note that the header is reversed in addition to the text. Fixes #2927.

<img width=550 src="https://user-images.githubusercontent.com/25517624/112896496-76fd0480-90ac-11eb-8d85-c574ec39aff7.png"> <img width=200 src=https://user-images.githubusercontent.com/25517624/112898480-e116a900-90ae-11eb-9ac8-0e225064ead8.png>
