### PR TITLE
Invert the semantics of the defaults key for whether to open Subscrib…

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -30,7 +30,7 @@ final class AppDefaults {
 		static let timelineGroupByFeed = "timelineGroupByFeed"
 		static let detailFontSize = "detailFontSize"
 		static let openInBrowserInBackground = "openInBrowserInBackground"
-		static let subscribeToFeedsInNetNewsWire = "subscribeToFeedsInNetNewsWire"
+		static let subscribeToFeedsInDefaultBrowser = "subscribeToFeedsInDefaultBrowser"
 		static let articleTextSize = "articleTextSize"
 		static let refreshInterval = "refreshInterval"
 		static let addWebFeedAccountID = "addWebFeedAccountID"
@@ -107,12 +107,12 @@ final class AppDefaults {
 		}
 	}
 
-	var subscribeToFeedsInNetNewsWire: Bool {
+	var subscribeToFeedsInDefaultBrowser: Bool {
 		get {
-			return AppDefaults.bool(for: Key.subscribeToFeedsInNetNewsWire)
+			return AppDefaults.bool(for: Key.subscribeToFeedsInDefaultBrowser)
 		}
 		set {
-			AppDefaults.setBool(for: Key.subscribeToFeedsInNetNewsWire, newValue)
+			AppDefaults.setBool(for: Key.subscribeToFeedsInDefaultBrowser, newValue)
 		}
 	}
 
@@ -297,7 +297,7 @@ final class AppDefaults {
 										Key.detailFontSize: FontSize.medium.rawValue,
 										Key.timelineSortDirection: ComparisonResult.orderedDescending.rawValue,
 										Key.timelineGroupByFeed: false,
-										Key.subscribeToFeedsInNetNewsWire: true,
+										Key.subscribeToFeedsInDefaultBrowser: false,
 										"NSScrollViewShouldScrollUnderTitlebar": false,
 										Key.refreshInterval: RefreshInterval.everyHour.rawValue,
 										Key.showDebugMenu: showDebugMenu]

--- a/Mac/Base.lproj/Preferences.storyboard
+++ b/Mac/Base.lproj/Preferences.storyboard
@@ -190,7 +190,11 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
-                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.subscribeToFeedsInNetNewsWire" id="Q15-dB-PCt"/>
+                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.subscribeToFeedsInDefaultBrowser" id="rgT-1E-AoD">
+                                                <dictionary key="options">
+                                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                </dictionary>
+                                            </binding>
                                         </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Yrc-6Q-kx8">
@@ -200,11 +204,7 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
-                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.subscribeToFeedsInNetNewsWire" id="Ikq-MR-S1U">
-                                                <dictionary key="options">
-                                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                                </dictionary>
-                                            </binding>
+                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.subscribeToFeedsInDefaultBrowser" id="Dnc-co-ppt"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/Mac/SafariExtension/SafariExtensionHandler.swift
+++ b/Mac/SafariExtension/SafariExtensionHandler.swift
@@ -43,6 +43,8 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 	override func messageReceived(withName messageName: String, from page: SFSafariPage, userInfo: [String : Any]?) {
 		if (messageName == "subscribeToFeed") {
 			if var feedURLString = userInfo?["url"] as? String {
+				var openInDefaultBrowser = false
+
 				// Ask for the user default from NetNewsWire's defaults to determine whether to open the feed URL
 				// using whatever the system configured default is, or to always hard-code it to NetNewsWire itself.
 				if let pluginBundleID = Bundle.main.bundleIdentifier {
@@ -51,12 +53,14 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 					let hostAppBundleID = pluginBundleID.replacingOccurrences(of: ".Subscribe-to-Feed", with: "")
 
 					if let sharedDefaults = UserDefaults(suiteName: hostAppBundleID) {
-						let openInNNW = sharedDefaults.bool(forKey: "subscribeToFeedsInNetNewsWire")
-						if openInNNW {
-							feedURLString = feedURLString.replacingOccurrences(of: "feed:", with: "x-netnewswire-feed")
-						}
+						openInDefaultBrowser = sharedDefaults.bool(forKey: "subscribeToFeedsInDefaultBrowser")
 					}
 				}
+
+				if openInDefaultBrowser == false {
+						feedURLString = feedURLString.replacingOccurrences(of: "feed:", with: "x-netnewswire-feed")
+				}
+
 				if let feedURL = URL(string: feedURLString) {
 					NSWorkspace.shared.open(feedURL)
 				}

--- a/Mac/SafariExtension/SafariExtensionHandler.swift
+++ b/Mac/SafariExtension/SafariExtensionHandler.swift
@@ -58,7 +58,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 				}
 
 				if openInDefaultBrowser == false {
-						feedURLString = feedURLString.replacingOccurrences(of: "feed:", with: "x-netnewswire-feed")
+						feedURLString = feedURLString.replacingOccurrences(of: "feed:", with: "x-netnewswire-feed:")
 				}
 
 				if let feedURL = URL(string: feedURLString) {

--- a/Multiplatform/Shared/AppDefaults.swift
+++ b/Multiplatform/Shared/AppDefaults.swift
@@ -75,7 +75,7 @@ final class AppDefaults: ObservableObject {
 		static let articleTextSize = "articleTextSize"
 		static let openInBrowserInBackground = "openInBrowserInBackground"
 		static let defaultBrowserID = "defaultBrowserID"
-		static let subscribeToFeedsInNetNewsWire = "subscribeToFeedsInNetNewsWire"
+		static let subscribeToFeedsInDefaultBrowser = "subscribeToFeedsInDefaultBrowser"
 		static let checkForUpdatesAutomatically = "checkForUpdatesAutomatically"
 		static let downloadTestBuilds = "downloadTestBuild"
 		static let sendCrashLogs = "sendCrashLogs"
@@ -267,7 +267,7 @@ final class AppDefaults: ObservableObject {
 		}
 	}
 
-	@AppStorage(wrappedValue: false, Key.subscribeToFeedsInNetNewsWire, store: store) var subscribeToFeedsInNetNewsWire: Bool {
+	@AppStorage(wrappedValue: false, Key.subscribeToFeedsInDefaultBrowser, store: store) var subscribeToFeedsInDefaultBrowser: Bool {
 		didSet {
 			objectWillChange.send()
 		}

--- a/Multiplatform/macOS/Preferences/Preference Panes/General/GeneralPreferencesView.swift
+++ b/Multiplatform/macOS/Preferences/Preference Panes/General/GeneralPreferencesView.swift
@@ -41,10 +41,10 @@ struct GeneralPreferencesView: View {
 			Toggle("Hide Unread Count in Dock", isOn: $defaults.hideDockUnreadCount)
 
 			Picker("Safari Extension:",
-				   selection: $defaults.subscribeToFeedsInNetNewsWire,
+				   selection: $defaults.subscribeToFeedsInDefaultBrowser,
 				   content: {
-					Text("Open feeds in NetNewsWire").tag(true)
-					Text("Open feeds in default news reader").tag(false)
+					Text("Open feeds in NetNewsWire").tag(false)
+					Text("Open feeds in default news reader").tag(true)
 				   }).pickerStyle(RadioGroupPickerStyle())
 		}
 		.frame(width: 400, alignment: .center)


### PR DESCRIPTION
…e to Feed feeds in NNW or the user's configured default browser. This ensures the fallback behavior when no preference has been set will default as wanted to opening in NetNewsWire.