### PR TITLE
Re-add figcaption margin

### DIFF
--- a/Shared/Article Rendering/stylesheet.css
+++ b/Shared/Article Rendering/stylesheet.css
@@ -263,6 +263,10 @@ figure {
 	margin-top: 1em;
 }
 
+figure > * + * {
+	margin-top: 0.5em;
+}
+
 figcaption {
 	font-size: 14px;
 	line-height: 1.3em;


### PR DESCRIPTION
This re-adds the top-margin on figcaption change (https://github.com/Ranchero-Software/NetNewsWire/pull/3477) that was removed when the default theme was changed.

This change is slightly improved from the previous implementation so that the margin spacing appears regardless of the order of `img` and `figcaption` within `figure`.