### PR TITLE
Add Copy Article URL & Copy External URL Menu Items. Fixes #1285.

### DIFF
--- a/Mac/Base.lproj/Main.storyboard
+++ b/Mac/Base.lproj/Main.storyboard
@@ -157,6 +157,18 @@
                                                 <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Copy Article URL" id="qNk-By-jKp">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="copyArticleURL:" target="Ady-hI-5gd" id="A5t-x7-Mmy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy External URL" id="fOF-99-6Iv">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="copyExternalURL:" target="Ady-hI-5gd" id="MkV-Do-Bc1"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
                                             <connections>
                                                 <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>

--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -188,6 +188,14 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 	
 	public func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
 		
+		if item.action == #selector(copyArticleURL(_:)) {
+			return canCopyArticleURL()
+		}
+		
+		if item.action == #selector(copyExternalURL(_:)) {
+			return canCopyExternalURL()
+		}
+		
 		if item.action == #selector(openArticleInBrowser(_:)) {
 			if let item = item as? NSMenuItem, item.keyEquivalentModifierMask.contains(.shift) {
 				item.title = Browser.titleForOpenInBrowserInverted
@@ -284,6 +292,18 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 			}
 		}
 
+	}
+
+	@IBAction func copyArticleURL(_ sender: Any?) {
+		if let link = currentLink {
+			URLPasteboardWriter.write(urlString: link, to: .general)
+		}
+	}
+
+	@IBAction func copyExternalURL(_ sender: Any?) {
+		if let link = oneSelectedArticle?.externalURL {
+			URLPasteboardWriter.write(urlString: link, to: .general)
+		}
 	}
 
 	@IBAction func openArticleInBrowser(_ sender: Any?) {
@@ -1007,6 +1027,14 @@ private extension MainWindowController {
 	}
 
 	// MARK: - Command Validation
+	
+	func canCopyArticleURL() -> Bool {
+		return currentLink != nil
+	}
+	
+	func canCopyExternalURL() -> Bool {
+		return oneSelectedArticle?.externalURL != nil && oneSelectedArticle?.externalURL != currentLink
+	}
 
 	func canGoToNextUnread(wrappingToTop wrapping: Bool = false) -> Bool {
 		

--- a/Mac/MainWindow/Timeline/TimelineViewController+ContextualMenus.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController+ContextualMenus.swift
@@ -90,6 +90,13 @@ extension TimelineViewController {
 		}
 		Browser.open(urlString, inBackground: false)
 	}
+	
+	@objc func copyURLFromContextualMenu(_ sender: Any?) {
+		guard let menuItem = sender as? NSMenuItem, let urlString = menuItem.representedObject as? String else {
+			return
+		}
+		URLPasteboardWriter.write(urlString: urlString, to: .general)
+	}
 
 	@objc func performShareServiceFromContextualMenu(_ sender: Any?) {
 		guard let menuItem = sender as? NSMenuItem, let sharingCommandInfo = menuItem.representedObject as? SharingCommandInfo else {
@@ -168,6 +175,12 @@ private extension TimelineViewController {
 		if articles.count == 1, let link = articles.first!.preferredLink {
 			menu.addSeparatorIfNeeded()
 			menu.addItem(openInBrowserMenuItem(link))
+			menu.addSeparatorIfNeeded()
+			menu.addItem(copyArticleURLMenuItem(link))
+			
+			if let externalLink = articles.first?.externalURL, externalLink != link {
+				menu.addItem(copyExternalURLMenuItem(externalLink))
+			}
 		}
 
 		if let sharingMenu = shareMenu(for: articles) {
@@ -260,6 +273,15 @@ private extension TimelineViewController {
 
 		return menuItem(NSLocalizedString("Open in Browser", comment: "Command"), #selector(openInBrowserFromContextualMenu(_:)), urlString)
 	}
+	
+	func copyArticleURLMenuItem(_ urlString: String) -> NSMenuItem {
+		return menuItem(NSLocalizedString("Copy Article URL", comment: "Command"), #selector(copyURLFromContextualMenu(_:)), urlString)
+	}
+	
+	func copyExternalURLMenuItem(_ urlString: String) -> NSMenuItem {
+		return menuItem(NSLocalizedString("Copy External URL", comment: "Command"), #selector(copyURLFromContextualMenu(_:)), urlString)
+	}
+
 
 	func menuItem(_ title: String, _ action: Selector, _ representedObject: Any) -> NSMenuItem {
 

--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -362,6 +362,17 @@ class MasterTimelineViewController: UITableViewController, UndoableCommandRunner
 				menuElements.append(UIMenu(title: "", options: .displayInline, children: secondaryActions))
 			}
 			
+			var copyActions = [UIAction]()
+			if let action = self.copyArticleURLAction(article) {
+				copyActions.append(action)
+			}
+			if let action = self.copyExternalURLAction(article) {
+				copyActions.append(action)
+			}
+			if !copyActions.isEmpty {
+				menuElements.append(UIMenu(title: "", options: .displayInline, children: copyActions))
+			}
+			
 			if let action = self.openInBrowserAction(article) {
 				menuElements.append(UIMenu(title: "", options: .displayInline, children: [action]))
 			}
@@ -887,6 +898,25 @@ private extension MasterTimelineViewController {
 		}
 		return action
 	}
+	
+	func copyArticleURLAction(_ article: Article) -> UIAction? {
+		guard let preferredLink = article.preferredLink, let url = URL(string: preferredLink) else { return nil }
+		let title = NSLocalizedString("Copy Article URL", comment: "Copy Article URL")
+		let action = UIAction(title: title, image: AppAssets.copyImage) { action in
+			UIPasteboard.general.url = url
+		}
+		return action
+	}
+	
+	func copyExternalURLAction(_ article: Article) -> UIAction? {
+		guard let externalURL = article.externalURL, externalURL != article.preferredLink, let url = URL(string: externalURL) else { return nil }
+		let title = NSLocalizedString("Copy External URL", comment: "Copy External URL")
+		let action = UIAction(title: title, image: AppAssets.copyImage) { action in
+			UIPasteboard.general.url = url
+		}
+		return action
+	}
+
 
 	func openInBrowserAction(_ article: Article) -> UIAction? {
 		guard let preferredLink = article.preferredLink, let _ = URL(string: preferredLink) else {


### PR DESCRIPTION
The Mac items display in the edit and contextual menus, and on iOS in the contextual menu for an article. The external URL option disables/hides as appropriate if there's no external URL, or if it's the same as the article URL.

**iOS**
<img width=275 src=https://user-images.githubusercontent.com/4419005/116794749-80a7cc80-aa9d-11eb-96d7-c8aec02df013.png> <img width=275 src=https://user-images.githubusercontent.com/4419005/116794750-83a2bd00-aa9d-11eb-910f-31753d506959.png>

**Mac**
<img width=275 src=https://user-images.githubusercontent.com/4419005/116794765-a92fc680-aa9d-11eb-9c09-b5bcd40c262c.png> <img width=275 src=https://user-images.githubusercontent.com/4419005/116794767-ac2ab700-aa9d-11eb-8d50-8a49fbec8e36.png>
![Screen Shot 2021-05-01 at 4 51 11 PM](https://user-images.githubusercontent.com/4419005/116794768-afbe3e00-aa9d-11eb-9177-c94e50a1e40d.png) ![Screen Shot 2021-05-01 at 4 51 07 PM](https://user-images.githubusercontent.com/4419005/116794770-b2209800-aa9d-11eb-81ac-320c74b3ab30.png)
