### PR TITLE
Capture fully resolved footnote backlinks. Extends #3084

### DIFF
--- a/Shared/Article Rendering/newsfoot.js
+++ b/Shared/Article Rendering/newsfoot.js
@@ -157,7 +157,7 @@
     document.addEventListener("click", (ev) =>
     {
 	    if (!(ev.target && ev.target instanceof HTMLAnchorElement)) return;
-        if (!ev.target.matches(".footnotes .reversefootnote, .footnotes .footnoteBackLink, .footnotes .footnote-return, .footnotes a[href^='#']")) return;
+        if (!ev.target.matches(".footnotes .reversefootnote, .footnotes .footnoteBackLink, .footnotes .footnote-return, .footnotes a[href*='#fn'], .footnotes a[href^='#']")) return;
 		const id = idFromHash(ev.target);
 		if (!id) return;
 		const fnref = document.getElementById(id);

--- a/Shared/Article Rendering/shared.css
+++ b/Shared/Article Rendering/shared.css
@@ -376,7 +376,7 @@ img[src*="share-buttons"] {
 .newsfoot-footnote-popover .reversefootnote,
 .newsfoot-footnote-popover .footnoteBackLink,
 .newsfoot-footnote-popover .footnote-return,
-.newsfoot-footnote-popover a[href^='#fn'] {
+.newsfoot-footnote-popover a[href*='#fn'] {
 	display: none;
 }
 


### PR DESCRIPTION
If a footnote backlink has a fully resolved URL, not just a detailed same-page # link, it was not caught by the recent patch. The need for this has now been identified in the RSS feed for SixColors.com. (The original bug report was for the json feed, which has slightly different link formatting.)