### PR TITLE
Change toggle sidebar button ID to the correct one

### DIFF
--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -796,7 +796,7 @@ extension MainWindowController: NSToolbarDelegate {
 
 		case .sidebarToggle:
 			let title = NSLocalizedString("Toggle Sidebar", comment: "Toggle Sidebar")
-			return buildToolbarButton(.toggleSidebar, title, AppAsset.Mac.Toolbar.sidebarToggle, "toggleTheSidebar:")
+			return buildToolbarButton(.sidebarToggle, title, AppAsset.Mac.Toolbar.sidebarToggle, "toggleTheSidebar:")
 
 		case .refresh:
 			let title = NSLocalizedString("Refresh", comment: "Refresh")


### PR DESCRIPTION
Fixes #4103 

UIKit printed out a debug message that the wrong ID was used. This fixes it and now it appears in the toolbar

![image](https://github.com/Ranchero-Software/NetNewsWire/assets/21402/c1d10152-2ae3-4721-9477-5cb80421b188)

@brentsimmons my best guess is your system saved the correct ID somewhere so it continued to work 🤷‍♂️