### PR TITLE
Always use localized compare when sorting list items presented to the user.

### DIFF
--- a/Account/Sources/Account/Account.swift
+++ b/Account/Sources/Account/Account.swift
@@ -153,7 +153,7 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 	
 	public var sortedFolders: [Folder]? {
 		if let folders = folders {
-			return Array(folders).sorted(by: { $0.nameForDisplay.caseInsensitiveCompare($1.nameForDisplay) == .orderedAscending })
+			return folders.sorted()
 		}
 		return nil
 	}

--- a/Shared/ArticleStyles/ArticleThemesManager.swift
+++ b/Shared/ArticleStyles/ArticleThemesManager.swift
@@ -135,7 +135,7 @@ private extension ArticleThemesManager {
 
 		let allThemeNames = appThemeNames.union(installedThemeNames)
 		
-		return allThemeNames.sorted(by: { $0.compare($1, options: .caseInsensitive) == .orderedAscending })
+		return allThemeNames.sorted(by: { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
 	}
 
 	func allThemePaths(_ folder: String) -> [String] {


### PR DESCRIPTION
When sorting list items presented to the user, one of `localizedStandardCompare` or `caseInsensitiveCompare` should always be used. This ensures items are sorted by the user's localization preferences.

This PR changes `compare` and `caseInsensitiveCompare` calls into their localized counterparts.