### PR TITLE
Fix iOS unread status indicator for ReaderAPI accounts

### DIFF
--- a/Account/Sources/Account/Account.swift
+++ b/Account/Sources/Account/Account.swift
@@ -844,7 +844,7 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 		database.markAndFetchNew(articleIDs: articleIDs, statusKey: statusKey, flag: flag) { result in
 			switch result {
 			case .success(let newArticleStatusIDs):
-				self.noteStatusesForArticleIDsDidChange(articleIDs: articleIDs, statusKey: statusKey, flag: flag)
+				self.noteStatusesForArticleIDsDidChange(articleIDs: newArticleStatusIDs, statusKey: statusKey, flag: flag)
 				completion?(.success(newArticleStatusIDs))
 			case .failure(let databaseError):
 				completion?(.failure(databaseError))


### PR DESCRIPTION
Fix for issue #3512 where the unread status indicator toggles state on each refresh for some ReaderAPI accounts (at least miniflux accounts, perhaps others).

This PR changes `markAndFetchNew` to only notify for article IDs that actually change as opposed to all article IDs. This seems to match the original intent of the method and fixes the “status toggling” issue.

TBH, I’m unsure precisely _why_ this fixes the issue for ReaderAPI accounts — I believe there’s a race condition in the ReaderAPI code on iOS (but not macOS) that’s the root cause, and notifying only on new article statuses during a refresh happens to fix it.