### PR TITLE
Add `authorID` to `search` virtual table

### DIFF
--- a/ArticlesDatabase/Sources/ArticlesDatabase/ArticlesDatabase.swift
+++ b/ArticlesDatabase/Sources/ArticlesDatabase/ArticlesDatabase.swift
@@ -344,7 +344,7 @@ private extension ArticlesDatabase {
 
 	CREATE INDEX if not EXISTS statuses_starred_index on statuses (starred);
 
-	CREATE VIRTUAL TABLE if not EXISTS search using fts4(title, body);
+	CREATE VIRTUAL TABLE if not EXISTS search using fts4(title, body, authorID);
 
 	CREATE TRIGGER if not EXISTS articles_after_delete_trigger_delete_search_text after delete on articles begin delete from search where rowid = OLD.searchRowID; end;
 	"""


### PR DESCRIPTION
I'm not sure if this will solve #4003 as I don't know what `authorID` actually looks like.  It might need the `author.name` instead.