### PR TITLE
Add proper OSLog argument for os_log calls.

### DIFF
--- a/Account/Sources/Account/Feedly/Operations/FeedlyLogoutOperation.swift
+++ b/Account/Sources/Account/Feedly/Operations/FeedlyLogoutOperation.swift
@@ -34,7 +34,7 @@ final class FeedlyLogoutOperation: FeedlyOperation {
 		assert(Thread.isMainThread)
 		switch result {
 		case .success:
-			os_log("Logged out of %{public}@ account.", "\(account.type)")
+			os_log("Logged out of %{public}@ account.", log: log, "\(account.type)")
 			do {
 				try account.removeCredentials(type: .oauthAccessToken)
 				try account.removeCredentials(type: .oauthRefreshToken)
@@ -44,7 +44,7 @@ final class FeedlyLogoutOperation: FeedlyOperation {
 			didFinish()
 			
 		case .failure(let error):
-			os_log("Logout failed because %{public}@.", error as NSError)
+			os_log("Logout failed because %{public}@.", log: log, error as NSError)
 			didFinish(with: error)
 		}
 	}

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -37,6 +37,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		static let mainWindow = "mainWindow"
 	}
 	
+	var log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "Application")
+	
 	var userNotificationManager: UserNotificationManager!
 	var faviconDownloader: FaviconDownloader!
 	var imageDownloader: ImageDownloader!
@@ -199,7 +201,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		AppDefaults.shared.registerDefaults()
 		let isFirstRun = AppDefaults.shared.isFirstRun
 		if isFirstRun {
-			os_log(.debug, "Is first run.")
+			os_log(.debug, log: log, "Is first run.")
 		}
 		let localAccount = AccountManager.shared.defaultAccount
 
@@ -1010,12 +1012,12 @@ private extension AppDelegate {
 		
 		let account = AccountManager.shared.existingAccount(with: accountID)
 		guard account != nil else {
-			os_log(.debug, "No account found from notification.")
+			os_log(.debug, log: log, "No account found from notification.")
 			return
 		}
 		let article = try? account!.fetchArticles(.articleIDs([articleID]))
 		guard article != nil else {
-			os_log(.debug, "No article found from search using %@", articleID)
+			os_log(.debug, log: log, "No article found from search using %@", articleID)
 			return
 		}
 		account!.markArticles(article!, statusKey: .read, flag: true) { _ in }
@@ -1029,12 +1031,12 @@ private extension AppDelegate {
 		}
 		let account = AccountManager.shared.existingAccount(with: accountID)
 		guard account != nil else {
-			os_log(.debug, "No account found from notification.")
+			os_log(.debug, log: log, "No account found from notification.")
 			return
 		}
 		let article = try? account!.fetchArticles(.articleIDs([articleID]))
 		guard article != nil else {
-			os_log(.debug, "No article found from search using %@", articleID)
+			os_log(.debug, log: log, "No article found from search using %@", articleID)
 			return
 		}
 		account!.markArticles(article!, statusKey: .starred, flag: true) { _ in }

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -940,7 +940,7 @@ extension TimelineViewController: NSTableViewDelegate {
 				return [action]
 
 			@unknown default:
-				os_log(.error, "Unknown table row edge: %ld", edge.rawValue)
+				print("Unknown table row edge: \(edge.rawValue)")
 		}
 
 		return []

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -431,12 +431,12 @@ private extension AppDelegate {
 		resumeDatabaseProcessingIfNecessary()
 		let account = AccountManager.shared.existingAccount(with: accountID)
 		guard account != nil else {
-			os_log(.debug, "No account found from notification.")
+			os_log(.debug, log: self.log, "No account found from notification.")
 			return
 		}
 		let article = try? account!.fetchArticles(.articleIDs([articleID]))
 		guard article != nil else {
-			os_log(.debug, "No article found from search using %@", articleID)
+			os_log(.debug, log: self.log, "No article found from search using %@", articleID)
 			return
 		}
 		account!.markArticles(article!, statusKey: .read, flag: true) { _ in }
@@ -459,12 +459,12 @@ private extension AppDelegate {
 		resumeDatabaseProcessingIfNecessary()
 		let account = AccountManager.shared.existingAccount(with: accountID)
 		guard account != nil else {
-			os_log(.debug, "No account found from notification.")
+			os_log(.debug, log: self.log, "No account found from notification.")
 			return
 		}
 		let article = try? account!.fetchArticles(.articleIDs([articleID]))
 		guard article != nil else {
-			os_log(.debug, "No article found from search using %@", articleID)
+			os_log(.debug, log: self.log, "No article found from search using %@", articleID)
 			return
 		}
 		account!.markArticles(article!, statusKey: .starred, flag: true) { _ in }


### PR DESCRIPTION
The [`os_log`](https://developer.apple.com/documentation/os/3580306-os_log) function defaults `log` parameter to [`OSLog.default`](https://developer.apple.com/documentation/os/oslog/2320724-default) which has no `category` and `subsystem` associated. This makes it extremely difficult to distinguish NetNewsWire logs from system ones within Console.app.

This PR adds proper OSLog argument for all os_log calls.