### PR TITLE
Shows Twitter Deprecation Alert on iOS

### DIFF
--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -58,6 +58,7 @@ final class AppDefaults {
 		static let addFolderAccountID = "addFolderAccountID"
 		static let useSystemBrowser = "useSystemBrowser"
 		static let currentThemeName = "currentThemeName"
+		static let twitterDeprecationAlertShown = "twitterDeprecationAlertShown"
 	}
 
 	let isDeveloperBuild: Bool = {
@@ -229,6 +230,15 @@ final class AppDefaults {
 		}
 		set {
 			AppDefaults.setString(for: Key.currentThemeName, newValue)
+		}
+	}
+	
+	var twitterDeprecationAlertShown: Bool {
+		get {
+			return AppDefaults.bool(for: Key.twitterDeprecationAlertShown)
+		}
+		set {
+			AppDefaults.setBool(for: Key.twitterDeprecationAlertShown, newValue)
 		}
 	}
 	

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -717,7 +717,7 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 	private func presentTwitterDeprecationAlertIfRequired() {
 		if AppDefaults.shared.twitterDeprecationAlertShown { return }
 		
-		let expiryDate = Date(timeIntervalSince1970: 1691510400).timeIntervalSince1970 // August 9th 2023
+		let expiryDate = Date(timeIntervalSince1970: 1691539200).timeIntervalSince1970 // August 9th 2023, 00:00 UTC
 		let currentDate = Date().timeIntervalSince1970
 		if currentDate > expiryDate {
 			return // If after August 9th, don't show

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -730,7 +730,6 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 				   let host = components.host else {
 					return
 				}
-				print(host)
 				if host == "twitter.com" {
 					twitterIsActive = true
 					return

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -73,6 +73,7 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 		NotificationCenter.default.addObserver(self, selector: #selector(contentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(configureContextMenu(_:)), name: .ActiveExtensionPointsDidChange, object: nil)
+		
 
 		refreshControl = UIRefreshControl()
 		refreshControl!.addTarget(self, action: #selector(refreshAccounts(_:)), for: .valueChanged)
@@ -84,6 +85,16 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 	override func viewWillAppear(_ animated: Bool) {
 		updateUI()
 		super.viewWillAppear(animated)
+	}
+	
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+		
+		if (isBeingPresented || isMovingToParent) {
+			// Only show the Twitter alert the first time
+			// the view is presented.
+			presentTwitterDeprecationAlertIfRequired()
+		}
 	}
 	
 	override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -690,7 +701,7 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 			self.addNewItemButton.menu = contextMenu
 		}
 	}
-	
+		
 	func focus() {
 		becomeFirstResponder()
 	}
@@ -701,6 +712,44 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 			let vc = SFSafariViewController(url: url)
 			present(vc, animated: true)
 		}
+	}
+	
+	private func presentTwitterDeprecationAlertIfRequired() {
+		if AppDefaults.shared.twitterDeprecationAlertShown { return }
+		
+		let expiryDate = Date(timeIntervalSince1970: 1691510400).timeIntervalSince1970 // August 9th 2023
+		let currentDate = Date().timeIntervalSince1970
+		if currentDate > expiryDate {
+			return // If after August 9th, don't show
+		}
+		
+		var twitterIsActive: Bool = false
+		AccountManager.shared.accounts.forEach({ account in
+			account.flattenedWebFeeds().forEach({ webfeed in
+				guard let components = URLComponents(string: webfeed.url),
+				   let host = components.host else {
+					return
+				}
+				print(host)
+				if host == "twitter.com" {
+					twitterIsActive = true
+					return
+				}
+			})
+		})
+		if twitterIsActive {
+			showTwitterDeprecationAlert()
+		}
+		AppDefaults.shared.twitterDeprecationAlertShown = true
+	}
+	
+	private func showTwitterDeprecationAlert() {
+		let alert = UIAlertController(title: "Twitter Integration Removed",
+									  message: "On February 1, 2023, Twitter announced the end of free access to the Twitter API, effective February 9.\n\nSince Twitter does not provide RSS feeds, we’ve had to use the Twitter API. Without free access to that API, we can’t read feeds from Twitter.\n\nWe’ve left your Twitter feeds intact. If you have any starred items from those feeds, they will remain as long as you don’t delete those feeds.\n\nYou can still read whatever you have already downloaded. However, those feeds will no longer update.",
+									  preferredStyle: .alert)
+		
+		alert.addAction(UIAlertAction(title: "OK", style: .cancel))
+		present(alert, animated: true)
 	}
 	
 }

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -743,8 +743,8 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 	}
 	
 	private func showTwitterDeprecationAlert() {
-		let alert = UIAlertController(title: "Twitter Integration Removed",
-									  message: "On February 1, 2023, Twitter announced the end of free access to the Twitter API, effective February 9.\n\nSince Twitter does not provide RSS feeds, we’ve had to use the Twitter API. Without free access to that API, we can’t read feeds from Twitter.\n\nWe’ve left your Twitter feeds intact. If you have any starred items from those feeds, they will remain as long as you don’t delete those feeds.\n\nYou can still read whatever you have already downloaded. However, those feeds will no longer update.",
+		let alert = UIAlertController(title: NSLocalizedString("Twitter Integration Removed", comment: "Twitter Integration Removed"),
+									  message: NSLocalizedString("On February 1, 2023, Twitter announced the end of free access to the Twitter API, effective February 9.\n\nSince Twitter does not provide RSS feeds, we’ve had to use the Twitter API. Without free access to that API, we can’t read feeds from Twitter.\n\nWe’ve left your Twitter feeds intact. If you have any starred items from those feeds, they will remain as long as you don’t delete those feeds.\n\nYou can still read whatever you have already downloaded. However, those feeds will no longer update.", comment: "Twitter deprecation message"),
 									  preferredStyle: .alert)
 		
 		alert.addAction(UIAlertAction(title: "OK", style: .cancel))

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -725,16 +725,18 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner {
 		
 		var twitterIsActive: Bool = false
 		AccountManager.shared.accounts.forEach({ account in
-			account.flattenedWebFeeds().forEach({ webfeed in
-				guard let components = URLComponents(string: webfeed.url),
-				   let host = components.host else {
-					return
-				}
-				if host == "twitter.com" {
-					twitterIsActive = true
-					return
-				}
-			})
+			if account.type == .cloudKit || account.type == .onMyMac {
+				account.flattenedWebFeeds().forEach({ webfeed in
+					guard let components = URLComponents(string: webfeed.url),
+					   let host = components.host else {
+						return
+					}
+					if host == "twitter.com" {
+						twitterIsActive = true
+						return
+					}
+				})
+			}
 		})
 		if twitterIsActive {
 			showTwitterDeprecationAlert()


### PR DESCRIPTION

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-05 at 07 46 01](https://user-images.githubusercontent.com/7046652/216795891-257d04b4-0282-4038-99ab-686be4c83813.png)
Adds a `twitterDeprecationAlertShown` `Bool` to AppDefaults. The default is `false`, and it is updated to `true` on the first time the `MasterFeedController`'s `presentTwitterDeprecationAlertIfRequired` is run.

`presentTwitterDeprecationAlertIfRequired` checks for the following and will return if any are `true`:
- `twitterDeprecationAlertShown`
- current date > August, 9th, 2023

If it gets through those checks, it looks at all accounts to see if they have a web feed with the host `twitter.com`. If they do, the alert is shown. Otherwise, no alert is shown. In both cases, `twitterDeprecationAlertShown` is set to `true`.
