### PR TITLE
Mark as read just before display. Fixes #3037

### DIFF
--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -853,11 +853,11 @@ class SceneCoordinator: NSObject, UndoableCommandRunner, UnreadCountProvider {
 			currentArticleViewController = articleViewController!
 		}
 		
+		// Mark article as read before navigating to it, so the read status does not flash unread/read on display
+		markArticles(Set([article!]), statusKey: .read, flag: true)
+
 		masterTimelineViewController?.updateArticleSelection(animations: animations)
 		currentArticleViewController.article = article
-		
-		markArticles(Set([article!]), statusKey: .read, flag: true)
-		
 	}
 	
 	func beginSearching() {


### PR DESCRIPTION
Marking an article as read just before navigating to it prevents the read status from flashing unread/read on display when swiping to new unread articles, or navigating with the next article toolbar button.