### PR TITLE
Update swipe actions on macOS to match iOS

### DIFF
--- a/Mac/AppAssets.swift
+++ b/Mac/AppAssets.swift
@@ -312,11 +312,21 @@ struct AppAssets {
 	}()
 
 	static var swipeMarkStarredImage: RSImage = {
-		return RSImage(named: "swipeMarkStarred")!
+		if #available(OSX 11.0, *) {
+			return RSImage(systemSymbolName: "star.fill", accessibilityDescription: "Star")!
+				.withSymbolConfiguration(.init(scale: .large))!
+		} else {
+			return RSImage(named: "swipeMarkStarred")!
+		}
 	}()
 
 	static var swipeMarkUnstarredImage: RSImage = {
-		return RSImage(named: "swipeMarkUnstarred")!
+		if #available(OSX 11.0, *) {
+			return RSImage(systemSymbolName: "star", accessibilityDescription: "Unstar")!
+				.withSymbolConfiguration(.init(scale: .large))!
+		} else {
+			return RSImage(named: "swipeMarkUnstarred")!
+		}
 	}()
 	
 	static var starColor: NSColor = {

--- a/Mac/AppAssets.swift
+++ b/Mac/AppAssets.swift
@@ -292,11 +292,23 @@ struct AppAssets {
 	}()
 
 	static var swipeMarkReadImage: RSImage = {
-		return RSImage(named: "swipeMarkRead")!
+		if #available(OSX 11.0, *) {
+			return RSImage(systemSymbolName: "circle", accessibilityDescription: "Mark Read")!
+				.withSymbolConfiguration(.init(scale: .large))!
+		} else {
+			// TODO: remove swipeMarkRead asset when dropping support for macOS 10.15
+			return RSImage(named: "swipeMarkRead")!
+		}
 	}()
 
 	static var swipeMarkUnreadImage: RSImage = {
-		return RSImage(named: "swipeMarkUnread")!
+		if #available(OSX 11.0, *) {
+			return RSImage(systemSymbolName: "largecircle.fill.circle", accessibilityDescription: "Mark Unread")!
+				.withSymbolConfiguration(.init(scale: .large))!
+		} else {
+			// TODO: remove swipeMarkUnread asset when dropping support for macOS 10.15
+			return RSImage(named: "swipeMarkUnread")!
+		}
 	}()
 
 	static var swipeMarkStarredImage: RSImage = {

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -941,7 +941,7 @@ extension TimelineViewController: NSTableViewDelegate {
 
 		switch edge {
 			case .leading:
-				let action = NSTableViewRowAction(style: .regular, title: "") { (action, row) in
+				let action = NSTableViewRowAction(style: .regular, title: article.status.read ? "Unread" : "Read") { (action, row) in
 					self.toggleArticleRead(article);
 					tableView.rowActionsVisible = false
 				}
@@ -949,7 +949,7 @@ extension TimelineViewController: NSTableViewDelegate {
 				return [action]
 
 			case .trailing:
-				let action = NSTableViewRowAction(style: .regular, title: "") { (action, row) in
+				let action = NSTableViewRowAction(style: .regular, title: article.status.starred ? "Unstar" : "Star") { (action, row) in
 					self.toggleArticleStarred(article);
 					tableView.rowActionsVisible = false
 				}


### PR DESCRIPTION
Brought up in Slack: https://netnewswire.slack.com/archives/C017LQCQ3LG/p1617741539017100

The swipe actions now appear the same on macOS and iOS.