### PR TITLE
Always show smart feeds on iOS. Fixes #3052 on iOS

### DIFF
--- a/Shared/Tree/WebFeedTreeControllerDelegate.swift
+++ b/Shared/Tree/WebFeedTreeControllerDelegate.swift
@@ -56,9 +56,7 @@ private extension WebFeedTreeControllerDelegate {
 
 	func childNodesForSmartFeeds(_ parentNode: Node) -> [Node] {
 		return SmartFeedsController.shared.smartFeeds.compactMap { (feed) -> Node? in
-			if let feedID = feed.feedID, !filterExceptions.contains(feedID) && isReadFiltered && feed.unreadCount == 0 {
-				return nil
-			}
+			// All Smart Feeds should remain visible despite the Hide Read Feeds setting
 			return parentNode.existingOrNewChildNode(with: feed as AnyObject)
 		}
 	}


### PR DESCRIPTION
Simple edit, removing filter that previous would hide smart feeds if they contained no items, or all items had been read. This patch for iOS branch, same patch in other pull request for macOS branch.