### PR TITLE
Fix keyboard navigation in UI

### DIFF
--- a/iOS/KeyboardManager.swift
+++ b/iOS/KeyboardManager.swift
@@ -47,7 +47,11 @@ class KeyboardManager {
 	
 	static func createKeyCommand(title: String, action: String, input: String, modifiers: UIKeyModifierFlags) -> UIKeyCommand {
 		let selector = NSSelectorFromString(action)
-		return UIKeyCommand(title: title, image: nil, action: selector, input: input, modifierFlags: modifiers, propertyList: nil, alternates: [], discoverabilityTitle: nil, attributes: [], state: .on)
+		let keyCommand = UIKeyCommand(title: title, image: nil, action: selector, input: input, modifierFlags: modifiers, propertyList: nil, alternates: [], discoverabilityTitle: nil, attributes: [], state: .on)
+		if #available(iOS 15.0, *) {
+			keyCommand.wantsPriorityOverSystemBehavior = true
+		}
+		return keyCommand
 	}
 	
 }
@@ -62,7 +66,11 @@ private extension KeyboardManager {
 		if let title = keyEntry["title"] as? String {
 			return KeyboardManager.createKeyCommand(title: title, action: action, input: input, modifiers: modifiers)
 		} else {
-			return UIKeyCommand(input: input, modifierFlags: modifiers, action: NSSelectorFromString(action))
+			let keyCommand = UIKeyCommand(input: input, modifierFlags: modifiers, action: NSSelectorFromString(action))
+			if #available(iOS 15.0, *) {
+				keyCommand.wantsPriorityOverSystemBehavior = true
+			}
+			return keyCommand
 		}
 	}
 		


### PR DESCRIPTION
- Update to point to the 6.1 help book.
- Update version and release notes for first 6.1 TestFlight beta.
- Fix path to VerifyNoBS.
- Change how we delete embedded frameworks
- Bump build to 6101.
- Make app owner of its document type. Bump build to 6102.
- Assert that our UIKeyCommand instances should take priority over system behavior. This may be a bit more blunt than is strictly necessary, as I think there is only contention for e.g. unmodified keystrokes including bare arrow keys, but I also don't think that it will probably hurt anything to assert that all of our key commands should be active?
