### PR TITLE
Improves compatibility with sharing services

### DIFF
--- a/Mac/MainWindow/Timeline/ArticlePasteboardWriter.swift
+++ b/Mac/MainWindow/Timeline/ArticlePasteboardWriter.swift
@@ -36,12 +36,11 @@ extension Article: PasteboardWriterOwner {
 	// MARK: - NSPasteboardWriting
 
 	func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
-		var types = [ArticlePasteboardWriter.articleUTIType]
+		var types = [.string, .html, ArticlePasteboardWriter.articleUTIInternalType, ArticlePasteboardWriter.articleUTIType]
 
 		if let link = article.preferredLink, let _ = URL(string: link) {
-			types += [.URL]
+			types.append(.URL)
 		}
-		types += [.string, .html, ArticlePasteboardWriter.articleUTIInternalType]
 
 		return types
 	}
@@ -76,32 +75,9 @@ private extension ArticlePasteboardWriter {
 		if let title = article.title {
 			s += "\(title)\n\n"
 		}
-		if let text = article.contentText {
-			s += "\(text)\n\n"
-		}
-		else if let summary = article.summary {
-			s += "\(summary)\n\n"
-		}
-		else if let html = article.contentHTML {
-			let convertedHTML = html.convertingToPlainText()
-			s += "\(convertedHTML)\n\n"
-		}
-
+		
 		if let url = article.url {
-			s += "URL: \(url)\n\n"
-		}
-		if let externalURL = article.externalURL {
-			s += "external URL: \(externalURL)\n\n"
-		}
-
-		s += "Date: \(article.logicalDatePublished)\n\n"
-
-		if let feed = article.webFeed {
-			s += "Feed: \(feed.nameForDisplay)\n"
-			if let homePageURL = feed.homePageURL {
-				s += "Home page: \(homePageURL)\n"
-			}
-			s += "URL: \(feed.url)"
+			s += "\(url)\n\n"
 		}
 
 		return s

--- a/NetNewsWire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NetNewsWire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/Ranchero-Software/RSParser.git",
         "state": {
           "branch": null,
-          "revision": "a4467cb6ab32d67fa8b09fcef8b234c7f96b7f9c",
-          "version": "2.0.0"
+          "revision": "7de3940c67a5fd128c8088eaa218617f2d3cc3ee",
+          "version": "2.0.2"
         }
       },
       {


### PR DESCRIPTION
In relation to #3123: the changes in this commit allow text to be shared to additional apps in the share menu.

The first change is the ordering of the `writableTypes` array. It now puts `.string` first. This change on its own allows text to be shared to Tweetbot, Ulysees, and potentially other apps.

The second change is to the text—`plainText()`—that is shared. It has been reduced to `title` and `url`, which makes more sense in the context of sharing snippets. This is in large part to do with the fact that sharing title, contentText, summary, contentHTML, url, externalURL, date, and feedName is somewhat overkill when sharing to a Twitter-like service.

Lastly, the downside to this change is that Add to Reading List appears to have disappeared. 