### PR TITLE
Fix blurry sidebar symbols (#3268)

### DIFF
--- a/Mac/AppAssets.swift
+++ b/Mac/AppAssets.swift
@@ -159,8 +159,7 @@ struct AppAssets {
 		if #available(macOS 11.0, *) {
 			let image = NSImage(systemSymbolName: "folder", accessibilityDescription: nil)!
 			let preferredColor = NSColor(named: "AccentColor")!
-			let coloredImage = image.tinted(with: preferredColor)
-			return IconImage(coloredImage, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
+			return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 		} else {
 			return IconImage(RSImage(named: NSImage.folderName)!)
 		}
@@ -255,8 +254,7 @@ struct AppAssets {
 		if #available(macOS 11.0, *) {
 			let image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: nil)!
 			let preferredColor = NSColor(named: "StarColor")!
-			let coloredImage = image.tinted(with: preferredColor)
-			return IconImage(coloredImage, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
+			return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 		} else {
 			return IconImage(RSImage(named: NSImage.smartBadgeTemplateName)!, isBackgroundSupressed: true)
 		}
@@ -278,8 +276,7 @@ struct AppAssets {
 		if #available(macOS 11.0, *) {
 			let image = NSImage(systemSymbolName: "sun.max.fill", accessibilityDescription: nil)!
 			let preferredColor = NSColor.orange
-			let coloredImage = image.tinted(with: preferredColor)
-			return IconImage(coloredImage, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
+			return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 		} else {
 			return IconImage(RSImage(named: NSImage.smartBadgeTemplateName)!, isBackgroundSupressed: true)
 		}
@@ -289,8 +286,7 @@ struct AppAssets {
 		if #available(macOS 11.0, *) {
 			let image = NSImage(systemSymbolName: "largecircle.fill.circle", accessibilityDescription: nil)!
 			let preferredColor = NSColor(named: "AccentColor")!
-			let coloredImage = image.tinted(with: preferredColor)
-			return IconImage(coloredImage, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
+			return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 		} else {
 			return IconImage(RSImage(named: NSImage.smartBadgeTemplateName)!, isBackgroundSupressed: true)
 		}

--- a/Mac/MainWindow/IconView.swift
+++ b/Mac/MainWindow/IconView.swift
@@ -14,6 +14,9 @@ final class IconView: NSView {
 		didSet {
 			if iconImage !== oldValue {
 				imageView.image = iconImage?.image
+				if let tintColor = iconImage?.preferredColor {
+					imageView.contentTintColor = NSColor(cgColor: tintColor)
+				}
 
 				if NSApplication.shared.effectiveAppearance.isDarkMode {
 					if self.iconImage?.isDark ?? false {

--- a/Mac/MainWindow/Sidebar/Cell/SidebarCell.swift
+++ b/Mac/MainWindow/Sidebar/Cell/SidebarCell.swift
@@ -143,18 +143,17 @@ private extension SidebarCell {
 		var updatedIconImage = iconImage
 		
 		if let iconImage = iconImage, iconImage.isSymbol {
+			var tintColor: CGColor
 			if backgroundStyle != .normal {
-				let image = iconImage.image.tinted(with: .white)
-				updatedIconImage = IconImage(image, isSymbol: iconImage.isSymbol, isBackgroundSupressed: iconImage.isBackgroundSupressed)
+				tintColor = NSColor.white.cgColor
 			} else {
 				if let preferredColor = iconImage.preferredColor {
-					let image = iconImage.image.tinted(with: NSColor(cgColor: preferredColor)!)
-					updatedIconImage = IconImage(image, isSymbol: iconImage.isSymbol, isBackgroundSupressed: iconImage.isBackgroundSupressed)
+					tintColor = preferredColor
 				} else {
-					let image = iconImage.image.tinted(with: .controlAccentColor)
-					updatedIconImage = IconImage(image, isSymbol: iconImage.isSymbol, isBackgroundSupressed: iconImage.isBackgroundSupressed)
+					tintColor = NSColor.controlAccentColor.cgColor
 				}
 			}
+			updatedIconImage = IconImage(iconImage.image, isSymbol: iconImage.isSymbol, isBackgroundSupressed: iconImage.isBackgroundSupressed, preferredColor: tintColor)
 		}
 
 		if let image = updatedIconImage {


### PR DESCRIPTION
Fixes blurry sidebar symbols on macOS 11 and 12. (#3268)

Before:
![blurry](https://user-images.githubusercontent.com/4042863/150610409-1bf34192-02c6-4155-a6bb-323efe4cc9d1.png)
After:
![not-blurry](https://user-images.githubusercontent.com/4042863/150610435-b1924d0a-ba47-4e06-88a6-f5513539ef1e.png)
