### PR TITLE
Fix Privacy Policy link

### DIFF
--- a/Mac/AppAssets.swift
+++ b/Mac/AppAssets.swift
@@ -182,7 +182,7 @@ struct AppAssets {
 	}()
 
 	static var privacyPolicyLink: NSAttributedString = {
-		return NSAttributedString(linkText: NSLocalizedString("label.text.privacy-policy", comment: "Privacy Policy"), linkURL: URL(string: "https://netnewswire.com/privacypolicy")!)
+		return NSAttributedString(linkText: NSLocalizedString("label.text.privacy-policy", comment: "Privacy Policy"), linkURL: URL(string: "https://netnewswire.com/privacypolicy.html")!)
 	}()
 	
 	static var readClosedImage: RSImage = {


### PR DESCRIPTION
### Changes
Fix Privacy Policy link
`https://netnewswire.com/privacypolicy` -> `https://netnewswire.com/privacypolicy.html`

Fixes #4027 