### PR TITLE
Fix favicons when a feed's homepage URL has non-ASCII in its path

### DIFF
--- a/Shared/Favicons/FaviconDownloader.swift
+++ b/Shared/Favicons/FaviconDownloader.swift
@@ -200,7 +200,7 @@ private extension FaviconDownloader {
 
 	func findFaviconURLs(with homePageURL: String, _ completion: @escaping ([String]?) -> Void) {
 
-		guard let url = URL(string: homePageURL) else {
+		guard let url = URL(unicodeString: homePageURL) else {
 			completion(nil)
 			return
 		}

--- a/Shared/Favicons/FaviconURLFinder.swift
+++ b/Shared/Favicons/FaviconURLFinder.swift
@@ -42,7 +42,7 @@ struct FaviconURLFinder {
 	///   - urls: An array of favicon URLs as strings.
 	static func findFaviconURLs(with homePageURL: String, _ completion: @escaping (_ urls: [String]?) -> Void) {
 
-		guard let _ = URL(string: homePageURL) else {
+		guard let _ = URL(unicodeString: homePageURL) else {
 			completion(nil)
 			return
 		}

--- a/Shared/HTMLMetadata/HTMLMetadataDownloader.swift
+++ b/Shared/HTMLMetadata/HTMLMetadataDownloader.swift
@@ -15,7 +15,7 @@ struct HTMLMetadataDownloader {
 	static let serialDispatchQueue = DispatchQueue(label: "HTMLMetadataDownloader")
 
 	static func downloadMetadata(for url: String, _ completion: @escaping (RSHTMLMetadata?) -> Void) {
-		guard let actualURL = URL(string: url) else {
+		guard let actualURL = URL(unicodeString: url) else {
 			completion(nil)
 			return
 		}


### PR DESCRIPTION
Fixes #3216.