### PR TITLE
Add required closure to macOS AppDelegate

### DIFF
--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -832,7 +832,7 @@ private extension AppDelegate {
 			os_log(.debug, "No article found from search using %@", articleID)
 			return
 		}
-		account!.markArticles(article!, statusKey: .read, flag: true)
+		account!.markArticles(article!, statusKey: .read, flag: true) { _ in }
 	}
 	
 	func handleMarkAsStarred(userInfo: [AnyHashable: Any]) {
@@ -851,6 +851,6 @@ private extension AppDelegate {
 			os_log(.debug, "No article found from search using %@", articleID)
 			return
 		}
-		account!.markArticles(article!, statusKey: .starred, flag: true)
+		account!.markArticles(article!, statusKey: .starred, flag: true) { _ in }
 	}
 }


### PR DESCRIPTION
Incorporates closure from mac-release branch to enable the macOS target to build on the ios-candidate branch.