### PR TITLE
Always show Smart Feeds on macOS. Fixes #3052 on macOS

### DIFF
--- a/Shared/Tree/WebFeedTreeControllerDelegate.swift
+++ b/Shared/Tree/WebFeedTreeControllerDelegate.swift
@@ -56,9 +56,7 @@ private extension WebFeedTreeControllerDelegate {
 
 	func childNodesForSmartFeeds(_ parentNode: Node) -> [Node] {
 		return SmartFeedsController.shared.smartFeeds.compactMap { (feed) -> Node? in
-			if let feedID = feed.feedID, !filterExceptions.contains(feedID) && isReadFiltered && feed.unreadCount == 0 {
-				return nil
-			}
+			// All Smart Feeds should remain visible despite the Hide Read Feeds setting
 			return parentNode.existingOrNewChildNode(with: feed as AnyObject)
 		}
 	}


### PR DESCRIPTION
Display Smart Feeds always, even when read articles are being hidden and all articles from a feed have been marked as read, and even when there are no items in a Smart Feed.