### PR TITLE
Mention .xcodeproj in readme instead .xcworkspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ aDirectory/
   SharedXcodeSettings/
     DeveloperSettings.xcconfig
   NetNewsWire/
-    NetNewsWire.xcworkspace
+    NetNewsWire.xcodeproj
 ```
 Example:
 


### PR DESCRIPTION
In  README, under directory structure ,NetNewsWire.xcworkspace is mentioned. Instead we have NetNewsWire.xcodeproj in our project. 

<img width="640" alt="Screenshot 2024-09-06 at 8 39 02 PM" src="https://github.com/user-attachments/assets/87e36c19-a7f0-434c-8bec-e8d8e779dda1">
