### PR TITLE
🩹 Fixes memory leaks caused by NSString usage

### DIFF
--- a/Shared/ArticleRendering/ArticleRenderer.swift
+++ b/Shared/ArticleRendering/ArticleRenderer.swift
@@ -31,7 +31,7 @@ struct ArticleRenderer {
 		init(name: String) {
 			url = Bundle.main.url(forResource: name, withExtension: "html")!
 			baseURL = url.deletingLastPathComponent()
-			html = try! NSString(contentsOfFile: url.path, encoding: String.Encoding.utf8.rawValue) as String
+			html = try! String(contentsOfFile: url.path, encoding: .utf8)
 		}
 	}
 
@@ -185,13 +185,13 @@ private extension ArticleRenderer {
 
 	static var defaultStyleSheet: String = {
 		let path = Bundle.main.path(forResource: "styleSheet", ofType: "css")!
-		let s = try! NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue)
+		let s = try! String(contentsOfFile: path, encoding: .utf8)
 		return "\n\(s)\n"
 	}()
 
 	static let defaultTemplate: String = {
 		let path = Bundle.main.path(forResource: "template", ofType: "html")!
-		let s = try! NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue)
+		let s = try! String(contentsOfFile: path, encoding: .utf8)
 		return s as String
 	}()
 

--- a/Shared/ArticleStyles/ArticleTheme.swift
+++ b/Shared/ArticleStyles/ArticleTheme.swift
@@ -86,7 +86,8 @@ struct ArticleTheme: Equatable {
 			return nil
 		}
 
-		if let s = try? NSString(contentsOfFile: f, usedEncoding: nil) as String {
+		var encoding = String.Encoding.utf8
+		if let s = try? String(contentsOfFile: f, usedEncoding: &encoding) {
 			return s
 		}
 		return nil


### PR DESCRIPTION
Fixes #4509 by transitioning `NSString` usage to `String`.