### PR TITLE
use .package(path:) for local package dependencies to resolve Xcode 14 errors.

### DIFF
--- a/Account/Package.swift
+++ b/Account/Package.swift
@@ -1,6 +1,29 @@
 // swift-tools-version:5.3
 import PackageDescription
 
+var dependencies: [Package.Dependency] = [
+	.package(url: "https://github.com/Ranchero-Software/RSCore.git", .upToNextMajor(from: "1.0.0")),
+	.package(url: "https://github.com/Ranchero-Software/RSDatabase.git", .upToNextMajor(from: "1.0.0")),
+	.package(url: "https://github.com/Ranchero-Software/RSParser.git", .upToNextMajor(from: "2.0.2")),
+	.package(url: "https://github.com/Ranchero-Software/RSWeb.git", .upToNextMajor(from: "1.0.0")),
+]
+
+#if swift(>=5.6)
+dependencies.append(contentsOf: [
+	.package(path: "../Articles"),
+	.package(path: "../ArticlesDatabase"),
+	.package(path: "../Secrets"),
+	.package(path: "../SyncDatabase"),
+])
+#else
+dependencies.append(contentsOf: [
+	.package(url: "../Articles", .upToNextMajor(from: "1.0.0")),
+	.package(url: "../ArticlesDatabase", .upToNextMajor(from: "1.0.0")),
+	.package(url: "../Secrets", .upToNextMajor(from: "1.0.0")),
+	.package(url: "../SyncDatabase", .upToNextMajor(from: "1.0.0")),
+])
+#endif
+
 let package = Package(
     name: "Account",
 	platforms: [.macOS(SupportedPlatform.MacOSVersion.v10_15), .iOS(SupportedPlatform.IOSVersion.v13)],
@@ -10,16 +33,7 @@ let package = Package(
 			type: .dynamic,
             targets: ["Account"]),
     ],
-    dependencies: [
-		.package(url: "https://github.com/Ranchero-Software/RSCore.git", .upToNextMajor(from: "1.0.0")),
-		.package(url: "https://github.com/Ranchero-Software/RSDatabase.git", .upToNextMajor(from: "1.0.0")),
-		.package(url: "https://github.com/Ranchero-Software/RSParser.git", .upToNextMajor(from: "2.0.2")),
-		.package(url: "https://github.com/Ranchero-Software/RSWeb.git", .upToNextMajor(from: "1.0.0")),
-		.package(url: "../Articles", .upToNextMajor(from: "1.0.0")),
-		.package(url: "../ArticlesDatabase", .upToNextMajor(from: "1.0.0")),
-		.package(url: "../Secrets", .upToNextMajor(from: "1.0.0")),
-		.package(url: "../SyncDatabase", .upToNextMajor(from: "1.0.0")),
-    ],
+    dependencies: dependencies,
     targets: [
         .target(
             name: "Account",

--- a/ArticlesDatabase/Package.swift
+++ b/ArticlesDatabase/Package.swift
@@ -3,6 +3,22 @@
 
 import PackageDescription
 
+var dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/Ranchero-Software/RSCore.git", .upToNextMajor(from: "1.0.0")),
+    .package(url: "https://github.com/Ranchero-Software/RSDatabase.git", .upToNextMajor(from: "1.0.0")),
+    .package(url: "https://github.com/Ranchero-Software/RSParser.git", .upToNextMajor(from: "2.0.2")),
+]
+
+#if swift(>=5.6)
+dependencies.append(contentsOf: [
+    .package(path: "../Articles"),
+])
+#else
+dependencies.append(contentsOf: [
+    .package(url: "../Articles", .upToNextMajor(from: "1.0.0")),
+])
+#endif
+
 let package = Package(
     name: "ArticlesDatabase",
 	platforms: [.macOS(SupportedPlatform.MacOSVersion.v10_15), .iOS(SupportedPlatform.IOSVersion.v13)],
@@ -12,12 +28,7 @@ let package = Package(
 			type: .dynamic,
             targets: ["ArticlesDatabase"]),
     ],
-    dependencies: [
-		.package(url: "https://github.com/Ranchero-Software/RSCore.git", .upToNextMajor(from: "1.0.0")),
-		.package(url: "https://github.com/Ranchero-Software/RSDatabase.git", .upToNextMajor(from: "1.0.0")),
-		.package(url: "https://github.com/Ranchero-Software/RSParser.git", .upToNextMajor(from: "2.0.2")),
-		.package(url: "../Articles", .upToNextMajor(from: "1.0.0")),
-    ],
+    dependencies: dependencies,
     targets: [
         .target(
             name: "ArticlesDatabase",

--- a/SyncDatabase/Package.swift
+++ b/SyncDatabase/Package.swift
@@ -1,6 +1,21 @@
 // swift-tools-version:5.3
 import PackageDescription
 
+var dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/Ranchero-Software/RSCore.git", .upToNextMajor(from: "1.0.0")),
+    .package(url: "https://github.com/Ranchero-Software/RSDatabase.git", .upToNextMajor(from: "1.0.0")),
+]
+
+#if swift(>=5.6)
+dependencies.append(contentsOf: [
+    .package(path: "../Articles"),
+])
+#else
+dependencies.append(contentsOf: [
+    .package(url: "../Articles", .upToNextMajor(from: "1.0.0")),
+])
+#endif
+
 let package = Package(
     name: "SyncDatabase",
 	platforms: [.macOS(SupportedPlatform.MacOSVersion.v10_15), .iOS(SupportedPlatform.IOSVersion.v13)],
@@ -10,11 +25,7 @@ let package = Package(
 			type: .dynamic,
             targets: ["SyncDatabase"]),
     ],
-    dependencies: [
-		.package(url: "https://github.com/Ranchero-Software/RSCore.git", .upToNextMajor(from: "1.0.0")),
-		.package(url: "https://github.com/Ranchero-Software/RSDatabase.git", .upToNextMajor(from: "1.0.0")),
-		.package(url: "../Articles", .upToNextMajor(from: "1.0.0")),
-    ],
+    dependencies: dependencies,
     targets: [
         .target(
             name: "SyncDatabase",


### PR DESCRIPTION
This PR fixes package resolution errors on Xcode 14 by replacing `.package(url:)` to `.package(path:)` on Swift 5.6 (Xcode 13.3) and above.