### PR TITLE
Prefer expanding selected items upon right arrow key stroke on sidebar.

### DIFF
--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -469,6 +469,12 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 		currentTimelineViewController?.focus()
 	}
 
+	@IBAction func navigateToTimelineOrExpandSidebarItem(_ sender: Any?) {
+		if let sidebarViewController = sidebarViewController, !sidebarViewController.expandCurrentSelectedItems() {
+			currentTimelineViewController?.focus()
+		}
+	}
+
 	@IBAction func navigateToSidebar(_ sender: Any?) {
 		sidebarViewController?.focus()
 	}

--- a/Mac/MainWindow/Sidebar/SidebarViewController.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController.swift
@@ -299,6 +299,18 @@ protocol SidebarDelegate: AnyObject {
 
 	// MARK: - Navigation
 	
+	func expandCurrentSelectedItems() -> Bool {
+		var expanded = false
+		outlineView.selectedItems.forEach { item in
+			guard outlineView.isExpandable(item), !outlineView.isItemExpanded(item) else {
+				return
+			}
+			outlineView.expandItem(item)
+			expanded = true
+		}
+		return expanded
+	}
+
 	func canGoToNextUnread(wrappingToTop wrapping: Bool = false) -> Bool {
 		if let _ = nextSelectableRowWithUnreadArticle(wrappingToTop: wrapping) {
 			return true

--- a/Shared/Resources/SidebarKeyboardShortcuts.plist
+++ b/Shared/Resources/SidebarKeyboardShortcuts.plist
@@ -66,7 +66,7 @@
 		<key>key</key>
 		<string>[rightarrow]</string>
 		<key>action</key>
-		<string>navigateToTimeline:</string>
+		<string>navigateToTimelineOrExpandSidebarItem:</string>
 	</dict>
 	<dict>
 		<key>title</key>


### PR DESCRIPTION
This PR tweaks the right arrow keyboard shortcut on the sidebar to expand currently selected items if applicable rather than navigating to the timeline list. This results from a more predictable response to user actions.

https://user-images.githubusercontent.com/8158163/173612072-757fd66d-eb25-438d-89eb-88a81d756150.mov
