### PR TITLE
Renames Default theme to NetNewsWire

### DIFF
--- a/Shared/ArticleStyles/ArticleTheme.swift
+++ b/Shared/ArticleStyles/ArticleTheme.swift
@@ -20,7 +20,7 @@ struct ArticleTheme: Equatable {
 	static let defaultTheme = ArticleTheme()
 	static let nnwThemeSuffix = ".nnwtheme"
 	
-	private static let defaultThemeName = NSLocalizedString("Default", comment: "Default")
+	private static let defaultThemeName = "NetNewsWire"
 	private static let unknownValue = NSLocalizedString("Unknown", comment: "Unknown Value")
 	
 	let path: String?

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -28,7 +28,7 @@ enum UserInterfaceColorPalette: Int, CustomStringConvertible, CaseIterable {
 
 final class AppDefaults {
 
-	static let defaultThemeName = "Default"
+	static let defaultThemeName = "NetNewsWire"
 	
 	static let shared = AppDefaults()
 	private init() {}

--- a/iOS/Article/ArticleViewController.swift
+++ b/iOS/Article/ArticleViewController.swift
@@ -267,7 +267,7 @@ class ArticleViewController: UIViewController, MainControllerIdentifiable, Loggi
 			themeActions.append(action)
 		}
 		
-		let defaultThemeAction = UIAction(title: NSLocalizedString("Default", comment: "Default"),
+		let defaultThemeAction = UIAction(title: "NetNewsWire",
 										  image: nil,
 										  identifier: nil,
 										  discoverabilityTitle: nil,


### PR DESCRIPTION
Where ‘NetNewsWire’ is used `NSLocalizedString` has been removed. This is so that ‘NetNewsWire’ is not picked via Export Localizations.