### PR TITLE
Fix: bottom inset of TimelineTableView disappeared on macOS Monterey.

### DIFF
--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -812,6 +812,12 @@ extension TimelineViewController: NSTableViewDataSource {
 		}
 		return ArticlePasteboardWriter(article: article)
 	}
+
+	func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+		// Keeping -[NSTableViewDelegate tableView:heightOfRow:] implemented fixes
+		// an issue that the bottom inset of NSTableView disappears on macOS Monterey.
+		return tableView.rowHeight
+	}
 }
 
 // MARK: - NSTableViewDelegate


### PR DESCRIPTION
I found an interesting issue of disappeared bottom inset of TimelineTableView, which should have default insets on four sides with `NSTableViewStyleInset` style.

<img width="1049" alt="Screenshot 2022-01-10 08 22 18" src="https://user-images.githubusercontent.com/8158163/148707173-ede46eab-761c-4054-92a0-17ec4dd93446.png">

After some time tinkering, I can confirm this issue is more like a bug of macOS Monterey and can be resolved by implementing `-[NSTableViewDelegate tableView:heightOfRow:]`.

A quick way to verify this fact is attaching to apps with(or without) this issue with a symbol breakpoint set on `-[NSTableView _sendDelegateHeightOfRow:]`. NSTableView calls this method before asking its delegate for row height.

This PR has been tested on:
* macOS Monterey 12.1 (21C52), both Intel and M1 Macs
* macOS Big Sur 11.6.2 (20G314)
* macOS Catalina 10.15.7 (19H1615)