### PR TITLE
Older Smart Feed

### DIFF
--- a/Account/Sources/Account/Account.swift
+++ b/Account/Sources/Account/Account.swift
@@ -55,6 +55,7 @@ public enum FetchType {
     case starred(_: Int? = nil)
 	case unread(_: Int? = nil)
 	case today(_: Int? = nil)
+	case older(_: Int? = nil)
 	case folder(Folder, Bool)
 	case webFeed(WebFeed)
 	case articleIDs(Set<String>)
@@ -664,6 +665,8 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 			return try fetchUnreadArticles(limit: limit)
 		case .today(let limit):
 			return try fetchTodayArticles(limit: limit)
+		case .older(let limit):
+			return try fetchOlderArticles(limit: limit)
 		case .folder(let folder, let readFilter):
 			if readFilter {
 				return try fetchUnreadArticles(folder: folder)
@@ -689,6 +692,8 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 			fetchUnreadArticlesAsync(limit: limit, completion)
 		case .today(let limit):
 			fetchTodayArticlesAsync(limit: limit, completion)
+		case .older(let limit):
+			fetchOlderArticlesAsync(limit: limit, completion)
 		case .folder(let folder, let readFilter):
 			if readFilter {
 				return fetchUnreadArticlesAsync(folder: folder, completion)
@@ -708,6 +713,10 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 
 	public func fetchUnreadCountForToday(_ completion: @escaping SingleUnreadCountCompletionBlock) {
 		database.fetchUnreadCountForToday(for: flattenedWebFeeds().webFeedIDs(), completion: completion)
+	}
+
+	public func fetchUnreadCountForOlder(_ completion: @escaping SingleUnreadCountCompletionBlock) {
+		database.fetchUnreadCountForOlder(for: flattenedWebFeeds().webFeedIDs(), completion: completion)
 	}
 
 	public func fetchUnreadCountForStarredArticles(_ completion: @escaping SingleUnreadCountCompletionBlock) {
@@ -1060,6 +1069,14 @@ private extension Account {
 
 	func fetchArticlesAsync(folder: Folder, _ completion: @escaping ArticleSetResultBlock) {
 		fetchArticlesAsync(forContainer: folder, completion)
+	}
+
+	func fetchOlderArticles(limit: Int?) throws -> Set<Article> {
+		return try database.fetchOlderArticles(flattenedWebFeeds().webFeedIDs(), limit)
+	}
+
+	func fetchOlderArticlesAsync(limit: Int?, _ completion: @escaping ArticleSetResultBlock) {
+		database.fetchOlderArticlesAsync(flattenedWebFeeds().webFeedIDs(), limit, completion)
 	}
 
 	func fetchUnreadArticles(folder: Folder) throws -> Set<Article> {

--- a/ArticlesDatabase/Sources/ArticlesDatabase/ArticlesDatabase.swift
+++ b/ArticlesDatabase/Sources/ArticlesDatabase/ArticlesDatabase.swift
@@ -110,6 +110,10 @@ public final class ArticlesDatabase {
 		return try articlesTable.fetchArticlesSince(webFeedIDs, todayCutoffDate(), limit)
 	}
 
+	public func fetchOlderArticles(_ webFeedIDs: Set<String>, _ limit: Int?) throws -> Set<Article> {
+		return try articlesTable.fetchArticlesBetween(webFeedIDs, limit, before: todayCutoffDate())
+	}
+
 	public func fetchStarredArticles(_ webFeedIDs: Set<String>, _ limit: Int?) throws -> Set<Article> {
 		return try articlesTable.fetchStarredArticles(webFeedIDs, limit)
 	}
@@ -142,6 +146,10 @@ public final class ArticlesDatabase {
 
 	public func fetchTodayArticlesAsync(_ webFeedIDs: Set<String>, _ limit: Int?, _ completion: @escaping ArticleSetResultBlock) {
 		articlesTable.fetchArticlesSinceAsync(webFeedIDs, todayCutoffDate(), limit, completion)
+	}
+
+	public func fetchOlderArticlesAsync(_ webFeedIDs: Set<String>, _ limit: Int?, _ completion: @escaping ArticleSetResultBlock) {
+		articlesTable.fetchArticlesBetweenAsync(webFeedIDs, limit, completion, before: todayCutoffDate())
 	}
 
 	public func fetchedStarredArticlesAsync(_ webFeedIDs: Set<String>, _ limit: Int?, _ completion: @escaping ArticleSetResultBlock) {
@@ -195,6 +203,14 @@ public final class ArticlesDatabase {
 
 	public func fetchUnreadCount(for webFeedIDs: Set<String>, since: Date, completion: @escaping SingleUnreadCountCompletionBlock) {
 		articlesTable.fetchUnreadCount(webFeedIDs, since, completion)
+	}
+
+	public func fetchUnreadCountForOlder(for webFeedIDs: Set<String>, completion: @escaping SingleUnreadCountCompletionBlock) {
+		fetchUnreadCountBetween(for: webFeedIDs, before: todayCutoffDate(), completion: completion)
+	}
+
+	public func fetchUnreadCountBetween(for webFeedIDs: Set<String>, since: Date? = nil, before: Date? = nil, completion: @escaping SingleUnreadCountCompletionBlock) {
+		articlesTable.fetchUnreadCountBetween(webFeedIDs: webFeedIDs, since: since, before: before, completion: completion)
 	}
 
 	public func fetchStarredAndUnreadCount(for webFeedIDs: Set<String>, completion: @escaping SingleUnreadCountCompletionBlock) {

--- a/Mac/AppAssets.swift
+++ b/Mac/AppAssets.swift
@@ -242,6 +242,12 @@ struct AppAssets {
 		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 	}()
 
+	static var oldFeedImage: IconImage = {
+		let image = NSImage(systemSymbolName: "moon.zzz.fill", accessibilityDescription: nil)!
+		let preferredColor = NSColor.orange
+		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
+	}()
+
 	static var unreadFeedImage: IconImage = {
 		let image = NSImage(systemSymbolName: "largecircle.fill.circle", accessibilityDescription: nil)!
 		let preferredColor = NSColor(named: "AccentColor")!

--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		17E0084625941887000C23F0 /* SizeCategories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E0084525941887000C23F0 /* SizeCategories.swift */; };
 		17EF6A2125C4E5B4002C9F81 /* RSWeb in Frameworks */ = {isa = PBXBuildFile; productRef = 17EF6A2025C4E5B4002C9F81 /* RSWeb */; };
 		17EF6A2225C4E5B4002C9F81 /* RSWeb in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 17EF6A2025C4E5B4002C9F81 /* RSWeb */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		1B0D7B0228B9F6B4006B5005 /* OlderFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0D7B0128B9F6B4006B5005 /* OlderFeedDelegate.swift */; };
+		1B0D7B0328B9F7F8006B5005 /* OlderFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0D7B0128B9F6B4006B5005 /* OlderFeedDelegate.swift */; };
+		1B0D7B0428B9F7F9006B5005 /* OlderFeedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0D7B0128B9F6B4006B5005 /* OlderFeedDelegate.swift */; };
 		27B86EEB25A53AAB00264340 /* Account in Frameworks */ = {isa = PBXBuildFile; productRef = 51BC2F4A24D343A500E90810 /* Account */; };
 		4679674625E599C100844E8D /* Articles in Frameworks */ = {isa = PBXBuildFile; productRef = 4679674525E599C100844E8D /* Articles */; };
 		4679674725E599C100844E8D /* Articles in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 4679674525E599C100844E8D /* Articles */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -1152,6 +1155,7 @@
 		17D643B026F8A436008D4C05 /* ArticleThemeDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleThemeDownloader.swift; sourceTree = "<group>"; };
 		17D7586C2679C21700B17787 /* NetNewsWire-iOS-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NetNewsWire-iOS-Bridging-Header.h"; sourceTree = "<group>"; };
 		17E0084525941887000C23F0 /* SizeCategories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeCategories.swift; sourceTree = "<group>"; };
+		1B0D7B0128B9F6B4006B5005 /* OlderFeedDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OlderFeedDelegate.swift; sourceTree = "<group>"; };
 		49F40DEF2335B71000552BF4 /* newsfoot.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = newsfoot.js; sourceTree = "<group>"; };
 		510289CC24519A1D00426DDF /* SelectComboTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectComboTableViewCell.swift; sourceTree = "<group>"; };
 		510289CF2451BA3A00426DDF /* TwitterAdd.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TwitterAdd.storyboard; sourceTree = "<group>"; };
@@ -2760,6 +2764,7 @@
 				845EE7C01FC2488C00854A1F /* SmartFeed.swift */,
 				84DEE56422C32CA4005FC42C /* SmartFeedDelegate.swift */,
 				84F2D5361FC22FCB00998D64 /* TodayFeedDelegate.swift */,
+				1B0D7B0128B9F6B4006B5005 /* OlderFeedDelegate.swift */,
 				845EE7B01FC2366500854A1F /* StarredFeedDelegate.swift */,
 				8477ACBD22238E9500DF7F37 /* SearchFeedDelegate.swift */,
 				51938DF1231AFC660055A1A0 /* SearchTimelineFeedDelegate.swift */,
@@ -3961,6 +3966,7 @@
 				178A9F9E2549449F00AB7E9D /* AddAccountsView.swift in Sources */,
 				65ED402D235DEF6C0081F399 /* DetailStatusBarView.swift in Sources */,
 				65ED402E235DEF6C0081F399 /* MainWindowController+Scriptability.swift in Sources */,
+				1B0D7B0428B9F7F9006B5005 /* OlderFeedDelegate.swift in Sources */,
 				65ED402F235DEF6C0081F399 /* PreferencesWindowController.swift in Sources */,
 				65ED4030235DEF6C0081F399 /* SmallIconProvider.swift in Sources */,
 				653813192680E15B007A082C /* CacheCleaner.swift in Sources */,
@@ -4050,6 +4056,7 @@
 				51FA73A52332BE110090D516 /* ArticleExtractor.swift in Sources */,
 				51314704235C41FC00387FDC /* Intents.intentdefinition in Sources */,
 				FF3ABF162325AF5D0074C542 /* ArticleSorter.swift in Sources */,
+				1B0D7B0328B9F7F8006B5005 /* OlderFeedDelegate.swift in Sources */,
 				51C4525C226508DF00C03939 /* String-Extensions.swift in Sources */,
 				51F9F3F923DFB16300A314FD /* UITableView-Extensions.swift in Sources */,
 				51C452792265091600C03939 /* MasterTimelineTableViewCell.swift in Sources */,
@@ -4236,6 +4243,7 @@
 				849A97651ED9EB96007D329B /* WebFeedTreeControllerDelegate.swift in Sources */,
 				849A97671ED9EB96007D329B /* UnreadCountView.swift in Sources */,
 				510C418024E5D1AE008226FD /* ExtensionFeedAddRequestFile.swift in Sources */,
+				1B0D7B0228B9F6B4006B5005 /* OlderFeedDelegate.swift in Sources */,
 				51FE10092346739D0056195D /* ActivityType.swift in Sources */,
 				840BEE4121D70E64009BBAFA /* CrashReportWindowController.swift in Sources */,
 				8426118A1FCB67AA0086A189 /* WebFeedIconDownloader.swift in Sources */,

--- a/Shared/SmartFeeds/OlderFeedDelegate.swift
+++ b/Shared/SmartFeeds/OlderFeedDelegate.swift
@@ -1,0 +1,31 @@
+//
+//  OlderFeedDelegate.swift
+//  NetNewsWire
+//
+//  Created by Bryan Culver on 08/25/22.
+//  Copyright © 2017 Ranchero Software. All rights reserved.
+//
+
+import Foundation
+import RSCore
+import Articles
+import ArticlesDatabase
+import Account
+
+struct OlderFeedDelegate: SmartFeedDelegate {
+
+	var feedID: FeedIdentifier? {
+		return FeedIdentifier.smartFeed(String(describing: OlderFeedDelegate.self))
+	}
+
+	let nameForDisplay = NSLocalizedString("Old", comment: "Old pseudo-feed title")
+	let fetchType = FetchType.older(nil)
+	var smallIcon: IconImage? {
+		return AppAssets.oldFeedImage
+	}
+
+	func fetchUnreadCount(for account: Account, completion: @escaping SingleUnreadCountCompletionBlock) {
+		account.fetchUnreadCountForOlder(completion)
+	}
+}
+

--- a/Shared/SmartFeeds/SmartFeedsController.swift
+++ b/Shared/SmartFeeds/SmartFeedsController.swift
@@ -21,11 +21,12 @@ final class SmartFeedsController: DisplayNameProvider, ContainerIdentifiable {
 
 	var smartFeeds = [Feed]()
 	let todayFeed = SmartFeed(delegate: TodayFeedDelegate())
+	let olderFeed = SmartFeed(delegate: OlderFeedDelegate())
 	let unreadFeed = UnreadFeed()
 	let starredFeed = SmartFeed(delegate: StarredFeedDelegate())
 
 	private init() {
-		self.smartFeeds = [todayFeed, unreadFeed, starredFeed]
+		self.smartFeeds = [todayFeed, unreadFeed, starredFeed, olderFeed]
 	}
 	
 	func find(by identifier: FeedIdentifier) -> PseudoFeed? {
@@ -34,6 +35,8 @@ final class SmartFeedsController: DisplayNameProvider, ContainerIdentifiable {
 			switch stringIdentifer {
 			case String(describing: TodayFeedDelegate.self):
 				return todayFeed
+			case String(describing: OlderFeedDelegate.self):
+				return olderFeed
 			case String(describing: UnreadFeed.self):
 				return unreadFeed
 			case String(describing: StarredFeedDelegate.self):

--- a/iOS/AppAssets.swift
+++ b/iOS/AppAssets.swift
@@ -276,6 +276,11 @@ struct AppAssets {
 		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: UIColor.systemOrange.cgColor)
 	}
 
+	static var oldFeedImage: IconImage {
+		let image = UIImage(systemName: "moon.zzz.fill")!
+		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: UIColor.systemPurple.cgColor)
+	}
+
 	static var trashImage: UIImage = {
 		return UIImage(systemName: "trash")!
 	}()


### PR DESCRIPTION
While not a direct implementation of #662, this does provide a way to see all articles published before today.

To "Catch Up" a user can view the older feed and mark all as read.

The feed name "Old" is obviously open to change.

I have left some review comments asking for direction/feedback. This is my first Swift project so I might be missing some conventions.

![Screen Shot 2022-08-28 at 09 19 31](https://user-images.githubusercontent.com/31187/187076064-93603c41-0f32-49f1-9250-9c2b947cf4eb.jpg)

Getting a build failure (duplicate copy) for Mac due to NewsFax theme.