### PR TITLE
🩹 Fixes incorrect refresh control visibility 

### DIFF
--- a/iOS/MainTimeline/TimelineViewController.swift
+++ b/iOS/MainTimeline/TimelineViewController.swift
@@ -60,9 +60,6 @@ class TimelineViewController: UITableViewController, UndoableCommandRunner {
 		NotificationCenter.default.addObserver(self, selector: #selector(displayNameDidChange), name: .DisplayNameDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
 		
-		// Split View Controller Delegate
-		splitViewController?.delegate = self
-		
 		// Initialize Programmatic Buttons
 		filterButton = UIBarButtonItem(image: AppAssets.filterInactiveImage, style: .plain, target: self, action: #selector(toggleFilter(_:)))
 		firstUnreadButton = UIBarButtonItem(image: AppAssets.nextUnreadArticleImage, style: .plain, target: self, action: #selector(firstUnread(_:)))
@@ -599,39 +596,6 @@ extension TimelineViewController: UISearchBarDelegate {
 		let searchScope = SearchScope(rawValue: selectedScope)!
 		coordinator.searchArticles(searchBar.text!, searchScope)
 	}
-}
-
-extension TimelineViewController: UISplitViewControllerDelegate {
-	
-	func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
-		switch displayMode {
-		case .automatic:
-			return
-		case .secondaryOnly:
-			return
-		case .oneBesideSecondary:
-			// Timeline + Article - show the refresh control on the timeline
-			self.toolbarItems?[2].customView?.alpha = 1.0
-		case .oneOverSecondary:
-			return
-		case .twoBesideSecondary:
-			return
-		case .twoOverSecondary:
-			return
-		case .twoDisplaceSecondary:
-			// Sidebar + Timeline + Article - hide the refresh control on the timeline
-			self.toolbarItems?[2].customView?.alpha = 0.0
-		case .primaryHidden:
-			return
-		case .allVisible:
-			return
-		case .primaryOverlay:
-			return
-		@unknown default:
-			return
-		}
-	}
-	
 }
 
 // MARK: Private

--- a/iOS/MainTimeline/TimelineViewController.swift
+++ b/iOS/MainTimeline/TimelineViewController.swift
@@ -59,7 +59,10 @@ class TimelineViewController: UITableViewController, UndoableCommandRunner {
 		NotificationCenter.default.addObserver(self, selector: #selector(contentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(displayNameDidChange), name: .DisplayNameDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
-
+		
+		// Split View Controller Delegate
+		splitViewController?.delegate = self
+		
 		// Initialize Programmatic Buttons
 		filterButton = UIBarButtonItem(image: AppAssets.filterInactiveImage, style: .plain, target: self, action: #selector(toggleFilter(_:)))
 		firstUnreadButton = UIBarButtonItem(image: AppAssets.nextUnreadArticleImage, style: .plain, target: self, action: #selector(firstUnread(_:)))
@@ -598,11 +601,44 @@ extension TimelineViewController: UISearchBarDelegate {
 	}
 }
 
+extension TimelineViewController: UISplitViewControllerDelegate {
+	
+	func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
+		switch displayMode {
+		case .automatic:
+			return
+		case .secondaryOnly:
+			return
+		case .oneBesideSecondary:
+			// Timeline + Article - show the refresh control on the timeline
+			self.toolbarItems?[2].customView?.alpha = 1.0
+		case .oneOverSecondary:
+			return
+		case .twoBesideSecondary:
+			return
+		case .twoOverSecondary:
+			return
+		case .twoDisplaceSecondary:
+			// Sidebar + Timeline + Article - hide the refresh control on the timeline
+			self.toolbarItems?[2].customView?.alpha = 0.0
+		case .primaryHidden:
+			return
+		case .allVisible:
+			return
+		case .primaryOverlay:
+			return
+		@unknown default:
+			return
+		}
+	}
+	
+}
+
 // MARK: Private
 
 private extension TimelineViewController {
 
-	func configureToolbar() {		
+	func configureToolbar() {
 		guard !(splitViewController?.isCollapsed ?? true) else {
 			return
 		}

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -1310,6 +1310,35 @@ extension SceneCoordinator: UISplitViewControllerDelegate {
 		}
 	}
 	
+	func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
+		switch displayMode {
+		case .automatic:
+			return
+		case .secondaryOnly:
+			return
+		case .oneBesideSecondary:
+			// Timeline + Article - show the refresh control on the timeline
+			mainTimelineViewController?.toolbarItems?[2].customView?.alpha = 1.0
+		case .oneOverSecondary:
+			return
+		case .twoBesideSecondary:
+			return
+		case .twoOverSecondary:
+			return
+		case .twoDisplaceSecondary:
+			// Sidebar + Timeline + Article - hide the refresh control on the timeline
+			mainTimelineViewController?.toolbarItems?[2].customView?.alpha = 0.0
+		case .primaryHidden:
+			return
+		case .allVisible:
+			return
+		case .primaryOverlay:
+			return
+		@unknown default:
+			return
+		}
+	}
+	
 }
 
 // MARK: UINavigationControllerDelegate


### PR DESCRIPTION
Makes `TimelineViewController` a `UISplitViewControllerDelegate`.

- When the display mode is such that the feeds, timeline and article are visible, the timeline refresh control is hidden. 
- When the display mode is such that the timeline and article are visible, the timeline refresh control is visible.

Tested on iPad and iPhone 16 Pro Max (landscape).

Fixes #4490 