### PR TITLE
Replaced uses of "InoReader" with "Inoreader"

### DIFF
--- a/Mac/Settings/Accounts/AccountsReaderAPIWindowController.swift
+++ b/Mac/Settings/Accounts/AccountsReaderAPIWindowController.swift
@@ -46,9 +46,9 @@ final class AccountsReaderAPIWindowController: NSWindowController {
 				apiURLTextField.placeholderString = NSLocalizedString("fresh.rss.net/api/greader.php", comment: "FreshRSS API Helper")
 			case .inoreader:
 				titleImageView.image = AppImage.account(.inoreader)
-				titleLabel.stringValue = NSLocalizedString("Sign in to your InoReader account.", comment: "InoReader")
+				titleLabel.stringValue = NSLocalizedString("Sign in to your Inoreader account.", comment: "Inoreader")
 				gridView.row(at: 2).isHidden = true
-				noAccountTextField.stringValue = NSLocalizedString("Don’t have an InoReader account?", comment: "No InoReader")
+				noAccountTextField.stringValue = NSLocalizedString("Don’t have an Inoreader account?", comment: "No Inoreader")
 			case .bazQux:
 				titleImageView.image = AppImage.account(.bazQux)
 				titleLabel.stringValue = NSLocalizedString("Sign in to your BazQux account.", comment: "BazQux")

--- a/iOS/Settings/Account/ReaderAPIAccountViewController.swift
+++ b/iOS/Settings/Account/ReaderAPIAccountViewController.swift
@@ -52,7 +52,7 @@ final class ReaderAPIAccountViewController: UITableViewController {
 				title = NSLocalizedString("FreshRSS", comment: "FreshRSS")
 				apiURLTextField.placeholder = NSLocalizedString("API URL: fresh.rss.net/api/greader.php", comment: "FreshRSS API Helper")
 			case .inoreader:
-				title = NSLocalizedString("InoReader", comment: "InoReader")
+				title = NSLocalizedString("Inoreader", comment: "Inoreader")
 			case .bazQux:
 				title = NSLocalizedString("BazQux", comment: "BazQux")
 			case .theOldReader:
@@ -75,8 +75,8 @@ final class ReaderAPIAccountViewController: UITableViewController {
 			footerLabel.text = NSLocalizedString("Sign in to your BazQux account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have a BazQux account?", comment: "BazQux")
 			signUpButton.setTitle(NSLocalizedString("Sign Up Here", comment: "BazQux SignUp"), for: .normal)
 		case .inoreader:
-			footerLabel.text = NSLocalizedString("Sign in to your InoReader account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have an InoReader account?", comment: "InoReader")
-			signUpButton.setTitle(NSLocalizedString("Sign Up Here", comment: "InoReader SignUp"), for: .normal)
+			footerLabel.text = NSLocalizedString("Sign in to your Inoreader account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have an Inoreader account?", comment: "Inoreader")
+			signUpButton.setTitle(NSLocalizedString("Sign Up Here", comment: "Inoreader SignUp"), for: .normal)
 		case .theOldReader:
 			footerLabel.text = NSLocalizedString("Sign in to your The Old Reader account and sync your feeds across your devices. Your username and password will be encrypted and stored in Keychain.\n\nDon’t have a The Old Reader account?", comment: "TOR")
 			signUpButton.setTitle(NSLocalizedString("Sign Up Here", comment: "TOR SignUp"), for: .normal)


### PR DESCRIPTION
Full disclosure: I'm not an engineer, so there's a chance there are other implications of the proposed changes here that I'm not aware of.

Anyways, I happened to sign up for an Inoreader account recently and went to set it up in NNW. When doing so, I noticed there were some inconsistent uses of "Inoreader" and "InoReader" in the app depending on the view you were on. From their own website, it seems like "Inoreader" is the way to go, so I went through uses of this in the codebase to update any uses of "InoReader".