### PR TITLE
Fix for #3543

### DIFF
--- a/Mac/MainWindow/Detail/DetailWebView.swift
+++ b/Mac/MainWindow/Detail/DetailWebView.swift
@@ -90,7 +90,7 @@ final class DetailWebView: WKWebView {
 
 		frame.size = NSSize(width: window!.frame.width, height: window!.frame.height - 1)
 		window!.setFrame(frame, display: false)
-		frame.size = NSSize(width: window!.frame.width, height: window!.frame.height + 1)
+		frame.size = NSSize(width: frame.width, height: frame.height + 1)
 		window!.setFrame(frame, display: false)
 	}
 }


### PR DESCRIPTION
Noticed that the window size wasn't returning the new value right after the code that sets its height to be old height -1 in one of the three times it's called during show or hide of the sidebar.  As a result, using the window size to calculate the size to restore the window to increments the original size instead of the -1 of that we thought we set.

IMPORTANT:  I'm not sure if this _breaks_ the fix that the `bigSurOffsetFix()` code was implementing because I can't replicate that bug on macOS 12.4 (I may just lack steps).

So someone who can replicate that should test this fix to see if that bug stays fixed or if this just effectively re-introduces it.