### PR TITLE
Fixes #3335

### DIFF
--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -211,9 +211,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 			if let sceneDelegate = response.targetScene?.delegate as? SceneDelegate {
 				sceneDelegate.handle(response)
 				DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
-					NotificationCenter.default.post(name: .DidLaunchFromExternalAction, object: nil)
+					sceneDelegate.coordinator.dismissIfLaunchingFromExternalAction()
 				})
-				
 			}
 		}
 		

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -210,6 +210,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 		default:
 			if let sceneDelegate = response.targetScene?.delegate as? SceneDelegate {
 				sceneDelegate.handle(response)
+				DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
+					NotificationCenter.default.post(name: .DidLaunchFromExternalAction, object: nil)
+				})
+				
 			}
 		}
 		

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -75,7 +75,6 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 		NotificationCenter.default.addObserver(self, selector: #selector(contentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(configureContextMenu(_:)), name: .ActiveExtensionPointsDidChange, object: nil)
-		NotificationCenter.default.addObserver(self, selector: #selector(didLaunchFromExternalAction), name: .DidLaunchFromExternalAction, object: nil)
 
 		refreshControl = UIRefreshControl()
 		refreshControl!.addTarget(self, action: #selector(refreshAccounts(_:)), for: .valueChanged)
@@ -688,13 +687,7 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 			present(vc, animated: true)
 		}
 	}
-	
-	@objc func didLaunchFromExternalAction() {
-		guard let presentedController = presentedViewController as? SFSafariViewController else {
-			return
-		}
-		presentedController.dismiss(animated: true, completion: nil)
-	}
+
 }
 
 // MARK: UIContextMenuInteractionDelegate

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -75,6 +75,7 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 		NotificationCenter.default.addObserver(self, selector: #selector(contentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(configureContextMenu(_:)), name: .ActiveExtensionPointsDidChange, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(didLaunchFromURLContext), name: .DidLaunchFromExternalAction, object: nil)
 
 		refreshControl = UIRefreshControl()
 		refreshControl!.addTarget(self, action: #selector(refreshAccounts(_:)), for: .valueChanged)
@@ -686,6 +687,13 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 			let vc = SFSafariViewController(url: url)
 			present(vc, animated: true)
 		}
+	}
+	
+	@objc func didLaunchFromURLContext() {
+		guard let presentedController = presentedViewController as? SFSafariViewController else {
+			return
+		}
+		presentedController.dismiss(animated: true, completion: nil)
 	}
 }
 

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -75,7 +75,7 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 		NotificationCenter.default.addObserver(self, selector: #selector(contentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(configureContextMenu(_:)), name: .ActiveExtensionPointsDidChange, object: nil)
-		NotificationCenter.default.addObserver(self, selector: #selector(didLaunchFromURLContext), name: .DidLaunchFromExternalAction, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(didLaunchFromExternalAction), name: .DidLaunchFromExternalAction, object: nil)
 
 		refreshControl = UIRefreshControl()
 		refreshControl!.addTarget(self, action: #selector(refreshAccounts(_:)), for: .valueChanged)
@@ -689,7 +689,7 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 		}
 	}
 	
-	@objc func didLaunchFromURLContext() {
+	@objc func didLaunchFromExternalAction() {
 		guard let presentedController = presentedViewController as? SFSafariViewController else {
 			return
 		}

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -1327,6 +1327,23 @@ class SceneCoordinator: NSObject, UndoableCommandRunner {
 		
 	}
 	
+	/// This will dismiss the foremost view controller if the user
+	/// has launched from an external action (i.e., a widget tap, or
+	/// selecting an artice via a notification).
+	///
+	/// The dismiss is only applicable if the view controller is a
+	/// `SFSafariViewController` or `SettingsViewController`,
+	/// otherwise, this function does nothing.
+	func dismissIfLaunchingFromExternalAction() {
+		guard let presentedController = masterFeedViewController.presentedViewController else { return }
+		
+		if presentedController.isKind(of: SFSafariViewController.self) {
+			presentedController.dismiss(animated: true, completion: nil)
+		}
+		guard let settings = presentedController.children.first as? SettingsViewController else { return }
+		settings.dismiss(animated: true, completion: nil)
+	}
+	
 }
 
 // MARK: UISplitViewControllerDelegate

--- a/iOS/SceneDelegate.swift
+++ b/iOS/SceneDelegate.swift
@@ -11,6 +11,10 @@ import UserNotifications
 import Account
 import Zip
 
+public extension Notification.Name {
+	static let DidLaunchFromExternalAction = Notification.Name("DidLaunchFromExternalAction")
+}
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	
 	var window: UIWindow?
@@ -105,6 +109,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		guard let context = urlContexts.first else { return }
 		
 		DispatchQueue.main.async {
+			
+			DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+				NotificationCenter.default.post(name: .DidLaunchFromExternalAction, object: nil)
+			}
+			
 			let urlString = context.url.absoluteString
 			
 			// Handle the feed: and feeds: schemes
@@ -201,6 +210,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 			} else {
 				return
 			}
+			
 			
 		}
 	}

--- a/iOS/SceneDelegate.swift
+++ b/iOS/SceneDelegate.swift
@@ -11,10 +11,6 @@ import UserNotifications
 import Account
 import Zip
 
-public extension Notification.Name {
-	static let DidLaunchFromExternalAction = Notification.Name("DidLaunchFromExternalAction")
-}
-
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	
 	var window: UIWindow?
@@ -111,7 +107,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		DispatchQueue.main.async {
 			
 			DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-				NotificationCenter.default.post(name: .DidLaunchFromExternalAction, object: nil)
+				self.coordinator.dismissIfLaunchingFromExternalAction()
 			}
 			
 			let urlString = context.url.absoluteString

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -38,6 +38,7 @@ class SettingsViewController: UITableViewController {
 		NotificationCenter.default.addObserver(self, selector: #selector(accountsDidChange), name: .UserDidDeleteAccount, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(displayNameDidChange), name: .DisplayNameDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(activeExtensionPointsDidChange), name: .ActiveExtensionPointsDidChange, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(didLaunchFromURLContext), name: .DidLaunchFromExternalAction, object: nil)
 		
 
 		tableView.register(UINib(nibName: "SettingsComboTableViewCell", bundle: nil), forCellReuseIdentifier: "SettingsComboTableViewCell")
@@ -387,6 +388,10 @@ class SettingsViewController: UITableViewController {
 	
 	@objc func browserPreferenceDidChange() {
 		tableView.reloadData()
+	}
+	
+	@objc func didLaunchFromURLContext() {
+		dismiss(animated: true, completion: nil)
 	}
 	
 }

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -38,7 +38,6 @@ class SettingsViewController: UITableViewController {
 		NotificationCenter.default.addObserver(self, selector: #selector(accountsDidChange), name: .UserDidDeleteAccount, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(displayNameDidChange), name: .DisplayNameDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(activeExtensionPointsDidChange), name: .ActiveExtensionPointsDidChange, object: nil)
-		NotificationCenter.default.addObserver(self, selector: #selector(didLaunchFromExternalAction), name: .DidLaunchFromExternalAction, object: nil)
 		
 
 		tableView.register(UINib(nibName: "SettingsComboTableViewCell", bundle: nil), forCellReuseIdentifier: "SettingsComboTableViewCell")
@@ -388,10 +387,6 @@ class SettingsViewController: UITableViewController {
 	
 	@objc func browserPreferenceDidChange() {
 		tableView.reloadData()
-	}
-	
-	@objc func didLaunchFromExternalAction() {
-		dismiss(animated: true, completion: nil)
 	}
 	
 }

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -38,7 +38,7 @@ class SettingsViewController: UITableViewController {
 		NotificationCenter.default.addObserver(self, selector: #selector(accountsDidChange), name: .UserDidDeleteAccount, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(displayNameDidChange), name: .DisplayNameDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(activeExtensionPointsDidChange), name: .ActiveExtensionPointsDidChange, object: nil)
-		NotificationCenter.default.addObserver(self, selector: #selector(didLaunchFromURLContext), name: .DidLaunchFromExternalAction, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(didLaunchFromExternalAction), name: .DidLaunchFromExternalAction, object: nil)
 		
 
 		tableView.register(UINib(nibName: "SettingsComboTableViewCell", bundle: nil), forCellReuseIdentifier: "SettingsComboTableViewCell")
@@ -390,7 +390,7 @@ class SettingsViewController: UITableViewController {
 		tableView.reloadData()
 	}
 	
-	@objc func didLaunchFromURLContext() {
+	@objc func didLaunchFromExternalAction() {
 		dismiss(animated: true, completion: nil)
 	}
 	


### PR DESCRIPTION
When the app is brought to the foreground from an external action (e.g., tapping on the widget, opening from a notification), a notification is posted (with a slight delay).

`MasterFeedViewController` and `SettingsViewController` are observers. `MasterFeedViewController` will dismiss any `SFSafariViewController`s that are presented, while `SettingsViewController` will dismiss itself. With these tweaks, the existing behaviour in #3335—where existing views will obscure what the user has requested—is fixed.