### PR TITLE
Fixes dark mode on Keyboard Shortcuts

### DIFF
--- a/Mac/Resources/KeyboardShortcuts/KeyboardShortcuts.html
+++ b/Mac/Resources/KeyboardShortcuts/KeyboardShortcuts.html
@@ -12,6 +12,16 @@
 			line-height: 1.4em;
 			font-family: -apple-system;
 		}
+		@media (prefers-color-scheme: dark) {
+			body {
+				color: white;
+				background-color: #333333;
+			}
+			
+			table tr:nth-child(odd) {
+				background-color: #1E1E1E !important;
+			}
+		}
 		table {
 			width: 100%;
 			line-height: 2.0em;


### PR DESCRIPTION
Adds `@media (prefers-color-scheme: dark)` directive so that keyboard shortcuts can adapt to dark mode.

Fixes #3781 

<img width="732" alt="Screenshot 2023-01-05 at 08 15 12" src="https://user-images.githubusercontent.com/7046652/210673790-538a693a-0ffa-46f2-ae49-f982ff3aad55.png">

