### PR TITLE
Add top margin to figcaption

### DIFF
--- a/Shared/Article Rendering/stylesheet.css
+++ b/Shared/Article Rendering/stylesheet.css
@@ -234,6 +234,7 @@ figure {
 }
 
 figcaption {
+	margin-top: 0.5em;
 	font-size: 14px;
 	line-height: 1.3em;
 }


### PR DESCRIPTION
Currently there is no margin between `img` and `figcaption` inside `figure`.

For example:
<kbd><a href="https://xkcd.com/2582/"><img width="620" alt="Screen Shot 2022-02-17 at 1 27 56 PM" src="https://user-images.githubusercontent.com/3684553/154547025-76df8ba8-4a17-472e-8f93-0415c222b433.png"></a></kbd>

This change adds a small margin so that the text has some breathing room.