### PR TITLE
Add http and https to the list of CFBundleURLSchemes.

### DIFF
--- a/Mac/Resources/Info.plist
+++ b/Mac/Resources/Info.plist
@@ -37,6 +37,8 @@
 				<string>feed</string>
 				<string>feeds</string>
 				<string>x-netnewswire-feed</string>
+				<string>http</string>
+				<string>https</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
If NetNewsWire on macOS says it is able to handle http and https URL schemes then Safari will list NetNewsWire as a target in Develop > Open Page With, which provides a trivial flow for subscribing to the page or site one is currently reading in Safari. This has the advantage of providing a reasonably fast path for subscription without requiring users configure the app extension to get the functionality.

This change implements https://github.com/Ranchero-Software/NetNewsWire/issues/4465.
