### PR TITLE
Disable audio autoplay on macOS

### DIFF
--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -90,6 +90,7 @@ protocol DetailWebViewControllerDelegate: AnyObject {
 		configuration.defaultWebpagePreferences = webpagePrefs
 		configuration.preferences = preferences
 		configuration.setURLSchemeHandler(detailIconSchemeHandler, forURLScheme: ArticleRenderer.imageIconScheme)
+		configuration.mediaTypesRequiringUserActionForPlayback = .audio
 
 		let userContentController = WKUserContentController()
 		userContentController.add(self, name: MessageName.windowDidScroll)


### PR DESCRIPTION
- To be in-line with how this is treated on iOS

Closes #3025
Closes #2696

As far as I could tell with my brief overview, this: https://github.com/Ranchero-Software/NetNewsWire/blob/2ef66d78e83f71470e3c0916f8bafc0fb16a37c2/iOS/Article/PreloadedWebView.swift#L31

Is the corresponding configuration for iOS

I did manage to build this locally and confirm that it stops the autoplaying youtube-embed in the "Nei, Norge svelger ikke fem EØS-rettsakter per arbeidsdag"-article from https://www.faktisk.no/atom.xml