### PR TITLE
Do not make the sidebar first responder when it’s collapsed.

### DIFF
--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -87,7 +87,9 @@ enum TimelineSourceMode {
 
 		detailSplitViewItem?.minimumThickness = CGFloat(MainWindowController.detailViewMinimumThickness)
 
-		sidebarViewController = splitViewController?.splitViewItems[0].viewController as? SidebarViewController
+		let sidebarSplitViewItem = splitViewController?.splitViewItems[0]
+		sidebarViewController = sidebarSplitViewItem?.viewController as? SidebarViewController
+		sidebarViewController!.splitViewItem = sidebarSplitViewItem
 		sidebarViewController!.delegate = self
 
 		timelineContainerViewController = splitViewController?.splitViewItems[1].viewController as? TimelineContainerViewController

--- a/Mac/MainWindow/Sidebar/SidebarViewController.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController.swift
@@ -29,6 +29,8 @@ protocol SidebarDelegate: AnyObject {
 	
 	weak var delegate: SidebarDelegate?
 
+	weak var splitViewItem: NSSplitViewItem?
+
 	private let rebuildTreeAndRestoreSelectionQueue = CoalescingQueue(name: "Rebuild Tree Queue", interval: 1.0)
 	let treeControllerDelegate = WebFeedTreeControllerDelegate()
 	lazy var treeController: TreeController = {
@@ -323,6 +325,7 @@ protocol SidebarDelegate: AnyObject {
 	}
 
 	func focus() {
+		if splitViewItem?.isCollapsed == true { return }
 		outlineView.window?.makeFirstResponderUnlessDescendantIsFirstResponder(outlineView)
 	}
 


### PR DESCRIPTION
Fixes #3944.

We should not actually send `makeFistResponder:` at `SidebarViewController.focus()` when it's collapsed.

`-[NSView setHidden:]` has a bahavior that tries to focus the receiver when the current `firstResponder` is hidden:

<img width="1404" alt="Screenshot 2023-05-26 at 13 03 33" src="https://github.com/Ranchero-Software/NetNewsWire/assets/8158163/397a1fb5-ed3e-4d74-a2b8-6b6a721b160c">

Since arbitrary calls to `setHidden:` are likely to cause the focus to be stolen by another view.  Keyboard navigation on the hidden `sidebarViewController` would be mostly problematic.