### PR TITLE
Theme tweaks

### DIFF
--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -926,9 +926,9 @@ internal extension AppDelegate {
 			case .typeMismatch(let type, _):
 				informativeText = "the type—'\(type)'—is mismatched."
 			case .valueNotFound(let value, _):
-				informativeText = "the value—'\(value)'—is not found."
+				informativeText = "the value—'\(value)'—is missing in the Info.plist."
 			case .keyNotFound(let codingKey, _):
-				informativeText = "the key—'\(codingKey.stringValue)'—is not found."
+				informativeText = "the key—'\(codingKey.stringValue)'—is missing in the Info.plist."
 			case .dataCorrupted( _):
 				informativeText = error.localizedDescription
 			default:

--- a/Shared/ArticleStyles/ArticleTheme.swift
+++ b/Shared/ArticleStyles/ArticleTheme.swift
@@ -58,7 +58,6 @@ struct ArticleTheme: Equatable {
 		let data = try Data(contentsOf: URL(fileURLWithPath: infoPath))
 		self.info = try PropertyListDecoder().decode(ArticleThemePlist.self, from: data)
 		
-		
 		let corePath = Bundle.main.path(forResource: "core", ofType: "css")!
 		let stylesheetPath = (path as NSString).appendingPathComponent("stylesheet.css")
 		if let stylesheetCSS = Self.stringAtPath(stylesheetPath) {

--- a/Shared/ArticleStyles/ArticleThemeDownloader.swift
+++ b/Shared/ArticleStyles/ArticleThemeDownloader.swift
@@ -22,7 +22,6 @@ public class ArticleThemeDownloader {
 		}
 	}
 	
-	
 	public static let shared = ArticleThemeDownloader()
 	private init() {}
 	

--- a/Technotes/Themes.md
+++ b/Technotes/Themes.md
@@ -1,7 +1,31 @@
 # Themes
 
-## Add Themes Directly to NetNewsWire
-Theme developers: on iOS and macOS, themes can be opened directly in NetNewsWire using the below URL scheme:
+## `.nnwtheme` Structure
+
+An `.nnwtheme` comprises of three files:
+- `Info.plist`
+- `template.html`
+- `stylesheet.css`
+
+### Info.plist
+The `Info.plist` requires the following keys/types:
+
+|Key|Type|Notes|
+|---|---|---|
+|`ThemeIdentifier`|`String`|Unique identifier for the theme, e.g. using reverse domain name.|
+|`Name`|`String`|Theme name|
+|`CreatorHomePage`|`String`||
+|`CreatorName`|`String`||
+|`Version`|`Integer`||
+
+### template.html
+This provides a starting point for editing the structure of the page. Theme variables are documented in the header.
+
+### stylesheet.css
+This provides a starting point for editing the style of the page. 
+
+## Add Themes Directly to NetNewsWire with URL Scheme
+On iOS and macOS, themes can be opened directly in NetNewsWire using the below URL scheme:
 
 `netnewswire://theme/add?url={url}`
 

--- a/iOS/UIKit Extensions/UIViewController-Extensions.swift
+++ b/iOS/UIKit Extensions/UIViewController-Extensions.swift
@@ -19,13 +19,13 @@ extension UIViewController {
 			let errorTitle = NSLocalizedString("Error", comment: "Error")
 			switch decodingError {
 			case .typeMismatch(let type, _):
-				let str = "This theme cannot be used because the type—'\(type)'—is mismatched."
+				let str = "This theme cannot be used because the type—'\(type)'—is mismatched in the Info.plist."
 				presentError(title: errorTitle, message: str, dismiss: dismiss)
 			case .valueNotFound(let value, _):
-				let str = "This theme cannot be used because the value—'\(value)'—is not found."
+				let str = "This theme cannot be used because the value—'\(value)'—is missing in the Info.plist."
 				presentError(title: errorTitle, message: str, dismiss: dismiss)
 			case .keyNotFound(let codingKey, _):
-				let str = "This theme cannot be used because the key—'\(codingKey.stringValue)'—is not found."
+				let str = "This theme cannot be used because the key—'\(codingKey.stringValue)'—is missing in the Info.plist."
 				presentError(title: errorTitle, message: str, dismiss: dismiss)
 			case .dataCorrupted( _):
 				presentError(title: errorTitle, message: error.localizedDescription, dismiss: dismiss)

--- a/iOS/UIKit Extensions/UIViewController-Extensions.swift
+++ b/iOS/UIKit Extensions/UIViewController-Extensions.swift
@@ -19,13 +19,13 @@ extension UIViewController {
 			let errorTitle = NSLocalizedString("Error", comment: "Error")
 			switch decodingError {
 			case .typeMismatch(let type, _):
-				let str = "Type '\(type)' mismatch."
+				let str = "This theme cannot be used because the type—'\(type)'—is mismatched."
 				presentError(title: errorTitle, message: str, dismiss: dismiss)
 			case .valueNotFound(let value, _):
-				let str = "Value '\(value)' not found."
+				let str = "This theme cannot be used because the value—'\(value)'—is not found."
 				presentError(title: errorTitle, message: str, dismiss: dismiss)
 			case .keyNotFound(let codingKey, _):
-				let str = "Key '\(codingKey.stringValue)' not found."
+				let str = "This theme cannot be used because the key—'\(codingKey.stringValue)'—is not found."
 				presentError(title: errorTitle, message: str, dismiss: dismiss)
 			case .dataCorrupted( _):
 				presentError(title: errorTitle, message: error.localizedDescription, dismiss: dismiss)

--- a/iOS/UIKit Extensions/UIViewController-Extensions.swift
+++ b/iOS/UIKit Extensions/UIViewController-Extensions.swift
@@ -17,20 +17,34 @@ extension UIViewController {
 			presentAccountError(accountError, dismiss: dismiss)
 		} else if let decodingError = error as? DecodingError {
 			let errorTitle = NSLocalizedString("Error", comment: "Error")
+			let infromativeText: String = ""
 			switch decodingError {
 			case .typeMismatch(let type, _):
-				let str = "This theme cannot be used because the type—'\(type)'—is mismatched in the Info.plist."
-				presentError(title: errorTitle, message: str, dismiss: dismiss)
+				let localizedError = NSLocalizedString("This theme cannot be used because the the type—“%@”—is mismatched in the Info.plist", comment: "Type mismatch")
+				informativeText = NSString.localizedStringWithFormat(localizedError as NSString, type as! CVarArg) as String
+				presentError(title: title, message: infromativeText, dismiss: dismiss)
 			case .valueNotFound(let value, _):
-				let str = "This theme cannot be used because the value—'\(value)'—is missing in the Info.plist."
-				presentError(title: errorTitle, message: str, dismiss: dismiss)
+				let localizedError = NSLocalizedString("This theme cannot be used because the the value—“%@”—is not found in the Info.plist.", comment: "Decoding value missing")
+				informativeText = NSString.localizedStringWithFormat(localizedError as NSString, value as! CVarArg) as String
+				presentError(title: title, message: infromativeText, dismiss: dismiss)
 			case .keyNotFound(let codingKey, _):
-				let str = "This theme cannot be used because the key—'\(codingKey.stringValue)'—is missing in the Info.plist."
-				presentError(title: errorTitle, message: str, dismiss: dismiss)
-			case .dataCorrupted( _):
-				presentError(title: errorTitle, message: error.localizedDescription, dismiss: dismiss)
+				let localizedError = NSLocalizedString("This theme cannot be used because the the key—“%@”—is not found in the Info.plist.", comment: "Decoding key missing")
+				informativeText = NSString.localizedStringWithFormat(localizedError as NSString, codingKey.stringValue) as String
+				presentError(title: title, message: infromativeText, dismiss: dismiss)
+			case .dataCorrupted(let context):
+				guard let error = context.underlyingError as NSError?,
+					  let debugDescription = error.userInfo["NSDebugDescription"] as? String else {
+					informativeText = error.localizedDescription
+					presentError(title: title, message: infromativeText, dismiss: dismiss)
+					return
+				}
+				let localizedError = NSLocalizedString("This theme cannot be used because of data corruption in the Info.plist. %@.", comment: "Decoding key missing")
+				informativeText = NSString.localizedStringWithFormat(localizedError as NSString, debugDescription) as String
+				presentError(title: title, message: infromativeText, dismiss: dismiss)
+				
 			default:
-				presentError(title: errorTitle, message: error.localizedDescription, dismiss: dismiss)
+				informativeText = error.localizedDescription
+				presentError(title: title, message: infromativeText, dismiss: dismiss)
 			}
 		} else {
 			let errorTitle = NSLocalizedString("Error", comment: "Error")


### PR DESCRIPTION
On macOS:
- The alert wording has been changed to "This theme cannot be used because _x_ is missing from the Info.plist".
- The alert contains an additional button that opens up the folder of the theme that the user was attempting to open or import. (When clicked, this button does not dismiss the alert.)

On iOS:
- The alert wording has been changed to "This theme cannot be used because _x_ is missing from the Info.plist".