### PR TITLE
Improve accessibility action labels for MasterTimelineCell in iOS

### DIFF
--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -243,8 +243,8 @@ class MasterTimelineViewController: UITableViewController, UndoableCommandRunner
 
 		// Set up the read action
 		let readTitle = article.status.read ?
-			NSLocalizedString("Unread", comment: "Unread") :
-			NSLocalizedString("Read", comment: "Read")
+			NSLocalizedString("Mark as Unread", comment: "Mark as Unread") :
+			NSLocalizedString("Mark as Read", comment: "Mark as Read")
 		
 		let readAction = UIContextualAction(style: .normal, title: readTitle) { [weak self] (action, view, completion) in
 			self?.coordinator.toggleRead(article)


### PR DESCRIPTION
Fixes #3072, by changing the accessibility labels for MasterTimelineCells to “Mark as Read” and “Mark as Unread”. 

Includes unit tests to protect against future regression. The current iOS app has fairly tight coupling of the SceneCoordinator and MasterTimelineViewController. [EDIT: See later discussion implementing an alternative from the public modifier discussed here:] Additionally, the SceneCoordinator method ```replaceArticles(with unsortedArticles: Set<Article>, animated: Bool)``` had to be marked as public in order to enable injection of test data into the MasterTimelineViewController. This prompts a warning:
>  'public' modifier conflicts with extension's default access of 'private’

Interested in feedback/discussion. My suggestion would be that the tightly coupled nature of these classes should be revised to use dependency injection, in order to allow testing without such work-arounds. However, it is still better to have unit tests for these issues and it would not make sense to delay this minor accessibility feature for what could be quite a significant refactoring. I note that these are the first unit tests for the NetNewsWire iOS target. Here’s to many more. :)