### PR TITLE
macOS: Feedly API is no longer returning the collection/folder values for deleted collections/folders…

### DIFF
--- a/Account/Sources/Account/Feedly/FeedlyAPICaller.swift
+++ b/Account/Sources/Account/Feedly/FeedlyAPICaller.swift
@@ -310,7 +310,7 @@ final class FeedlyAPICaller {
 		request.addValue("application/json", forHTTPHeaderField: "Accept-Type")
 		request.addValue("OAuth \(accessToken)", forHTTPHeaderField: HTTPRequestHeader.authorization)
 		
-		send(request: request, resultType: String.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
+		send(request: request, resultType: Optional<FeedlyCollection>.self, dateDecoding: .millisecondsSince1970, keyDecoding: .convertFromSnakeCase) { result in
 			switch result {
 			case .success(let (httpResponse, _)):
 				if httpResponse.statusCode == 200 {


### PR DESCRIPTION
…so make the response (which we ignore anyway), optional. Fixes #3015 for macOS builds.