### PR TITLE
Update `gyb` to latest version and use python3

### DIFF
--- a/Shared/Secrets.swift.gyb
+++ b/Shared/Secrets.swift.gyb
@@ -8,14 +8,14 @@ def chunks(seq, size):
   return (seq[i:(i + size)] for i in range(0, len(seq), size))
 
 def encode(string, salt):
-  bytes = string.encode("UTF-8")
-  return [ord(bytes[i]) ^ salt[i % len(salt)] for i in range(0, len(bytes))]
+  bytes_ = string.encode("UTF-8")
+  return [ord(bytes_[i]) ^ salt[i % len(salt)] for i in range(0, len(bytes_))]
 
 def snake_to_camel(snake_str):
   components = snake_str.split('_')
   return components[0].lower() + ''.join(x.title() for x in components[1:])
 
-salt = [ord(byte) for byte in os.urandom(64)]
+salt = [byte for byte in os.urandom(64)]
 }%
 import Secrets
 

--- a/Vendor/gyb
+++ b/Vendor/gyb
@@ -1,3 +1,3 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 import gyb
 gyb.main()

--- a/Vendor/gyb.py
+++ b/Vendor/gyb.py
@@ -4,16 +4,20 @@
 
 from __future__ import print_function
 
+import io
 import os
 import re
 import sys
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
 import textwrap
 import tokenize
 from bisect import bisect
+
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 
 try:
     basestring
@@ -48,7 +52,7 @@ def split_lines(s):
     If the lines are later concatenated, the result is s, possibly
     with a single appended newline.
     """
-    return [l + '\n' for l in s.split('\n')]
+    return [line + '\n' for line in s.split('\n')]
 
 
 # text on a line up to the first '$$', '${', or '%%'
@@ -396,9 +400,9 @@ class ParseContext(object):
     def __init__(self, filename, template=None):
         self.filename = os.path.abspath(filename)
         if sys.platform == 'win32':
-            self.filename = self.filename.replace('\\', '/')
+            self.filename = '/'.join(self.filename.split(os.sep))
         if template is None:
-            with open(filename) as f:
+            with io.open(os.path.normpath(filename), encoding='utf-8') as f:
                 self.template = f.read()
         else:
             self.template = template
@@ -733,8 +737,10 @@ class Code(ASTNode):
             result_string = None
             if isinstance(result, Number) and not isinstance(result, Integral):
                 result_string = repr(result)
-            else:
+            elif isinstance(result, Integral) or isinstance(result, list):
                 result_string = str(result)
+            else:
+                result_string = StringIO(result).read()
             context.append_text(
                 result_string, self.filename, self.start_line_number)
 
@@ -745,7 +751,7 @@ class Code(ASTNode):
             s = indent + 'Code: {' + source_lines[0] + '}'
         else:
             s = indent + 'Code:\n' + indent + '{\n' + '\n'.join(
-                indent + 4 * ' ' + l for l in source_lines
+                indent + 4 * ' ' + line for line in source_lines
             ) + '\n' + indent + '}'
         return s + self.format_children(indent)
 
@@ -760,8 +766,8 @@ def expand(filename, line_directive=_default_line_directive, **local_bindings):
     >>> # manually handle closing and deleting this file to allow us to open
     >>> # the file by its name across all platforms.
     >>> f = NamedTemporaryFile(delete=False)
-    >>> f.write(
-    ... r'''---
+    >>> _ = f.write(
+    ... br'''---
     ... % for i in range(int(x)):
     ... a pox on ${i} for epoxy
     ... % end
@@ -800,7 +806,7 @@ def expand(filename, line_directive=_default_line_directive, **local_bindings):
     >>> f.close()
     >>> os.remove(f.name)
     """
-    with open(filename) as f:
+    with io.open(filename, encoding='utf-8') as f:
         t = parse_template(filename, f.read())
         d = os.getcwd()
         os.chdir(os.path.dirname(os.path.abspath(filename)))
@@ -1133,16 +1139,6 @@ def execute_template(
 
 
 def main():
-    """
-    Lint this file.
-    >>> import sys
-    >>> gyb_path = os.path.realpath(__file__).replace('.pyc', '.py')
-    >>> sys.path.append(os.path.dirname(gyb_path))
-    >>> import python_lint
-    >>> python_lint.lint([gyb_path], verbose=False)
-    0
-    """
-
     import argparse
     import sys
 
@@ -1215,12 +1211,12 @@ def main():
         help='''Bindings to be set in the template's execution context''')
 
     parser.add_argument(
-        'file', type=argparse.FileType(),
+        'file', type=str,
         help='Path to GYB template file (defaults to stdin)', nargs='?',
-        default=sys.stdin)
+        default='-')
     parser.add_argument(
-        '-o', dest='target', type=argparse.FileType('w'),
-        help='Output file (defaults to stdout)', default=sys.stdout)
+        '-o', dest='target', type=str,
+        help='Output file (defaults to stdout)', default='-')
     parser.add_argument(
         '--test', action='store_true',
         default=False, help='Run a self-test')
@@ -1252,15 +1248,23 @@ def main():
             sys.exit(1)
 
     bindings = dict(x.split('=', 1) for x in args.defines)
-    ast = parse_template(args.file.name, args.file.read())
+    if args.file == '-':
+        ast = parse_template('stdin', sys.stdin.read())
+    else:
+        with io.open(os.path.normpath(args.file), 'r', encoding='utf-8') as f:
+            ast = parse_template(args.file, f.read())
     if args.dump:
         print(ast)
     # Allow the template to open files and import .py files relative to its own
     # directory
-    os.chdir(os.path.dirname(os.path.abspath(args.file.name)))
+    os.chdir(os.path.dirname(os.path.abspath(args.file)))
     sys.path = ['.'] + sys.path
 
-    args.target.write(execute_template(ast, args.line_directive, **bindings))
+    if args.target == '-':
+        sys.stdout.write(execute_template(ast, args.line_directive, **bindings))
+    else:
+        with io.open(args.target, 'w', encoding='utf-8', newline='\n') as f:
+            f.write(execute_template(ast, args.line_directive, **bindings))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I attempted to build NetNewsWire on my system running macOS 12.3 beta -- and quickly discovered that the NetNewsWire build uses python2.7 which is removed in macOS 12.3! It didn't take too much to get things back up and running with python3.

1. Updated `Vendor/gyb` and `Vendor/gyb.py` to the latest versions from <https://github.com/apple/swift/raw/main/utils/>
2. Manually updated the shebang in `Vendor/gyb` to be `#!/usr/bin/env python3`
3. Update `Shared/Secrets.swift.gyb` to avoid a name collision with the built-in python type `bytes` and to remove a now-unnecessary call to `ord`.

I tested this on my macOS 12.2 and 12.3 systems, but I do not have easy access to 11.x or 10.15.x systems on which to test, sorry.