### PR TITLE
Fixes #2994

### DIFF
--- a/Widget/Shared Views/ArticleItemView.swift
+++ b/Widget/Shared Views/ArticleItemView.swift
@@ -59,16 +59,14 @@ struct ArticleItemView: View {
 	func pubDate(_ dateString: String) -> String {
 		let dateFormatter = DateFormatter()
 		dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss Z"
-		let date = dateFormatter.date(from: dateString)
+		guard let date = dateFormatter.date(from: dateString) else {
+			return ""
+		}
 		
 		let displayFormatter = DateFormatter()
 		displayFormatter.dateStyle = .medium
 		displayFormatter.timeStyle = .none
 		
-		guard let dateFromDateFormatter = date else {
-			return ""
-		}
-		
-		return displayFormatter.string(from: dateFromDateFormatter)
+		return displayFormatter.string(from: date)
 	}
 }

--- a/Widget/Shared Views/ArticleItemView.swift
+++ b/Widget/Shared Views/ArticleItemView.swift
@@ -65,6 +65,10 @@ struct ArticleItemView: View {
 		displayFormatter.dateStyle = .medium
 		displayFormatter.timeStyle = .none
 		
-		return displayFormatter.string(from: date!)
+		guard let dateFromDateFormatter = date else {
+			return ""
+		}
+		
+		return displayFormatter.string(from: dateFromDateFormatter)
 	}
 }


### PR DESCRIPTION
Removes force unwrapping and returns an empty string if the `pubDate` cannot be determined.