### PR TITLE
Allow toolbar buttons to work on text-only mode (#3732).

### DIFF
--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -1386,19 +1386,25 @@ private extension MainWindowController {
 		}
 	}
 
-	func buildToolbarButton(_ itemIdentifier: NSToolbarItem.Identifier, _ title: String, _ image: NSImage, _ selector: String) -> NSToolbarItem {
+	func buildToolbarButton(_ itemIdentifier: NSToolbarItem.Identifier, _ title: String, _ image: NSImage, _ selector: String, usesCustomButtonView: Bool = false) -> NSToolbarItem {
 		let toolbarItem = RSToolbarItem(itemIdentifier: itemIdentifier)
 		toolbarItem.autovalidates = true
 		
-		let button = NSButton()
-		button.bezelStyle = .texturedRounded
-		button.image = image
-		button.imageScaling = .scaleProportionallyDown
-		button.action = Selector((selector))
-		
-		toolbarItem.view = button
 		toolbarItem.toolTip = title
 		toolbarItem.label = title
+		
+		if usesCustomButtonView {
+			let button = NSButton()
+			button.bezelStyle = .texturedRounded
+			button.image = image
+			button.imageScaling = .scaleProportionallyDown
+			button.action = Selector((selector))
+			toolbarItem.view = button
+		} else {
+			toolbarItem.image = image
+			toolbarItem.isBordered = true
+			toolbarItem.action = Selector((selector))
+		}
 		return toolbarItem
 	}
 

--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -894,6 +894,7 @@ extension MainWindowController: NSToolbarDelegate {
 			button.action = #selector(toggleArticleExtractor(_:))
 			button.rightClickAction = #selector(showArticleExtractorMenu(_:))
 			toolbarItem.view = button
+			toolbarItem.menuFormRepresentation = NSMenuItem(title: description, action: #selector(toggleArticleExtractor(_:)), keyEquivalent: "")
 			return toolbarItem
 
 		case .share:
@@ -1400,6 +1401,7 @@ private extension MainWindowController {
 			button.imageScaling = .scaleProportionallyDown
 			button.action = Selector((selector))
 			toolbarItem.view = button
+			toolbarItem.menuFormRepresentation = NSMenuItem(title: title, action: Selector((selector)), keyEquivalent: "")
 		} else {
 			toolbarItem.image = image
 			toolbarItem.isBordered = true

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -65,7 +65,6 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 			if !representedObjectArraysAreEqual(oldValue, representedObjects) {
 				unreadCount = 0
 
-				selectionDidChange(nil)
 				if showsSearchResults {
 					fetchAndReplaceArticlesAsync()
 				} else {
@@ -75,6 +74,7 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 					}
 					updateUnreadCount()
 				}
+				selectionDidChange(nil)
 			}
 		}
 	}


### PR DESCRIPTION
This PR allows toolbar buttons to work on text-only mode (#3732).

`RSToolbarItem` should also be updated to accommodate this change. ([RSCore #69](https://github.com/Ranchero-Software/RSCore/pull/69))