### PR TITLE
Fix importing OPML

### DIFF
--- a/Mac/Resources/Info.plist
+++ b/Mac/Resources/Info.plist
@@ -103,6 +103,23 @@
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
+				<string>public.xml</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>OPML</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.opml.opml</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>opml</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
 				<string>com.apple.package</string>
 			</array>
 			<key>UTTypeDescription</key>

--- a/Shared/UniformTypeIdentifiers+Extras.swift
+++ b/Shared/UniformTypeIdentifiers+Extras.swift
@@ -10,5 +10,5 @@ import UniformTypeIdentifiers
 
 extension UTType {
 
-	static let opml = UTType(filenameExtension: "opml", conformingTo: UTType.xml)!
+	static let opml = UTType("org.opml.opml")!
 }


### PR DESCRIPTION
This should fix OPML importing. Should be tested first, though, as simply reverting back to `main` after running once with these changes still allowed me to import OPML files (caching, I guess).

Fixes #4647.