### PR TITLE
💄 Stops footnote links being inadvertently hidden

### DIFF
--- a/Shared/Article Rendering/core.css
+++ b/Shared/Article Rendering/core.css
@@ -114,8 +114,7 @@ img[src*="share-buttons"] {
 
 .newsfoot-footnote-popover .reversefootnote,
 .newsfoot-footnote-popover .footnoteBackLink,
-.newsfoot-footnote-popover .footnote-return,
-.newsfoot-footnote-popover a[href*='#fn'] {
+.newsfoot-footnote-popover .footnote-return {
 	display: none;
 }
 


### PR DESCRIPTION
Stops `display: none` applying to `.newsfoot-footnote-popover a[href*='#fn’]`. This was indavertently hiding `<a>` elements where the href contains `#fn`…thus a link inside a footnote that links to another footnote was being hidden. Fixes #4485