### PR TITLE
Expand workaround for macOS 11 WebView origin offset bug. Fixes #2916

### DIFF
--- a/Mac/MainWindow/Detail/DetailWebView.swift
+++ b/Mac/MainWindow/Detail/DetailWebView.swift
@@ -58,11 +58,13 @@ final class DetailWebView: WKWebView {
 	
 	override func setFrameSize(_ newSize: NSSize) {
 		super.setFrameSize(newSize)
-		if (!self.inLiveResize) {
+		if (!inLiveResize) {
 			bigSurOffsetFix()
 		}
 	}
 		
+	private var inBigSurOffsetFix = false
+	
 	private func bigSurOffsetFix() {
 		/*
 		On macOS 11, when a user exits full screen
@@ -76,6 +78,17 @@ final class DetailWebView: WKWebView {
 			guard var frame = window?.frame else {
 				return
 			}
+
+			guard !inBigSurOffsetFix else {
+				return
+			}
+			
+			inBigSurOffsetFix = true
+			
+			defer {
+				inBigSurOffsetFix = false
+			}
+
 			frame.size = NSSize(width: window!.frame.width, height: window!.frame.height - 1)
 			window!.setFrame(frame, display: false)
 			frame.size = NSSize(width: window!.frame.width, height: window!.frame.height + 1)

--- a/Mac/MainWindow/Detail/DetailWebView.swift
+++ b/Mac/MainWindow/Detail/DetailWebView.swift
@@ -53,7 +53,17 @@ final class DetailWebView: WKWebView {
 	override func viewDidEndLiveResize() {
 		super.viewDidEndLiveResize()
 		evaluateJavaScript("document.body.style.overflow = 'visible';", completionHandler: nil)
+		bigSurOffsetFix()
+	}
+	
+	override func setFrameSize(_ newSize: NSSize) {
+		super.setFrameSize(newSize)
+		if (!self.inLiveResize) {
+			bigSurOffsetFix()
+		}
+	}
 		
+	private func bigSurOffsetFix() {
 		/*
 		On macOS 11, when a user exits full screen
 		or exits zoomed mode by disconnecting an external display


### PR DESCRIPTION
Move the code that twiddles the window frame from DetailWebView.viewDidEndLiveResize() into a new bigSurOffsetFix() API so it can also be called by setFrameSize() when the frame size is changed outside of a live resize.