### PR TITLE
Fix height of label on Feedbin sign-in modal

### DIFF
--- a/Mac/Preferences/Accounts/AccountsFeedbin.xib
+++ b/Mac/Preferences/Accounts/AccountsFeedbin.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,7 +26,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="433" height="249"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="433" height="249"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -97,7 +97,7 @@
                         </gridCells>
                     </gridView>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9mz-D9-krh">
-                        <rect key="frame" x="345" y="13" width="74" height="32"/>
+                        <rect key="frame" x="344" y="13" width="76" height="32"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="62" id="hU1-wc-ebZ"/>
                         </constraints>
@@ -113,7 +113,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XAM-Hb-0Hw">
-                        <rect key="frame" x="271" y="13" width="74" height="32"/>
+                        <rect key="frame" x="270" y="13" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ufs-ar-BAY">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -150,9 +150,9 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="X1Z-v1-T5L">
-                        <rect key="frame" x="78" y="81" width="337" height="30"/>
+                        <rect key="frame" x="78" y="79" width="337" height="32"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="30" id="NRl-GS-cHS"/>
+                            <constraint firstAttribute="height" constant="32" id="NRl-GS-cHS"/>
                             <constraint firstAttribute="width" constant="333" id="cNd-Nt-bdB"/>
                         </constraints>
                         <textFieldCell key="cell" title="Your username and password will be encrypted and stored in Keychain. " id="HuQ-TS-tS3">
@@ -176,14 +176,14 @@ Gw
                         </connections>
                     </button>
                     <progressIndicator hidden="YES" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="B0W-bh-Evv">
-                        <rect key="frame" x="253" y="23" width="16" height="16"/>
+                        <rect key="frame" x="253" y="22" width="16" height="16"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="Tcz-vj-cLr"/>
                             <constraint firstAttribute="height" constant="16" id="slt-7y-Jw0"/>
                         </constraints>
                     </progressIndicator>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sPC-hi-ewD">
-                        <rect key="frame" x="78" y="57" width="337" height="16"/>
+                        <rect key="frame" x="78" y="55" width="337" height="16"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" id="sl9-fG-jwg">
                             <font key="font" usesAppearanceFont="YES"/>
                             <color key="textColor" name="systemRedColor" catalog="System" colorSpace="catalog"/>
@@ -226,7 +226,7 @@ Gw
         </window>
     </objects>
     <resources>
-        <image name="accountFeedbin" width="25" height="25"/>
+        <image name="accountFeedbin" width="369" height="343"/>
         <namedColor name="AccentColor">
             <color red="0.030999999493360519" green="0.41600000858306885" blue="0.93300002813339233" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Mac/Preferences/Accounts/AccountsReaderAPI.xib
+++ b/Mac/Preferences/Accounts/AccountsReaderAPI.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -30,7 +30,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="433" height="275"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="433" height="275"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -125,7 +125,7 @@
                         </gridCells>
                     </gridView>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9mz-D9-krh">
-                        <rect key="frame" x="348" y="13" width="74" height="32"/>
+                        <rect key="frame" x="347" y="13" width="76" height="32"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="62" id="afy-Zh-DIy"/>
                         </constraints>
@@ -141,7 +141,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XAM-Hb-0Hw">
-                        <rect key="frame" x="274" y="13" width="74" height="32"/>
+                        <rect key="frame" x="273" y="13" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ufs-ar-BAY">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -177,7 +177,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="R8e-67-Bwh">
-                        <rect key="frame" x="78" y="218" width="186" height="16"/>
+                        <rect key="frame" x="78" y="218" width="185" height="16"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Don’t have a Reader account?" id="ker-hu-FEc">
                             <font key="font" usesAppearanceFont="YES"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -185,9 +185,9 @@ Gw
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kUQ-aj-Iu6">
-                        <rect key="frame" x="263" y="220" width="99" height="13"/>
+                        <rect key="frame" x="262" y="218" width="99" height="16"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="13" id="NOr-5b-kRd"/>
+                            <constraint firstAttribute="height" constant="16" id="NOr-5b-kRd"/>
                         </constraints>
                         <buttonCell key="cell" type="roundRect" title="Create one here." bezelStyle="roundedRect" alignment="center" state="on" imageScaling="proportionallyDown" inset="2" id="xY9-Rw-8kx">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>


### PR DESCRIPTION
Before (6.1b3 (6102)):
<img width="624" alt="Screenshot_2022-02-11 21 12 02" src="https://user-images.githubusercontent.com/25517624/153692480-658cba53-f475-4f77-bc5e-cdd87555b659.png">

After:
<img width="624" alt="Screenshot_2022-02-11 21 21 31" src="https://user-images.githubusercontent.com/25517624/153692819-ac6aff66-2c46-4156-842d-4f4b97d4c41e.png">
