### PR TITLE
Fixes #3910

### DIFF
--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -564,6 +564,8 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner, Ma
 			return
 		}
 		
+		if tableView.window == nil { return }
+		
 		tableView.performBatchUpdates {
 			if let deletes = changes.deletes, !deletes.isEmpty {
 				tableView.deleteSections(IndexSet(deletes), with: .middle)

--- a/iOS/MasterFeed/MasterFeedViewController.swift
+++ b/iOS/MasterFeed/MasterFeedViewController.swift
@@ -564,7 +564,10 @@ class MasterFeedViewController: UITableViewController, UndoableCommandRunner, Ma
 			return
 		}
 		
-		if tableView.window == nil { return }
+		if tableView.window == nil {
+			completion?()
+			return
+		}
 		
 		tableView.performBatchUpdates {
 			if let deletes = changes.deletes, !deletes.isEmpty {


### PR DESCRIPTION
`UITableViewAlertForLayoutOutsideViewHierarchy` will no longer fire as a check has been added to make sure that the tableView’s `window` property is not nil—i.e., it's in the view hierarchy—before performing batch updates.