### PR TITLE
Save Sidebar open/collapsed state between launches. Fixes #2707

### DIFF
--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -1273,6 +1273,8 @@ private extension MainWindowController {
 
 		let widths = splitView.arrangedSubviews.map{ Int(floor($0.frame.width)) }
 		state[MainWindowController.mainWindowWidthsStateKey] = widths
+		
+		state[UserInfoKey.isSidebarHidden] = sidebarSplitViewItem?.isCollapsed
 	}
 
 	func restoreSplitViewState(from state: [AnyHashable : Any]) {
@@ -1295,6 +1297,12 @@ private extension MainWindowController {
 
 		splitView.setPosition(CGFloat(sidebarWidth), ofDividerAt: 0)
 		splitView.setPosition(CGFloat(sidebarWidth + dividerThickness + timelineWidth), ofDividerAt: 1)
+		
+		let isSidebarHidden = state[UserInfoKey.isSidebarHidden] as? Bool ?? false
+		
+		if !(sidebarSplitViewItem?.isCollapsed ?? false) && isSidebarHidden {
+			sidebarSplitViewItem?.isCollapsed = true
+		}
 	}
 
 	func buildToolbarButton(_ itemIdentifier: NSToolbarItem.Identifier, _ title: String, _ image: NSImage, _ selector: String) -> NSToolbarItem {

--- a/Shared/UserInfoKey.swift
+++ b/Shared/UserInfoKey.swift
@@ -25,5 +25,6 @@ struct UserInfoKey {
 	static let selectedFeedsState = "selectedFeedsState"
 	static let isShowingExtractedArticle = "isShowingExtractedArticle"
 	static let articleWindowScrollY = "articleWindowScrollY"
+	static let isSidebarHidden = "isSidebarHidden"
 	
 }


### PR DESCRIPTION
~~From a conversation in Slack, it's not clear whether this needs to account for multiple windows (it does not currently).~~ Multiple windows behave properly (the sidebar open/closed state is preserved for each window).