### PR TITLE
Return [Article] from articlesForIndexes() instead of Set<Article>

### DIFF
--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -85,7 +85,7 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 
 	var showsSearchResults = false
 	var selectedArticles: [Article] {
-		return Array(articles.articlesForIndexes(tableView.selectedRowIndexes))
+		return articles.articlesForIndexes(tableView.selectedRowIndexes)
 	}
 
 	var hasAtLeastOneSelectedArticle: Bool {

--- a/Shared/Timeline/ArticleArray.swift
+++ b/Shared/Timeline/ArticleArray.swift
@@ -44,10 +44,10 @@ extension Array where Element == Article {
 		return nil
 	}
 
-	func articlesForIndexes(_ indexes: IndexSet) -> Set<Article> {
-		return Set(indexes.compactMap{ (oneIndex) -> Article? in
+	func articlesForIndexes(_ indexes: IndexSet) -> [Article] {
+		return indexes.compactMap{ (oneIndex) -> Article? in
 			return articleAtRow(oneIndex)
-		})
+		}
 	}
 		
 	func sortedByDate(_ sortDirection: ComparisonResult, groupByFeed: Bool = false) -> ArticleArray {


### PR DESCRIPTION
This will fix the main part of #3502 (delimiting/formatting articles not encompassed).