### PR TITLE
Add http and https to the list of CFBundleURLSchemes.

### DIFF
--- a/Mac/Resources/Info.plist
+++ b/Mac/Resources/Info.plist
@@ -37,6 +37,8 @@
 				<string>feed</string>
 				<string>feeds</string>
 				<string>x-netnewswire-feed</string>
+				<string>http</string>
+				<string>https</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
If NetNewsWire says it is able to handle http and https URL schemes, Safari will list NetNewsWire as a target in Develop > Open Page With, which provides a trivial flow for subscribing to the page or site one is currently reading in Safari. I believe this functionality existed in NetNewsWire "classic," and this patch just brings the functionality back.