### PR TITLE
Fix footnote popovers overlapping nearby later footnote bubbles

### DIFF
--- a/Shared/Article Rendering/newsfoot.js
+++ b/Shared/Article Rendering/newsfoot.js
@@ -55,7 +55,9 @@
 			this.popover = footnoteMarkup(content);
 			this.style = window.getComputedStyle(this.popover);
 			this.fnref = fnref;
-			this.fnref.closest(`.${CONTAINER_CLS}`).insertBefore(this.popover, fnref);
+			let container = this.fnref.closest(`.${CONTAINER_CLS}`);
+			container.insertBefore(this.popover, fnref);
+			container.style.zIndex = 1;
 			/** @type {HTMLElement} */
 		    this.arrow = this.popover.querySelector(`.${POPOVER_ARROW_CLS}`);
 			this.reposition();
@@ -77,6 +79,7 @@
 		}
   
 		cleanup() {
+			this.fnref.closest(`.${CONTAINER_CLS}`).style.zIndex = 0;
 			remove(this.popover);
 			document.removeEventListener("click", this.clickoutHandler, {capture: true});
 			window.removeEventListener("resize", this.resizeHandler);


### PR DESCRIPTION
Fixes #4117.

#### Causes

When a footnote bubble/pill is clicked, it's wrapped in a relatively-positioned container, which adds an implicit z-index. Explicitly setting the z-index on containers when clicking in/out fixes this issue.