### PR TITLE
Fixes #2369: Video playback is reset on rotation

### DIFF
--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -80,13 +80,6 @@ class WebViewController: UIViewController {
 		loadWebView()
 
 	}
-
-	override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-		// We need to reload the webview on the iPhone when rotation happens to clear out any old bad viewport sizes
-		if traitCollection.userInterfaceIdiom == .phone {
-			loadWebView()
-		}
-	}
 	
 	// MARK: Notifications
 	

--- a/iOS/Resources/main_ios.js
+++ b/iOS/Resources/main_ios.js
@@ -155,6 +155,17 @@ function postRenderProcessing() {
 	showFeedInspectorSetup();
 }
 
+function onResize() {
+	const meta = document.querySelector("meta[name=viewport]");
+	
+	if (!meta) return;
+	
+	const originalContent = meta.content;
+	meta.setAttribute("content", originalContent + ", maximum-scale=1.0");
+	meta.setAttribute("content", originalContent);
+}
+window.addEventListener("resize", onResize);
+
 
 function makeHighlightRect({left, top, width, height}, offsetTop=0, offsetLeft=0) {
 	const overlay = document.createElement('a');


### PR DESCRIPTION
The viewWillTransition(to:with:) method in WebViewController was introduced to
fix #3041, so I added an alternative solution using a resize handler in JS.