### PR TITLE
Fix bug where Newsblur feeds don't update

### DIFF
--- a/NewsBlur/Sources/NewsBlur/NewsBlurAPICaller.swift
+++ b/NewsBlur/Sources/NewsBlur/NewsBlurAPICaller.swift
@@ -71,7 +71,7 @@ import Secrets
 			.appendingPathComponent("reader/feeds")
 			.appendingQueryItems([
 				URLQueryItem(name: "flat", value: "true"),
-				URLQueryItem(name: "update_counts", value: "false"),
+				URLQueryItem(name: "update_counts", value: "true"),
 			])
 
 		let (_, payload) = try await requestData(callURL: url, resultType: NewsBlurFeedsResponse.self)


### PR DESCRIPTION
`update_counts` == `false` means that feeds going from a read to unread status won't update in NNW. Set to `true` so that we see them!

See: https://github.com/samuelclay/NewsBlur/issues/1821