### PR TITLE
Fixed missing argument `validateFeed:`

### DIFF
--- a/Multiplatform/Shared/Add/AddWebFeedModel.swift
+++ b/Multiplatform/Shared/Add/AddWebFeedModel.swift
@@ -112,7 +112,7 @@ class AddWebFeedModel: ObservableObject {
 				return
 			}
 			
-			account.createWebFeed(url: url.absoluteString, name: providedName, container: container, completion: { [weak self] result in
+			account.createWebFeed(url: url.absoluteString, name: providedName, container: container, validateFeed: true, completion: { [weak self] result in
 				self?.showProgressIndicator = false
 				switch result {
 				case .success(let feed):


### PR DESCRIPTION
Based on the newest API, `public func createWebFeed(url: String, name: String?, container: Container, validateFeed: Bool, completion: @escaping (Result<WebFeed, Error>) -> Void)`, there should be a `validateFeed:` argument.

I'm not quite sure if it should be `true` or `false`, but according to my search, it seems that this value should be `true` when creating a new web feed.