### PR TITLE
Fix account add crash

### DIFF
--- a/Mac/Preferences/Accounts/AccountsPreferencesViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsPreferencesViewController.swift
@@ -24,6 +24,7 @@ final class AccountsPreferencesViewController: NSViewController {
 	@IBOutlet weak var deleteButton: NSButton!
 	var addAccountDelegate: AccountsPreferencesAddAccountDelegate?
 	var addAccountWindowController: NSWindowController?
+	var addAccountsViewController: NSHostingController<AddAccountsView>?
 	
 	private var sortedAccounts = [Account]()
 
@@ -52,6 +53,7 @@ final class AccountsPreferencesViewController: NSViewController {
 		let controller = NSHostingController(rootView: AddAccountsView(delegate: self))
 		controller.rootView.parent = controller
 		presentAsSheet(controller)
+		addAccountsViewController = controller
 	}
 	
 	@IBAction func removeAccount(_ sender: Any) {


### PR DESCRIPTION
As reported in #3606, it was the case that attempting to add an account could result in a crash. This fixes the problem by retaining the `NSHostingController` that holds the `AddAccountsView` view in a manner similar to how 48138b1 retained `accountsAddLocalWindowController`.