### PR TITLE
Handle footnote backlinks that lack css classes and ids. Fixes #3084 for macOS

### DIFF
--- a/Shared/Article Rendering/newsfoot.js
+++ b/Shared/Article Rendering/newsfoot.js
@@ -157,7 +157,7 @@
     document.addEventListener("click", (ev) =>
     {
 	    if (!(ev.target && ev.target instanceof HTMLAnchorElement)) return;
-        if (!ev.target.matches(".footnotes .reversefootnote, .footnotes .footnoteBackLink, .footnotes .footnote-return")) return;
+        if (!ev.target.matches(".footnotes .reversefootnote, .footnotes .footnoteBackLink, .footnotes .footnote-return, .footnotes a[href^='#']")) return;
 		const id = idFromHash(ev.target);
 		if (!id) return;
 		const fnref = document.getElementById(id);

--- a/Shared/Article Rendering/shared.css
+++ b/Shared/Article Rendering/shared.css
@@ -375,7 +375,8 @@ img[src*="share-buttons"] {
 
 .newsfoot-footnote-popover .reversefootnote,
 .newsfoot-footnote-popover .footnoteBackLink,
-.newsfoot-footnote-popover .footnote-return {
+.newsfoot-footnote-popover .footnote-return,
+.newsfoot-footnote-popover a[href^='#fn'] {
 	display: none;
 }
 


### PR DESCRIPTION
—macOS application of this same patch submitted for the iOS branch.—

A recent bug report described unusual behavior with footnote backlinks from the SixColors.com feed on iOS. Investigations showed there were two separate bugs, one already fixed on NNW 6.x for iOS, the other present on NNW for both macOS and iOS. 

By utilizing CSS wildcard selectors that match internal links this patch generalizes the current selectors that make the backlink functionality work, fixing this bug. This is likely to also enable footnote backlinks to work in some future/unknown CMS systems that do not use the handpicked css class names NNW was previously targeting, as long as they use the overall .footnotes parent class.