### PR TITLE
Allow 'Open Link' item to show on the contextual menu of web links. (fixes #3666)

### DIFF
--- a/Mac/MainWindow/Detail/DetailWebView.swift
+++ b/Mac/MainWindow/Detail/DetailWebView.swift
@@ -117,7 +117,7 @@ private extension NSUserInterfaceItemIdentifier {
 
 private extension DetailWebView {
 
-	static let menuItemIdentifiersToHide: [NSUserInterfaceItemIdentifier] = [.DetailMenuItemIdentifierReload, .DetailMenuItemIdentifierOpenLink]
+	static let menuItemIdentifiersToHide: [NSUserInterfaceItemIdentifier] = [.DetailMenuItemIdentifierReload]
 	static let menuItemIdentifierMatchStrings = ["newwindow", "download"]
 
 	func shouldHideMenuItem(_ menuItem: NSMenuItem) -> Bool {


### PR DESCRIPTION
This PR allow 'Open Link' item to show on the contextual menu of web links, which fixes #3666.