### PR TITLE
Alternative to PR #3584 to fix #3580 

### DIFF
--- a/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
+++ b/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
@@ -339,7 +339,9 @@ private extension SidebarOutlineDataSource {
 	}
 	
 	func copyWebFeedInAccount(node: Node, to parentNode: Node) {
-		guard let feed = node.representedObject as? WebFeed, let destination = parentNode.representedObject as? Container else {
+		guard let feed = node.representedObject as? WebFeed,
+			  let destination = parentNode.representedObject as? Container
+		else {
 			return
 		}
 		copyWebFeedInAccount(feed, destination)
@@ -384,7 +386,10 @@ private extension SidebarOutlineDataSource {
 			let destinationContainer = parentNode.representedObject as? Container else {
 			return
 		}
-		
+		copyWebFeedBetweenAccounts(feed, destinationAccount, destinationContainer)
+	}
+	
+	func copyWebFeedBetweenAccounts(_ feed: WebFeed, _ destinationAccount: Account, _ destinationContainer: Container) {
 		if let existingFeed = destinationAccount.existingWebFeed(withURL: feed.url) {
 			destinationAccount.addWebFeed(existingFeed, to: destinationContainer) { result in
 				switch result {
@@ -440,25 +445,23 @@ private extension SidebarOutlineDataSource {
 		}
 		
 		draggedFeeds.forEach { pasteboardFeed in
+			guard let accountID = pasteboardFeed.accountID,
+				  let account = AccountManager.shared.existingAccount(with: accountID),
+				  let webFeedID = pasteboardFeed.webFeedID,
+				  let feed = account.existingWebFeed(withWebFeedID:  webFeedID),
+				  let destination = parentNode.representedObject as? Container
+			else {
+				return
+			}
+
 			if sameAccount(pasteboardFeed, parentNode) {
-				guard let accountID = pasteboardFeed.accountID,
-					  let account = AccountManager.shared.existingAccount(with: accountID),
-					  let webFeedID = pasteboardFeed.webFeedID,
-					  let feed = account.existingWebFeed(withWebFeedID:  webFeedID),
-					  let destination = parentNode.representedObject as? Container
-				else {
-					return
-				}
-				
 				if NSApplication.shared.currentEvent?.modifierFlags.contains(.option) ?? false {
 					copyWebFeedInAccount(feed, destination)
 				} else {
 					moveWebFeedInAccount(feed, account, destination)
 				}
 			} else {
-				// TODO: handle between accounts
-				print("ERROR \(#file):\(#line)")
-				// copyWebFeedBetweenAccounts(feed, destination)
+				copyWebFeedBetweenAccounts(feed, account, destination)
 			}
 		}
 		

--- a/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
+++ b/Mac/MainWindow/Sidebar/SidebarOutlineDataSource.swift
@@ -315,8 +315,7 @@ private extension SidebarOutlineDataSource {
 		if index != updatedIndex {
 			outlineView.setDropItem(parentNode, dropChildIndex: updatedIndex)
 		}
-		// TODO: handle local folder drags between windows
-		return localDragOperation(parentNode: parentNode)
+		return .copy	// only get here if src & dst are different accounts and can only copy to different account
 	}
 	
 	func validateLocalFoldersDrop(_ outlineView: NSOutlineView, _ draggedFolders: Set<PasteboardFolder>, _ parentNode: Node, _ index: Int) -> NSDragOperation {
@@ -334,8 +333,7 @@ private extension SidebarOutlineDataSource {
 		if index != NSOutlineViewDropOnItemIndex {
 			outlineView.setDropItem(parentNode, dropChildIndex: NSOutlineViewDropOnItemIndex)
 		}
-		// TODO: handle local folder drags between windows
-		return localDragOperation(parentNode: parentNode)
+		return .copy	// only get here if src & dst are different accounts and can only copy to different account
 	}
 	
 	func copyWebFeedInAccount(node: Node, to parentNode: Node) {


### PR DESCRIPTION
Alternative to PR #3584 to fix #3580.  This removes the `draggedNodes` cache optimization and always uses the drag pasteboard items for both within single window and across multiple window drags to reduce and simplify the code.