### PR TITLE
Add print support for macOS and iOS

### DIFF
--- a/Mac/Base.lproj/Main.storyboard
+++ b/Mac/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -115,6 +115,12 @@
                                         <menuItem title="Close Window" keyEquivalent="w" id="DVo-aG-piG">
                                             <connections>
                                                 <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="AGf-pt-56J"/>
+                                        <menuItem title="Print" keyEquivalent="p" id="i3h-o9-xhE">
+                                            <connections>
+                                                <action selector="printArticle:" target="Ady-hI-5gd" id="HpZ-XV-SDG"/>
                                             </connections>
                                         </menuItem>
                                     </items>

--- a/Mac/MainWindow/Detail/DetailViewController.swift
+++ b/Mac/MainWindow/Detail/DetailViewController.swift
@@ -99,6 +99,10 @@ final class DetailViewController: NSViewController, WKUIDelegate {
 		currentWebViewController.scrollPageUp(sender)
 	}
 	
+	func printArticle() {
+		currentWebViewController.printArticle()
+	}
+	
 	// MARK: - Navigation
 	
 	func focus() {

--- a/Mac/MainWindow/Detail/DetailWebViewController.swift
+++ b/Mac/MainWindow/Detail/DetailWebViewController.swift
@@ -204,6 +204,35 @@ final class DetailWebViewController: NSViewController {
 	override func scrollPageUp(_ sender: Any?) {
 		webView.scrollPageUp(sender)
 	}
+	
+	// MARK: Printing
+	
+	func printArticle() {
+		guard let window = self.view.window else {
+			NSSound.beep()
+			return
+		}
+		
+		let printInfo = NSPrintInfo.shared
+		printInfo.topMargin = 35.0
+		printInfo.bottomMargin = 35.0
+		printInfo.leftMargin = 35.0
+		printInfo.rightMargin = 35.0
+		
+		let printOperation = webView.printOperation(with: printInfo)
+		if let article = self.article, let articleTitle = article.title {
+			printOperation.jobTitle = articleTitle
+		}
+		
+		printOperation.showsPrintPanel = true
+		printOperation.printPanel.options = printOperation.printPanel.options.union([.showsPaperSize, .showsOrientation, .showsScaling, .showsPreview])
+		
+		printOperation.showsProgressPanel = true
+		// Without this line, the following error is printed to log, followed by a call to `AppKitBreakInDebugger`:
+		//		The NSPrintOperation view's frame was not initialized properly before knowsPageRange: returned
+		printOperation.view?.frame = self.webView.bounds
+		printOperation.runModal(for: window, delegate: nil, didRun: nil, contextInfo: nil)
+	}
 
 	// MARK: State Restoration
 	

--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -264,6 +264,10 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 		if item.action == #selector(toggleReadArticlesFilter(_:)) {
 			return validateToggleReadArticles(item)
 		}
+		
+		if item.action == #selector(printArticle(_:)) {
+			return oneSelectedArticle != nil
+		}
 
 		return true
 	}
@@ -519,6 +523,14 @@ class MainWindowController : NSWindowController, NSUserInterfaceValidations {
 		ArticleThemesManager.shared.currentThemeName = menuItem.title
 	}
 	
+	@IBAction func printArticle(_ sender: Any?) {
+		guard let detailViewController else {
+			// Should not reach here due to user interface item validation, but beep anyway.
+			NSSound.beep()
+			return
+		}
+		detailViewController.printArticle()
+	}
 }
 
 // MARK: NSWindowDelegate

--- a/Shared/Article Rendering/stylesheet.css
+++ b/Shared/Article Rendering/stylesheet.css
@@ -533,3 +533,56 @@ a.footnote:hover,
 	}
 
 }
+
+/* override styles when printing */
+@media print {
+	:root {
+		--primary-accent-color: #000;
+		--secondary-accent-color: #000;
+	}
+	
+	body {
+		margin: 0px;
+		padding: 0px;
+		max-width: 100%;
+		
+		word-break: break-word;
+		-webkit-hyphens: auto;
+	}
+	
+	/* Use macOS font sizes for printing, even on iOS*/
+	.smallText {
+		font-size: 14px;
+	}
+	
+	.mediumText {
+		font-size: 16px;
+	}
+	
+	.largeText {
+		font-size: 18px;
+	}
+	
+	.xlargeText {
+		font-size: 20px;
+	}
+	
+	.xxlargeText {
+		font-size: 22px;
+	}
+	
+	@supports not (-webkit-touch-callout: none) {
+		a:link {
+			color: #000;
+			text-decoration-color: #000;
+		}
+		
+		.articleBody a:link, .articleBody a:visited {
+			border-bottom: 1px solid #000;
+		}
+		
+		body a, body a:visited, body a * {
+			color: #000;
+		}
+	}
+}

--- a/iOS/Article/PrintActivity.swift
+++ b/iOS/Article/PrintActivity.swift
@@ -1,0 +1,65 @@
+//
+//  PrintActivity.swift
+//  NetNewsWire-iOS
+//
+//  Created by Léo Natan on 4/5/25.
+//  Copyright © 2025 Ranchero Software. All rights reserved.
+//
+
+import UIKit
+import WebKit
+
+class PrintActivity: UIActivity {
+	private let webView: WKWebView?
+	
+	init(webView: WKWebView?) {
+		self.webView = webView
+	}
+	
+	private var activityItems: [Any]?
+	
+	override var activityTitle: String? {
+		return NSLocalizedString("Print", comment: "Print")
+	}
+	
+	override var activityImage: UIImage? {
+		return UIImage(systemName: "printer", withConfiguration: UIImage.SymbolConfiguration(pointSize: 20, weight: .regular))
+	}
+	
+	override var activityType: UIActivity.ActivityType? {
+		return UIActivity.ActivityType(rawValue: "com.rancharo.NetNewsWire-Evergreen.print")
+	}
+	
+	override class var activityCategory: UIActivity.Category {
+		return .action
+	}
+	
+	override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
+		return webView != nil
+	}
+	
+	override func prepare(withActivityItems activityItems: [Any]) {
+		self.activityItems = activityItems
+	}
+	
+	override func perform() {
+		guard let webView else {
+			return
+		}
+		
+		let printFormatter = webView.viewPrintFormatter()
+		printFormatter.perPageContentInsets = UIEdgeInsets(top: 35.0, left: 35.0, bottom: 35.0, right: 35.0)
+		
+		let printInfo = UIPrintInfo(dictionary: nil)
+		printInfo.jobName = "page"
+		printInfo.outputType = .general
+		
+		let printController = UIPrintInteractionController.shared
+		printController.printInfo = printInfo
+		printController.showsPaperSelectionForLoadedPapers = true
+		printController.showsPaperOrientation = true
+		printController.printFormatter = printFormatter
+		printController.present(animated: true, completionHandler: nil)
+	}
+	
+}

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -264,7 +264,7 @@ class WebViewController: UIViewController {
 	
 	func showActivityDialog(popOverBarButtonItem: UIBarButtonItem? = nil) {
 		guard let url = article?.preferredURL else { return }
-		let activityViewController = UIActivityViewController(url: url, title: article?.title, applicationActivities: [FindInArticleActivity(), OpenInBrowserActivity()])
+		let activityViewController = UIActivityViewController(url: url, title: article?.title, applicationActivities: [FindInArticleActivity(), OpenInBrowserActivity(), PrintActivity(webView: webView)])
 		activityViewController.popoverPresentationController?.barButtonItem = popOverBarButtonItem
 		present(activityViewController, animated: true)
 	}


### PR DESCRIPTION
This PR adds support for printing articles on macOS and iOS, using the standard print panels on each platform.

<img width="1376" alt="Screenshot 2025-05-04 at 20 57 52" src="https://github.com/user-attachments/assets/730dc61b-fe49-42fa-bce2-fb8dc8324229" />
<img width="320" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-05-04 at 20 58 28" src="https://github.com/user-attachments/assets/69aa2a9b-a89e-4277-8706-0277aa4cdbde" />

~Since articles' HTML body max width is constrained to 44em, a new web view is created using the HTML of the actual web view, its body is unconstrained and then a print is triggered from that web view.~
The stylesheet was modified to include printing-specific overrides, which remove padding, margin and turn link colors black.

Closes #3715 and #3442