### PR TITLE
Applies changes for #3886

### DIFF
--- a/Mac/AppAssets.swift
+++ b/Mac/AppAssets.swift
@@ -207,7 +207,7 @@ struct AppAssets {
 	}()
 	
 	static var starClosedImage: RSImage = {
-		return NSImage(systemSymbolName: "star.fill", accessibilityDescription: nil)!
+		return NSImage(systemSymbolName: "star", accessibilityDescription: nil)!
 	}()
 
 	static var starOpenImage: RSImage = {
@@ -215,7 +215,7 @@ struct AppAssets {
 	}()
 	
 	static var starredFeedImage: IconImage = {
-		let image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: nil)!
+		let image = NSImage(systemSymbolName: "star", accessibilityDescription: nil)!
 		let preferredColor = NSColor(named: "AccentColor")!
 		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 	}()
@@ -255,12 +255,12 @@ struct AppAssets {
 	}()
 
 	static var swipeMarkStarredImage: RSImage = {
-		return RSImage(systemSymbolName: "star.fill", accessibilityDescription: "Star")!
+		return RSImage(systemSymbolName: "star", accessibilityDescription: "Star")!
 			.withSymbolConfiguration(.init(scale: .large))!
 	}()
 
 	static var swipeMarkUnstarredImage: RSImage = {
-		return RSImage(systemSymbolName: "star", accessibilityDescription: "Unstar")!
+		return RSImage(systemSymbolName: "star.slash", accessibilityDescription: "Unstar")!
 			.withSymbolConfiguration(.init(scale: .large))!
 	}()
 	

--- a/Mac/AppAssets.swift
+++ b/Mac/AppAssets.swift
@@ -183,7 +183,7 @@ struct AppAssets {
 	}()
 	
 	static var readClosedImage: RSImage = {
-		return NSImage(systemSymbolName: "largecircle.fill.circle", accessibilityDescription: nil)!
+		return NSImage(systemSymbolName: "record.circle", accessibilityDescription: nil)!
 	}()
 
 	static var readOpenImage: RSImage = {
@@ -216,7 +216,7 @@ struct AppAssets {
 	
 	static var starredFeedImage: IconImage = {
 		let image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: nil)!
-		let preferredColor = NSColor(named: "StarColor")!
+		let preferredColor = NSColor(named: "AccentColor")!
 		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 	}()
 
@@ -229,17 +229,17 @@ struct AppAssets {
 	}()
 
 	static var timelineStarUnselected: RSImage! = {
-		return RSImage(named: "timelineStar")?.tinted(with: starColor)
+		return RSImage(named: "timelineStar")?.tinted(with: NSColor(named: "AccentColor")!)
 	}()
 
 	static var todayFeedImage: IconImage = {
-		let image = NSImage(systemSymbolName: "sun.max.fill", accessibilityDescription: nil)!
-		let preferredColor = NSColor.orange
+		let image = NSImage(systemSymbolName: "doc.text.image", accessibilityDescription: nil)!
+		let preferredColor = NSColor(named: "AccentColor")!
 		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 	}()
 
 	static var unreadFeedImage: IconImage = {
-		let image = NSImage(systemSymbolName: "largecircle.fill.circle", accessibilityDescription: nil)!
+		let image = NSImage(systemSymbolName: "record.circle", accessibilityDescription: nil)!
 		let preferredColor = NSColor(named: "AccentColor")!
 		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: preferredColor.cgColor)
 	}()
@@ -250,7 +250,7 @@ struct AppAssets {
 	}()
 
 	static var swipeMarkUnreadImage: RSImage = {
-		return RSImage(systemSymbolName: "largecircle.fill.circle", accessibilityDescription: "Mark Unread")!
+		return RSImage(systemSymbolName: "record.circle", accessibilityDescription: "Mark Unread")!
 			.withSymbolConfiguration(.init(scale: .large))!
 	}()
 
@@ -262,10 +262,6 @@ struct AppAssets {
 	static var swipeMarkUnstarredImage: RSImage = {
 		return RSImage(systemSymbolName: "star", accessibilityDescription: "Unstar")!
 			.withSymbolConfiguration(.init(scale: .large))!
-	}()
-	
-	static var starColor: NSColor = {
-		return NSColor(named: NSColor.Name("StarColor"))!
 	}()
 	
 	static func image(for accountType: AccountType) -> NSImage? {

--- a/Mac/Base.lproj/Main.storyboard
+++ b/Mac/Base.lproj/Main.storyboard
@@ -459,7 +459,7 @@
                                                 <action selector="gotoToday:" target="Ady-hI-5gd" id="GyO-dW-XCy"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="All Unread" keyEquivalent="2" id="8ZT-ew-JNc">
+                                        <menuItem title="All Unread" keyEquivalent="2" id="8ZT-ew-JNc" userLabel="Unread">
                                             <connections>
                                                 <action selector="gotoAllUnread:" target="Ady-hI-5gd" id="xGb-dU-hH7"/>
                                             </connections>

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -1008,7 +1008,7 @@ extension TimelineViewController: NSTableViewDelegate {
 					self.toggleArticleStarred(article);
 					tableView.rowActionsVisible = false
 				}
-				action.backgroundColor = AppAssets.starColor
+				action.backgroundColor = NSColor(named: "AccentColor")!
 				action.image = article.status.starred ? AppAssets.swipeMarkUnstarredImage : AppAssets.swipeMarkStarredImage
 				return [action]
 

--- a/Shared/SmartFeeds/UnreadFeed.swift
+++ b/Shared/SmartFeeds/UnreadFeed.swift
@@ -30,7 +30,7 @@ final class UnreadFeed: PseudoFeed {
 		return FeedIdentifier.smartFeed(String(describing: UnreadFeed.self))
 	}
 
-	let nameForDisplay = NSLocalizedString("All Unread", comment: "All Unread pseudo-feed title")
+	let nameForDisplay = NSLocalizedString("Unread", comment: "Unread pseudo-feed title")
 	let fetchType = FetchType.unread(nil)
 	
 	var unreadCount = 0 {

--- a/Widget/Widget Views/SmartFeedSummaryWidget.swift
+++ b/Widget/Widget Views/SmartFeedSummaryWidget.swift
@@ -71,7 +71,7 @@ struct SmartFeedSummaryWidgetView: View {
 	}
 	
 	var starredImage: some View {
-		Image(systemName: "star.fill")
+		Image(systemName: "star")
 			.resizable()
 			.frame(width: 12, height: 12, alignment: .center)
 	}

--- a/Widget/Widget Views/StarredWidget.swift
+++ b/Widget/Widget Views/StarredWidget.swift
@@ -78,7 +78,7 @@ struct StarredWidgetView : View {
 	}
 	
 	var starredImage: some View {
-		Image(systemName: "star.fill")
+		Image(systemName: "star")
 			.resizable()
 			.frame(width: 30, height: 30, alignment: .center)
 			.cornerRadius(4)
@@ -100,7 +100,7 @@ struct StarredWidgetView : View {
 	var inboxZero: some View {
 		VStack(alignment: .center) {
 			Spacer()
-			Image(systemName: "star.fill")
+			Image(systemName: "star")
 				.resizable()
 				.aspectRatio(contentMode: .fit)
 				.frame(width: 30)

--- a/iOS/AppAssets.swift
+++ b/iOS/AppAssets.swift
@@ -94,7 +94,7 @@ struct AppAssets {
 	}()
 
 	static var circleClosedImage: UIImage = {
-		return UIImage(systemName: "largecircle.fill.circle")!
+		return UIImage(systemName: "record.circle")!
 	}()
 	
 	static var circleOpenImage: UIImage = {
@@ -247,7 +247,7 @@ struct AppAssets {
 	
 	static var starredFeedImage: IconImage {
 		let image = UIImage(systemName: "star.fill")!
-		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: AppAssets.starColor.cgColor)
+		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: AppAssets.secondaryAccentColor.cgColor)
 	}
 	
 	static var themeImage: UIImage = {
@@ -260,12 +260,12 @@ struct AppAssets {
 	
 	static var timelineStarImage: UIImage = {
 		let image = UIImage(systemName: "star.fill")!
-		return image.withTintColor(AppAssets.starColor, renderingMode: .alwaysOriginal)
+		return image.withTintColor(AppAssets.secondaryAccentColor, renderingMode: .alwaysOriginal)
 	}()
 	
 	static var todayFeedImage: IconImage {
-		let image = UIImage(systemName: "sun.max.fill")!
-		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: UIColor.systemOrange.cgColor)
+		let image = UIImage(systemName: "doc.text.image")!
+		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: AppAssets.secondaryAccentColor.cgColor)
 	}
 
 	static var trashImage: UIImage = {
@@ -273,7 +273,7 @@ struct AppAssets {
 	}()
 	
 	static var unreadFeedImage: IconImage {
-		let image = UIImage(systemName: "largecircle.fill.circle")!
+		let image = UIImage(systemName: "record.circle")!
 		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: AppAssets.secondaryAccentColor.cgColor)
 	}
 	

--- a/iOS/AppAssets.swift
+++ b/iOS/AppAssets.swift
@@ -233,10 +233,6 @@ struct AppAssets {
 		return UIImage(systemName: "gear")!
 	}()
 	
-	static var starColor: UIColor = {
-		return UIColor(named: "starColor")!
-	}()
-	
 	static var starClosedImage: UIImage = {
 		return UIImage(systemName: "star.fill")!
 	}()

--- a/iOS/AppAssets.swift
+++ b/iOS/AppAssets.swift
@@ -234,7 +234,7 @@ struct AppAssets {
 	}()
 	
 	static var starClosedImage: UIImage = {
-		return UIImage(systemName: "star.fill")!
+		return UIImage(systemName: "star.slash")!
 	}()
 	
 	static var starOpenImage: UIImage = {
@@ -242,7 +242,7 @@ struct AppAssets {
 	}()
 	
 	static var starredFeedImage: IconImage {
-		let image = UIImage(systemName: "star.fill")!
+		let image = UIImage(systemName: "star")!
 		return IconImage(image, isSymbol: true, isBackgroundSupressed: true, preferredColor: AppAssets.secondaryAccentColor.cgColor)
 	}
 	
@@ -255,7 +255,7 @@ struct AppAssets {
 	}()
 	
 	static var timelineStarImage: UIImage = {
-		let image = UIImage(systemName: "star.fill")!
+		let image = UIImage(systemName: "star")!
 		return image.withTintColor(AppAssets.secondaryAccentColor, renderingMode: .alwaysOriginal)
 	}()
 	

--- a/iOS/KeyboardManager.swift
+++ b/iOS/KeyboardManager.swift
@@ -144,7 +144,7 @@ private extension KeyboardManager {
 		let goToTodayTitle = NSLocalizedString("Go To Today", comment: "Go To Today")
 		keys.append(KeyboardManager.createKeyCommand(title: goToTodayTitle, action: "goToToday:", input: "1", modifiers: [.command]))
 
-		let goToAllUnreadTitle = NSLocalizedString("Go To All Unread", comment: "Go To All Unread")
+		let goToAllUnreadTitle = NSLocalizedString("Go To Unread", comment: "Go To Unread")
 		keys.append(KeyboardManager.createKeyCommand(title: goToAllUnreadTitle, action: "goToAllUnread:", input: "2", modifiers: [.command]))
 
 		let goToStarredTitle = NSLocalizedString("Go To Starred", comment: "Go To Starred")

--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -303,7 +303,7 @@ class MasterTimelineViewController: UITableViewController, UndoableCommandRunner
 		}
 		
 		starAction.image = article.status.starred ? AppAssets.starOpenImage : AppAssets.starClosedImage
-		starAction.backgroundColor = AppAssets.starColor
+		starAction.backgroundColor = AppAssets.primaryAccentColor
 		
 		// Set up the read action
 		let moreTitle = NSLocalizedString("More", comment: "More")

--- a/iOS/MasterTimeline/MasterTimelineViewController.swift
+++ b/iOS/MasterTimeline/MasterTimelineViewController.swift
@@ -302,7 +302,7 @@ class MasterTimelineViewController: UITableViewController, UndoableCommandRunner
 			completion(true)
 		}
 		
-		starAction.image = article.status.starred ? AppAssets.starOpenImage : AppAssets.starClosedImage
+		starAction.image = article.status.starred ? AppAssets.starClosedImage : AppAssets.starOpenImage
 		starAction.backgroundColor = AppAssets.primaryAccentColor
 		
 		// Set up the read action
@@ -768,7 +768,7 @@ private extension MasterTimelineViewController {
 		let title = article.status.starred ?
 			NSLocalizedString("Mark as Unstarred", comment: "Mark as Unstarred") :
 			NSLocalizedString("Mark as Starred", comment: "Mark as Starred")
-		let image = article.status.starred ? AppAssets.starOpenImage : AppAssets.starClosedImage
+		let image = article.status.starred ? AppAssets.starClosedImage : AppAssets.starOpenImage
 
 		let action = UIAction(title: title, image: image) { [weak self] action in
 			self?.coordinator.toggleStar(article)


### PR DESCRIPTION
Closes #3886 

Mac:
- Feeds renamed
- Icons changed
- Swipe actions tinted uniformly

<img width="606" alt="Screenshot 2023-03-01 at 08 31 51" src="https://user-images.githubusercontent.com/7046652/222014546-56ed167d-c291-4081-a5a6-f4bec92054d0.png">

<img width="607" alt="Screenshot 2023-03-01 at 08 31 40" src="https://user-images.githubusercontent.com/7046652/222014533-d594564f-7a17-4170-b1d9-21d2167dec57.png">

iOS:
- Feeds renamed
- Icons changed
- Icons are tinted with secondary accent colour
- Swipe actions tinted uniformly (excluding _More_ which remains gray)

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-01 at 08 35 16](https://user-images.githubusercontent.com/7046652/222014968-ffb24342-418d-47d0-b718-ace9864841f1.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-01 at 08 35 20](https://user-images.githubusercontent.com/7046652/222014980-31064010-4450-4c14-8baf-36495a6bf473.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-01 at 08 35 43](https://user-images.githubusercontent.com/7046652/222014990-473b5d7f-abe6-46f5-a10e-23830d0ca27a.png)
