### PR TITLE
Add protocol to FreshRSS example URLs

### DIFF
--- a/Mac/Preferences/Accounts/AccountsReaderAPIWindowController.swift
+++ b/Mac/Preferences/Accounts/AccountsReaderAPIWindowController.swift
@@ -44,7 +44,7 @@ class AccountsReaderAPIWindowController: NSWindowController {
 				titleLabel.stringValue = NSLocalizedString("Sign in to your FreshRSS account.", comment: "FreshRSS")
 				noAccountTextField.stringValue = NSLocalizedString("Don’t have a FreshRSS instance?", comment: "No FreshRSS")
 				createAccountButton.title = NSLocalizedString("Find out more", comment: "No FreshRSS Button")
-				apiURLTextField.placeholderString = NSLocalizedString("fresh.rss.net/api/greader.php", comment: "FreshRSS API Helper")
+				apiURLTextField.placeholderString = NSLocalizedString("https://fresh.rss.net/api/greader.php", comment: "FreshRSS API Helper")
 			case .inoreader:
 				titleImageView.image = AppAsset.inoReaderImage
 				titleLabel.stringValue = NSLocalizedString("Sign in to your InoReader account.", comment: "InoReader")

--- a/iOS/Account/ReaderAPIAccountViewController.swift
+++ b/iOS/Account/ReaderAPIAccountViewController.swift
@@ -56,7 +56,7 @@ class ReaderAPIAccountViewController: UITableViewController {
 			switch unwrappedAccountType {
 			case .freshRSS:
 				title = NSLocalizedString("FreshRSS", comment: "FreshRSS")
-				apiURLTextField.placeholder = NSLocalizedString("API URL: fresh.rss.net/api/greader.php", comment: "FreshRSS API Helper")
+				apiURLTextField.placeholder = NSLocalizedString("API URL: https://fresh.rss.net/api/greader.php", comment: "FreshRSS API Helper")
 			case .inoreader:
 				title = NSLocalizedString("InoReader", comment: "InoReader")
 			case .bazQux:


### PR DESCRIPTION
As a new user it's not obvious that the FreshRSS API URL needs to
include the protocol since the example URL does not have it. Add the
protocol to the example URL to clarify that.
