### PR TITLE
Execute WidgetDataEncoder synchronously before suspending database

### DIFF
--- a/Shared/Widget/WidgetDataEncoder.swift
+++ b/Shared/Widget/WidgetDataEncoder.swift
@@ -29,73 +29,79 @@ public final class WidgetDataEncoder {
 	private init () {}
 	
 	@available(iOS 14, *)
-	func encodeWidgetData() throws {
+	func encodeWidgetDataSync() throws {
 		
 		os_log(.debug, log: log, "Starting encoding widget data.")
-		
-		DispatchQueue.main.async {
-			do {
-				let unreadArticles = Array(try AccountManager.shared.fetchArticles(.unread(self.fetchLimit))).sortedByDate(.orderedDescending)
-				let starredArticles = Array(try AccountManager.shared.fetchArticles(.starred(self.fetchLimit))).sortedByDate(.orderedDescending)
-				let todayArticles = Array(try AccountManager.shared.fetchArticles(.today(self.fetchLimit))).sortedByDate(.orderedDescending)
-				
-				var unread = [LatestArticle]()
-				var today = [LatestArticle]()
-				var starred = [LatestArticle]()
-				
-				for article in unreadArticles {
-					let latestArticle = LatestArticle(id: article.sortableArticleID,
-													  feedTitle: article.sortableName,
-													  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
-													  articleSummary: article.summary,
-													  feedIcon: article.iconImage()?.image.dataRepresentation(),
-													  pubDate: article.datePublished?.description ?? "")
-					unread.append(latestArticle)
-				}
-				
-				for article in starredArticles {
-					let latestArticle = LatestArticle(id: article.sortableArticleID,
-													  feedTitle: article.sortableName,
-													  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
-													  articleSummary: article.summary,
-													  feedIcon: article.iconImage()?.image.dataRepresentation(),
-													  pubDate: article.datePublished?.description ?? "")
-					starred.append(latestArticle)
-				}
-				
-				for article in todayArticles {
-					let latestArticle = LatestArticle(id: article.sortableArticleID,
-													  feedTitle: article.sortableName,
-													  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
-													  articleSummary: article.summary,
-													  feedIcon: article.iconImage()?.image.dataRepresentation(),
-													  pubDate: article.datePublished?.description ?? "")
-					today.append(latestArticle)
-				}
-				
-				let latestData = WidgetData(currentUnreadCount: SmartFeedsController.shared.unreadFeed.unreadCount,
-											currentTodayCount: SmartFeedsController.shared.todayFeed.unreadCount,
-											currentStarredCount: try! SmartFeedsController.shared.starredFeed.fetchArticles().count,
-											unreadArticles: unread,
-											starredArticles: starred,
-											todayArticles:today,
-											lastUpdateTime: Date())
-				
-				
-				let encodedData = try JSONEncoder().encode(latestData)
-				os_log(.debug, log: self.log, "Finished encoding widget data.")
-				
-				if self.fileExists() {
-					try? FileManager.default.removeItem(at: self.dataURL!)
-					os_log(.debug, log: self.log, "Removed widget data from container.")
-				}
-				if FileManager.default.createFile(atPath: self.dataURL!.path, contents: encodedData, attributes: nil) {
-					os_log(.debug, log: self.log, "Wrote widget data to container.")
-					WidgetCenter.shared.reloadAllTimelines()
-				}
-			} catch {
-				print(error.localizedDescription)
+
+		do {
+
+			let unreadArticles = Array(try AccountManager.shared.fetchArticles(.unread(self.fetchLimit))).sortedByDate(.orderedDescending)
+			let starredArticles = Array(try AccountManager.shared.fetchArticles(.starred(self.fetchLimit))).sortedByDate(.orderedDescending)
+			let todayArticles = Array(try AccountManager.shared.fetchArticles(.today(self.fetchLimit))).sortedByDate(.orderedDescending)
+			
+			var unread = [LatestArticle]()
+			var today = [LatestArticle]()
+			var starred = [LatestArticle]()
+			
+			for article in unreadArticles {
+				let latestArticle = LatestArticle(id: article.sortableArticleID,
+												  feedTitle: article.sortableName,
+												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
+												  articleSummary: article.summary,
+												  feedIcon: article.iconImage()?.image.dataRepresentation(),
+												  pubDate: article.datePublished?.description ?? "")
+				unread.append(latestArticle)
 			}
+			
+			for article in starredArticles {
+				let latestArticle = LatestArticle(id: article.sortableArticleID,
+												  feedTitle: article.sortableName,
+												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
+												  articleSummary: article.summary,
+												  feedIcon: article.iconImage()?.image.dataRepresentation(),
+												  pubDate: article.datePublished?.description ?? "")
+				starred.append(latestArticle)
+			}
+			
+			for article in todayArticles {
+				let latestArticle = LatestArticle(id: article.sortableArticleID,
+												  feedTitle: article.sortableName,
+												  articleTitle: ArticleStringFormatter.truncatedTitle(article).isEmpty ? ArticleStringFormatter.truncatedSummary(article) : ArticleStringFormatter.truncatedTitle(article),
+												  articleSummary: article.summary,
+												  feedIcon: article.iconImage()?.image.dataRepresentation(),
+												  pubDate: article.datePublished?.description ?? "")
+				today.append(latestArticle)
+			}
+			
+			let latestData = WidgetData(currentUnreadCount: SmartFeedsController.shared.unreadFeed.unreadCount,
+										currentTodayCount: SmartFeedsController.shared.todayFeed.unreadCount,
+										currentStarredCount: try! SmartFeedsController.shared.starredFeed.fetchArticles().count,
+										unreadArticles: unread,
+										starredArticles: starred,
+										todayArticles:today,
+										lastUpdateTime: Date())
+			
+			
+			let encodedData = try JSONEncoder().encode(latestData)
+			os_log(.debug, log: self.log, "Finished encoding widget data.")
+			
+			if self.fileExists() {
+				try? FileManager.default.removeItem(at: self.dataURL!)
+				os_log(.debug, log: self.log, "Removed widget data from container.")
+			}
+			if FileManager.default.createFile(atPath: self.dataURL!.path, contents: encodedData, attributes: nil) {
+				os_log(.debug, log: self.log, "Wrote widget data to container.")
+				WidgetCenter.shared.reloadAllTimelines()
+			}
+		} catch {
+			print(error.localizedDescription)
+		}
+	}
+	
+	@available(iOS 14, *)
+	func encodeWidgetDataAsync() throws {
+		DispatchQueue.main.async {
+			try? self.encodeWidgetDataSync()
 		}
 	}
 	

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -399,7 +399,7 @@ private extension AppDelegate {
 			AccountManager.shared.refreshAll(errorHandler: ErrorHandler.log) { [unowned self] in
 				if !AccountManager.shared.isSuspended {
 					if #available(iOS 14, *) {
-						try? WidgetDataEncoder.shared.encodeWidgetData()
+						try? WidgetDataEncoder.shared.encodeWidgetDataSync()
 					}
 					self.suspendApplication()
 					os_log("Account refresh operation completed.", log: self.log, type: .info)
@@ -446,7 +446,7 @@ private extension AppDelegate {
 		account!.syncArticleStatus(completion: { [weak self] _ in
 			if !AccountManager.shared.isSuspended {
 				if #available(iOS 14, *) {
-					try? WidgetDataEncoder.shared.encodeWidgetData()
+					try? WidgetDataEncoder.shared.encodeWidgetDataSync()
 				}
 				self?.prepareAccountsForBackground()
 				self?.suspendApplication()
@@ -475,7 +475,7 @@ private extension AppDelegate {
 		account!.syncArticleStatus(completion: { [weak self] _ in
 			if !AccountManager.shared.isSuspended {
 				if #available(iOS 14, *) {
-					try? WidgetDataEncoder.shared.encodeWidgetData()
+					try? WidgetDataEncoder.shared.encodeWidgetDataSync()
 				}
 				self?.prepareAccountsForBackground()
 				self?.suspendApplication()

--- a/iOS/SceneDelegate.swift
+++ b/iOS/SceneDelegate.swift
@@ -67,7 +67,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	
 	func sceneDidEnterBackground(_ scene: UIScene) {
 		if #available(iOS 14, *) {
-			try? WidgetDataEncoder.shared.encodeWidgetData()
+			try? WidgetDataEncoder.shared.encodeWidgetDataAsync()
 		}
 		ArticleStringFormatter.emptyCaches()
 		appDelegate.prepareAccountsForBackground()


### PR DESCRIPTION
Refactor WidgetDataEncoder to provide both sync & async entry points.
Update callers that subsequently suspend the database to encode widget
data synchronously. This prevents the encoding from blocking on the
suspended database.

Partial fix for Ranchero-Software#3200