### PR TITLE
Allow ImageViewController to be closed with the space key on physical keyoard for iOS.

### DIFF
--- a/iOS/Article/ImageViewController.swift
+++ b/iOS/Article/ImageViewController.swift
@@ -25,6 +25,16 @@ class ImageViewController: UIViewController {
 		return imageScrollView.zoomedFrame
 	}
 	
+	override var keyCommands: [UIKeyCommand]? {
+		return [
+			UIKeyCommand(
+				title: NSLocalizedString("Close Image", comment: "Close Image"),
+				action: #selector(done(_:)),
+				input: " "
+			)
+		]
+	}
+	
 	override func viewDidLoad() {
         super.viewDidLoad()
 		


### PR DESCRIPTION
Closes #3954.

This PR adds the space key as a `UIKeyCommand` for `ImageViewController` to allow it to be closed with physical key stroke on iOS.

This matches the behavior of Apple's own app like Photos, improving the support for full keyboard navigation.

NetNewsWire:

<img width="652" alt="Screenshot 2023-04-22 at 20 09 56" src="https://user-images.githubusercontent.com/8158163/233784297-4de2f388-3ed4-4968-a6e7-6c71efa733af.png">

Apple Photos:

<img width="644" alt="Screenshot 2023-04-22 at 20 10 48" src="https://user-images.githubusercontent.com/8158163/233784293-7b0d1bc1-ac44-4ad8-8ee6-c402f03631d2.png">