### PR TITLE
Fix the credits view's size

### DIFF
--- a/Mac/MainWindow/About/CreditsNetNewsWireView.swift
+++ b/Mac/MainWindow/About/CreditsNetNewsWireView.swift
@@ -49,6 +49,7 @@ struct CreditsNetNewsWireView: View, LoadableAboutData {
 				.frame(height: 12)
 		}
 		.padding(.horizontal)
+		.frame(width: 400, height: 400)
 	}
 	
 	func contributorView(_ appCredit: AboutData.Contributor) -> some View {


### PR DESCRIPTION
When the credits view was visible, the window could be resized so the height was 0 and the width was restricted only by the window toolbar buttons.