### PR TITLE
Fix the issue that the article webView don’t show up on launch until it finishes loading all the page resources.

### DIFF
--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -240,7 +240,7 @@ extension DetailWebViewController: WKNavigationDelegate, WKUIDelegate {
 		decisionHandler(.allow)
 	}
 	
-	public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+	public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
 		// See note in viewDidLoad()
 		if waitingForFirstReload {
 			assert(webView.isHidden)
@@ -252,11 +252,14 @@ extension DetailWebViewController: WKNavigationDelegate, WKUIDelegate {
 			DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
 				webView.isHidden = false
 			}
-		} else {
-			if let windowScrollY = windowScrollY {
-				webView.evaluateJavaScript("window.scrollTo(0, \(windowScrollY));")
-				self.windowScrollY = nil
-			}
+		}
+	}
+
+	public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+		assert(!waitingForFirstReload)
+		if let windowScrollY = windowScrollY {
+			webView.evaluateJavaScript("window.scrollTo(0, \(windowScrollY));")
+			self.windowScrollY = nil
 		}
 	}
 


### PR DESCRIPTION
Fixes #4030.

By unhiding the article webView at `webView:didCommitNavigation:` instead of `webView:didFinishNavigation:`, this PR fixes the issue that that the article webView don’t show up on launch until it finishes loading all the page resources (or waits until the last request times out).

The issue happens when certain images on the page take long time to load, or could be reproduced with a poor network condition.