### PR TITLE
Handle links with unencoded spaces. Fixes #3069

### DIFF
--- a/Mac/MainWindow/Timeline/ArticlePasteboardWriter.swift
+++ b/Mac/MainWindow/Timeline/ArticlePasteboardWriter.swift
@@ -38,7 +38,7 @@ extension Article: PasteboardWriterOwner {
 	func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
 		var types = [ArticlePasteboardWriter.articleUTIType]
 
-		if let link = article.preferredLink, let _ = URL(string: link) {
+		if let _ = article.preferredURL {
 			types += [.URL]
 		}
 		types += [.string, .html, ArticlePasteboardWriter.articleUTIInternalType]

--- a/Multiplatform/Shared/Article/ArticleToolbarModifier.swift
+++ b/Multiplatform/Shared/Article/ArticleToolbarModifier.swift
@@ -107,7 +107,7 @@ struct ArticleToolbarModifier: ViewModifier {
 					.disabled(sceneModel.shareButtonState == nil)
 					.help("Share")
 					.sheet(isPresented: $showActivityView) {
-						if let article = sceneModel.selectedArticles.first, let link = article.preferredLink, let url = URL(string: link) {
+						if let article = sceneModel.selectedArticles.first, let url = article.preferredURL {
 							ActivityViewController(title: article.title, url: url)
 						}
 					}

--- a/Multiplatform/Shared/Timeline/TimelineModel.swift
+++ b/Multiplatform/Shared/Timeline/TimelineModel.swift
@@ -249,12 +249,11 @@ class TimelineModel: ObservableObject, UndoableCommandRunner {
 	}
 	
 	func openIndicatedArticleInBrowser(_ article: Article) {
-		guard let link = article.preferredLink else { return }
-		
 		#if os(macOS)
+		guard let link = article.preferredLink else { return }
 		Browser.open(link, invertPreference: NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false)
 		#else
-		guard let url = URL(string: link) else { return }
+		guard let url = article.preferredURL else { return }
 		UIApplication.shared.open(url, options: [:])
 		#endif
 	}

--- a/Shared/Extensions/ArticleUtilities.swift
+++ b/Shared/Extensions/ArticleUtilities.swift
@@ -56,6 +56,18 @@ extension Article {
 		return nil
 	}
 	
+	var preferredURL: URL? {
+		guard let link = preferredLink else { return nil }
+		// If required, we replace any space characters to handle malformed links that are otherwise percent
+		// encoded but contain spaces. For performance reasons, only try this if initial URL init fails.
+		if let url = URL(string: link) {
+			return url
+		} else if let url = URL(string: link.replacingOccurrences(of: " ", with: "%20")) {
+			return url
+		}
+		return nil
+	}
+	
 	var body: String? {
 		return contentHTML ?? contentText ?? summary
 	}

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -235,20 +235,14 @@ class WebViewController: UIViewController {
 	}
 	
 	func showActivityDialog(popOverBarButtonItem: UIBarButtonItem? = nil) {
-		guard let preferredLink = article?.preferredLink, let url = URL(string: preferredLink) else {
-			return
-		}
-
+		guard let url = article?.preferredURL else { return }
 		let activityViewController = UIActivityViewController(url: url, title: article?.title, applicationActivities: [FindInArticleActivity(), OpenInBrowserActivity()])
 		activityViewController.popoverPresentationController?.barButtonItem = popOverBarButtonItem
 		present(activityViewController, animated: true)
 	}
 
 	func openInAppBrowser() {
-		guard let preferredLink = article?.preferredLink, let url = URL(string: preferredLink) else {
-			return
-		}
-
+		guard let url = article?.preferredURL else { return }
 		let vc = SFSafariViewController(url: url)
 		present(vc, animated: true)
 	}

--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -889,9 +889,7 @@ private extension MasterTimelineViewController {
 	}
 
 	func openInBrowserAction(_ article: Article) -> UIAction? {
-		guard let preferredLink = article.preferredLink, let _ = URL(string: preferredLink) else {
-			return nil
-		}
+		guard let _ = article.preferredURL else { return nil }
 		let title = NSLocalizedString("Open in Browser", comment: "Open in Browser")
 		let action = UIAction(title: title, image: AppAssets.safariImage) { [weak self] action in
 			self?.coordinator.showBrowserForArticle(article)
@@ -900,9 +898,7 @@ private extension MasterTimelineViewController {
 	}
 
 	func openInBrowserAlertAction(_ article: Article, completion: @escaping (Bool) -> Void) -> UIAlertAction? {
-		guard let preferredLink = article.preferredLink, let _ = URL(string: preferredLink) else {
-			return nil
-		}
+		guard let _ = article.preferredURL else { return nil }
 		let title = NSLocalizedString("Open in Browser", comment: "Open in Browser")
 		let action = UIAlertAction(title: title, style: .default) { [weak self] action in
 			self?.coordinator.showBrowserForArticle(article)
@@ -923,10 +919,7 @@ private extension MasterTimelineViewController {
 	}
 	
 	func shareAction(_ article: Article, indexPath: IndexPath) -> UIAction? {
-		guard let preferredLink = article.preferredLink, let url = URL(string: preferredLink) else {
-			return nil
-		}
-				
+		guard let url = article.preferredURL else { return nil }
 		let title = NSLocalizedString("Share", comment: "Share")
 		let action = UIAction(title: title, image: AppAssets.shareImage) { [weak self] action in
 			self?.shareDialogForTableCell(indexPath: indexPath, url: url, title: article.title)
@@ -935,10 +928,7 @@ private extension MasterTimelineViewController {
 	}
 	
 	func shareAlertAction(_ article: Article, indexPath: IndexPath, completion: @escaping (Bool) -> Void) -> UIAlertAction? {
-		guard let preferredLink = article.preferredLink, let url = URL(string: preferredLink) else {
-			return nil
-		}
-		
+		guard let url = article.preferredURL else { return nil }
 		let title = NSLocalizedString("Share", comment: "Share")
 		let action = UIAlertAction(title: title, style: .default) { [weak self] action in
 			completion(true)

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -1238,16 +1238,12 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 	}
 	
 	func showBrowserForArticle(_ article: Article) {
-		guard let preferredLink = article.preferredLink, let url = URL(string: preferredLink) else {
-			return
-		}
+		guard let url = article.preferredURL else { return }
 		UIApplication.shared.open(url, options: [:])
 	}
 
 	func showBrowserForCurrentArticle() {
-		guard let preferredLink = currentArticle?.preferredLink, let url = URL(string: preferredLink) else {
-			return
-		}
+		guard let url = currentArticle?.preferredURL else { return }
 		UIApplication.shared.open(url, options: [:])
 	}
 	


### PR DESCRIPTION
Issue #3069 identified that when a feed has links that incorrectly include space characters that have not been percent encoded, a user is unable to share an article and in the swipe actions on an article's MasterTimelineTableViewCell, the share option does not even appear under More. These bugs are a result of guard statements that test if an `Article.preferredLink` string exists and whether a URL can be constructed out of this. When a space character is present in the string, the URL cannot be constructed and the function returns.

This pull request addresses ten such locations in NetNewsWire where the presence of a guard statement would cause UI to not be displayed/an action not proceeded with—that could be fixed by replacing space characters with percent encoding. There are also several other places that guard for the presence of a preferredLink but do not test for the ability to covert to a URL. These remain unchanged.

Two points on style:
• Brent Simmons in Slack directed "Fixing up broken URLs is a good idea — it should be done at the point of use (when passing to the web browser to open)." Hence the changes in ten separate locations, if I have understood this correctly. Another option would be to address this at a single point in ArticleUtilities, either by modifying `preferredLink` itself to correct this issue, or by creating an additional convenience computed var `preferredURL`, which could return an optional URL object if both preferredLink existed and a URL could be generated. This would simplify each of these ten guard statements to `guard let url = article.preferredURL else { return }` The latter would have perhaps been my default preference to implement.

• `.replacingOccurrences(of: " ", with: "%20")` has been directly appended to `preferredLink` in each case, as .replacingOcurrences(of:) returns a non-Optional String. If this was not directly appended to preferredLink, there would have to be two guard statements separated by a non-optional line of code, resulting in more noise than seemed warranted.