### PR TITLE
Add global Hide Read Articles preference with per-feed overrides

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -339,6 +339,22 @@ final class AppDefaults: Sendable {
 		}
 	}
 
+	func setFeedHideReadOverride(accountID: String, feedID: String, enabled: Bool) {
+		var overrides = feedReadFilterOverrides
+		if enabled {
+			overrides.setOverride(accountID: accountID, feedID: feedID, hideReadArticles ? .show : .hide)
+		} else {
+			overrides.clearOverride(accountID: accountID, feedID: feedID)
+		}
+		feedReadFilterOverrides = overrides
+	}
+
+	func clearFeedHideReadOverrides(accountID: String) {
+		var overrides = feedReadFilterOverrides
+		overrides.clearAll(accountID: accountID)
+		feedReadFilterOverrides = overrides
+	}
+
 	init() {
 		// Migrate every-10-minute refresh interval to 30 minutes.
 		let rawValue = UserDefaults.standard.integer(forKey: Key.refreshInterval)

--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -43,6 +43,8 @@ final class AppDefaults: Sendable {
 		static let defaultBrowserID = "defaultBrowserID"
 		static let currentThemeName = "currentThemeName"
 		static let articleContentJavascriptEnabled = "articleContentJavascriptEnabled"
+		static let feedReadFilterOverrides = "feedReadFilterOverrides"
+		static let hideReadArticles = "hideReadArticles"
 
 		// Hidden prefs
 		static let showDebugMenu = "ShowDebugMenu"
@@ -316,6 +318,24 @@ final class AppDefaults: Sendable {
 		}
 		set {
 			UserDefaults.standard.set(newValue, forKey: Key.articleContentJavascriptEnabled)
+		}
+	}
+
+	var feedReadFilterOverrides: FeedReadFilterOverrides {
+		get {
+			FeedReadFilterOverrides(data: UserDefaults.standard.data(forKey: Key.feedReadFilterOverrides))
+		}
+		set {
+			UserDefaults.standard.set(newValue.data, forKey: Key.feedReadFilterOverrides)
+		}
+	}
+
+	var hideReadArticles: Bool {
+		get {
+			return AppDefaults.bool(for: Key.hideReadArticles)
+		}
+		set {
+			AppDefaults.setBool(for: Key.hideReadArticles, newValue)
 		}
 	}
 

--- a/Mac/Base.lproj/Preferences.storyboard
+++ b/Mac/Base.lproj/Preferences.storyboard
@@ -31,11 +31,11 @@
             <objects>
                 <viewController title="General" storyboardIdentifier="General" id="iuH-lz-18x" customClass="GeneralPreferencesViewController" customModule="NetNewsWire" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="WnV-px-wCT">
-                        <rect key="frame" x="0.0" y="0.0" width="509" height="460"/>
+                        <rect key="frame" x="0.0" y="0.0" width="509" height="525"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Ut3-yd-q6G">
-                                <rect key="frame" x="57" y="16" width="393" height="428"/>
+                                <rect key="frame" x="57" y="16" width="393" height="493"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pR2-Bf-7Fd">
                                         <rect key="frame" x="-2" y="404" width="106" height="16"/>
@@ -277,6 +277,34 @@
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="N1a-qV-4Os"/>
                                         </constraints>
                                     </popUpButton>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="av1-Lb-Hdr">
+                                        <rect key="frame" x="-2" y="0.0" width="106" height="16"/>
+                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Article Visibility:" id="av1-Tc-Hdr">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hr1-Cb-Hrd">
+                                        <rect key="frame" x="110" y="0.0" width="283" height="16"/>
+                                        <buttonCell key="cell" type="check" title="Hide read articles by default" bezelStyle="regularSquare" imagePosition="left" inset="2" id="hr1-Bc-Hrd">
+                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <binding destination="mAF-gO-1PI" name="value" keyPath="values.hideReadArticles" id="hr1-Bd-Hrd">
+                                                <dictionary key="options">
+                                                    <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                    <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                    <integer key="NSMultipleValuesPlaceholder" value="0"/>
+                                                    <integer key="NSNoSelectionPlaceholder" value="0"/>
+                                                    <integer key="NSNotApplicablePlaceholder" value="0"/>
+                                                    <integer key="NSNullPlaceholder" value="0"/>
+                                                    <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                                </dictionary>
+                                            </binding>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="Ci4-fW-KjU" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="0Do-jh-Hqq"/>
@@ -291,7 +319,7 @@
                                     <constraint firstItem="yrg-M3-Dbz" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="Bmt-Mn-CCl"/>
                                     <constraint firstItem="UI6-sq-M15" firstAttribute="top" secondItem="1w0-nA-DEO" secondAttribute="bottom" constant="12" id="DMk-OP-dpa"/>
                                     <constraint firstItem="Ubm-Pk-l7x" firstAttribute="top" secondItem="Ci4-fW-KjU" secondAttribute="bottom" constant="12" id="E3r-xf-7aZ"/>
-                                    <constraint firstAttribute="bottom" secondItem="SFF-mL-yc8" secondAttribute="bottom" constant="4" id="FAd-wh-IFu"/>
+                                    <constraint firstAttribute="bottom" secondItem="hr1-Cb-Hrd" secondAttribute="bottom" constant="4" id="FAd-wh-IFu"/>
                                     <constraint firstItem="pR2-Bf-7Fd" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="G0C-1M-LW1"/>
                                     <constraint firstItem="yrg-M3-Dbz" firstAttribute="trailing" secondItem="pR2-Bf-7Fd" secondAttribute="trailing" id="JbY-CP-pK8"/>
                                     <constraint firstAttribute="trailing" secondItem="Ubm-Pk-l7x" secondAttribute="trailing" id="KIg-w5-ceG"/>
@@ -337,6 +365,12 @@
                                     <constraint firstItem="j0t-Wa-UTL" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" constant="22" id="xSA-4l-R2v"/>
                                     <constraint firstAttribute="trailing" secondItem="ISO-Wu-R60" secondAttribute="trailing" constant="1" id="xaY-qS-LSN"/>
                                     <constraint firstItem="ucw-vG-yLt" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="xmq-Ob-wCJ"/>
+                                    <constraint firstItem="av1-Lb-Hdr" firstAttribute="leading" secondItem="Ut3-yd-q6G" secondAttribute="leading" id="av1-C2-Ldg"/>
+                                    <constraint firstItem="av1-Lb-Hdr" firstAttribute="trailing" secondItem="pR2-Bf-7Fd" secondAttribute="trailing" id="av1-C3-Trl"/>
+                                    <constraint firstItem="av1-Lb-Hdr" firstAttribute="firstBaseline" secondItem="hr1-Cb-Hrd" secondAttribute="firstBaseline" id="av1-C4-Bsl"/>
+                                    <constraint firstItem="hr1-Cb-Hrd" firstAttribute="leading" secondItem="Z6O-Zt-V1g" secondAttribute="leading" id="hr1-C7-Cbx"/>
+                                    <constraint firstItem="hr1-Cb-Hrd" firstAttribute="top" secondItem="SFF-mL-yc8" secondAttribute="bottom" constant="12" id="hr1-C8-Cbx"/>
+                                    <constraint firstAttribute="trailing" secondItem="hr1-Cb-Hrd" secondAttribute="trailing" id="hr1-C9-Cbx"/>
                                 </constraints>
                             </customView>
                         </subviews>

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -82,6 +82,7 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 		didSet {
 			if !representedObjectArraysAreEqual(oldValue, representedObjects) {
 				seedReadFilterForFolders()
+				seedReadFilterFromOverrides()
 				unreadCount = 0
 
 				selectionDidChange(nil)
@@ -99,8 +100,17 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 	}
 
 	var windowState: TimelineWindowState {
-		let readArticlesFilterStateKeys = readFilterEnabledTable.keys.compactMap { $0.userInfo }
-		let readArticlesFilterStateValues = readFilterEnabledTable.values.compactMap( { $0 })
+		// Feed read-filter state lives in feedReadFilterOverrides (UserDefaults); window
+		// state persists only folder and smart-feed entries.
+		var readArticlesFilterStateKeys = [[String: String]]()
+		var readArticlesFilterStateValues = [Bool]()
+		for (sidebarItemID, hidesReadArticles) in readFilterEnabledTable {
+			if case .feed = sidebarItemID {
+				continue
+			}
+			readArticlesFilterStateKeys.append(sidebarItemID.userInfo)
+			readArticlesFilterStateValues.append(hidesReadArticles)
+		}
 
 		if selectedArticles.count == 1 {
 			let path = selectedArticles.first!.pathUserInfo
@@ -349,6 +359,16 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 		AppDefaults.shared.feedReadFilterOverrides = cachedFeedReadFilterOverrides
 	}
 
+	/// Migrate a feed's legacy window-state read-filter setting into
+	/// feedReadFilterOverrides, without overwriting an existing override.
+	private func migrateLegacyFeedReadFilterIfNeeded(_ sidebarItemID: SidebarItemIdentifier, hiding: Bool) {
+		guard case let .feed(accountID, feedID) = sidebarItemID,
+			  cachedFeedReadFilterOverrides.override(accountID: accountID, feedID: feedID) == nil else {
+			return
+		}
+		persistFeedOverride(sidebarItemID, hiding: hiding)
+	}
+
 	func restoreState(from state: TimelineWindowState) {
 		for i in 0..<state.readArticlesFilterStateKeys.count {
 			if let sidebarItemID = SidebarItemIdentifier(userInfo: state.readArticlesFilterStateKeys[i]) {
@@ -358,6 +378,7 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 				} else {
 					noteSidebarItemShowsReadArticles(sidebarItemID, persistOverride: false)
 				}
+				migrateLegacyFeedReadFilterIfNeeded(sidebarItemID, hiding: hidesReadArticles)
 			}
 		}
 
@@ -397,6 +418,7 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 				} else {
 					noteSidebarItemShowsReadArticles(sidebarItemID, persistOverride: false)
 				}
+				migrateLegacyFeedReadFilterIfNeeded(sidebarItemID, hiding: hidesReadArticles)
 			}
 		}
 
@@ -1412,6 +1434,22 @@ private extension TimelineViewController {
 			if readFilterEnabledTable[sidebarItemID] == nil {
 				readFilterEnabledTable[sidebarItemID] = true
 			}
+		}
+	}
+
+	/// Seed the represented feed's read-filter state from feedReadFilterOverrides,
+	/// since feed entries are no longer restored from window state.
+	private func seedReadFilterFromOverrides() {
+		guard let representedObjects else {
+			return
+		}
+		for object in representedObjects {
+			guard let feed = object as? Feed, let sidebarItemID = feed.sidebarItemID,
+				  readFilterEnabledTable[sidebarItemID] == nil,
+				  let override = cachedFeedReadFilterOverrides.override(accountID: feed.accountID, feedID: feed.feedID) else {
+				continue
+			}
+			readFilterEnabledTable[sidebarItemID] = override == .hide
 		}
 	}
 

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -337,17 +337,27 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 
 	// MARK: State Restoration
 
-	private func noteSidebarItemHidesReadArticles(_ sidebarItemID: SidebarItemIdentifier, persistOverride: Bool = true) {
+	private func noteSidebarItemHidesReadArticles(_ sidebarItemID: SidebarItemIdentifier) {
 		readFilterEnabledTable[sidebarItemID] = true
-		if persistOverride {
-			persistFeedOverride(sidebarItemID, hiding: true)
-		}
+		persistFeedOverride(sidebarItemID, hiding: true)
 	}
 
-	private func noteSidebarItemShowsReadArticles(_ sidebarItemID: SidebarItemIdentifier, persistOverride: Bool = true) {
+	private func noteSidebarItemShowsReadArticles(_ sidebarItemID: SidebarItemIdentifier) {
 		readFilterEnabledTable[sidebarItemID] = false
-		if persistOverride {
-			persistFeedOverride(sidebarItemID, hiding: false)
+		persistFeedOverride(sidebarItemID, hiding: false)
+	}
+
+	/// Restore a sidebar item's read-filter state from window state.
+	///
+	/// For feeds, `feedReadFilterOverrides` is authoritative: migrate the legacy
+	/// window-state value only when no override exists yet, and never let it
+	/// overwrite a stored override in the active table. Folders and smart feeds
+	/// continue to restore directly from window state.
+	private func restoreReadFilterState(_ sidebarItemID: SidebarItemIdentifier, hidesReadArticles: Bool) {
+		if case .feed = sidebarItemID {
+			migrateLegacyFeedReadFilterIfNeeded(sidebarItemID, hiding: hidesReadArticles)
+		} else {
+			readFilterEnabledTable[sidebarItemID] = hidesReadArticles
 		}
 	}
 
@@ -372,13 +382,7 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 	func restoreState(from state: TimelineWindowState) {
 		for i in 0..<state.readArticlesFilterStateKeys.count {
 			if let sidebarItemID = SidebarItemIdentifier(userInfo: state.readArticlesFilterStateKeys[i]) {
-				let hidesReadArticles = state.readArticlesFilterStateValues[i]
-				if hidesReadArticles {
-					noteSidebarItemHidesReadArticles(sidebarItemID, persistOverride: false)
-				} else {
-					noteSidebarItemShowsReadArticles(sidebarItemID, persistOverride: false)
-				}
-				migrateLegacyFeedReadFilterIfNeeded(sidebarItemID, hiding: hidesReadArticles)
+				restoreReadFilterState(sidebarItemID, hidesReadArticles: state.readArticlesFilterStateValues[i])
 			}
 		}
 
@@ -412,13 +416,7 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 
 		for i in 0..<readArticlesFilterStateKeys.count {
 			if let sidebarItemID = SidebarItemIdentifier(userInfo: readArticlesFilterStateKeys[i]) {
-				let hidesReadArticles = readArticlesFilterStateValues[i]
-				if hidesReadArticles {
-					noteSidebarItemHidesReadArticles(sidebarItemID, persistOverride: false)
-				} else {
-					noteSidebarItemShowsReadArticles(sidebarItemID, persistOverride: false)
-				}
-				migrateLegacyFeedReadFilterIfNeeded(sidebarItemID, hiding: hidesReadArticles)
+				restoreReadFilterState(sidebarItemID, hidesReadArticles: readArticlesFilterStateValues[i])
 			}
 		}
 

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -380,9 +380,9 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 	}
 
 	func restoreState(from state: TimelineWindowState) {
-		for i in 0..<state.readArticlesFilterStateKeys.count {
-			if let sidebarItemID = SidebarItemIdentifier(userInfo: state.readArticlesFilterStateKeys[i]) {
-				restoreReadFilterState(sidebarItemID, hidesReadArticles: state.readArticlesFilterStateValues[i])
+		for (key, hidesReadArticles) in zip(state.readArticlesFilterStateKeys, state.readArticlesFilterStateValues) {
+			if let sidebarItemID = SidebarItemIdentifier(userInfo: key) {
+				restoreReadFilterState(sidebarItemID, hidesReadArticles: hidesReadArticles)
 			}
 		}
 
@@ -414,9 +414,9 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 			return
 		}
 
-		for i in 0..<readArticlesFilterStateKeys.count {
-			if let sidebarItemID = SidebarItemIdentifier(userInfo: readArticlesFilterStateKeys[i]) {
-				restoreReadFilterState(sidebarItemID, hidesReadArticles: readArticlesFilterStateValues[i])
+		for (key, hidesReadArticles) in zip(readArticlesFilterStateKeys, readArticlesFilterStateValues) {
+			if let sidebarItemID = SidebarItemIdentifier(userInfo: key) {
+				restoreReadFilterState(sidebarItemID, hidesReadArticles: hidesReadArticles)
 			}
 		}
 

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -31,19 +31,33 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 
 	var sharingServicePickerDelegate: NSSharingServicePickerDelegate?
 
+	private var hideReadArticles = AppDefaults.shared.hideReadArticles
+	private var cachedFeedReadFilterOverrides = AppDefaults.shared.feedReadFilterOverrides
 	private var readFilterEnabledTable = [SidebarItemIdentifier: Bool]()
 
 	var isReadFiltered: Bool? {
-		guard representedObjects?.count == 1, let timelineFeed = representedObjects?.first as? SidebarItem else {
+		guard representedObjects?.count == 1,
+			  let timelineFeed = representedObjects?.first as? SidebarItem,
+			  timelineFeed.defaultReadFilterType != .alwaysRead else {
 			return nil
 		}
-		guard timelineFeed.defaultReadFilterType != .alwaysRead else {
+		if let sidebarItemID = timelineFeed.sidebarItemID {
+			if let readFiltered = readFilterEnabledTable[sidebarItemID] {
+				return readFiltered
+			}
+			if let override = persistedFeedOverride(sidebarItemID) {
+				return override
+			}
+		}
+		return hideReadArticles || timelineFeed.defaultReadFilterType == .read
+	}
+
+	private func persistedFeedOverride(_ sidebarItemID: SidebarItemIdentifier) -> Bool? {
+		guard case .feed(let accountID, let feedID) = sidebarItemID,
+			  let override = cachedFeedReadFilterOverrides.override(accountID: accountID, feedID: feedID) else {
 			return nil
 		}
-		if let sidebarItemID = timelineFeed.sidebarItemID, let readFiltered = readFilterEnabledTable[sidebarItemID] {
-			return readFiltered
-		}
-		return timelineFeed.defaultReadFilterType == .read
+		return override == .hide
 	}
 
 	var isCleanUpAvailable: Bool {
@@ -313,12 +327,26 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 
 	// MARK: State Restoration
 
-	private func noteSidebarItemHidesReadArticles(_ sidebarItemID: SidebarItemIdentifier) {
+	private func noteSidebarItemHidesReadArticles(_ sidebarItemID: SidebarItemIdentifier, persistOverride: Bool = true) {
 		readFilterEnabledTable[sidebarItemID] = true
+		if persistOverride {
+			persistFeedOverride(sidebarItemID, hiding: true)
+		}
 	}
 
-	private func noteSidebarItemShowsReadArticles(_ sidebarItemID: SidebarItemIdentifier) {
+	private func noteSidebarItemShowsReadArticles(_ sidebarItemID: SidebarItemIdentifier, persistOverride: Bool = true) {
 		readFilterEnabledTable[sidebarItemID] = false
+		if persistOverride {
+			persistFeedOverride(sidebarItemID, hiding: false)
+		}
+	}
+
+	private func persistFeedOverride(_ sidebarItemID: SidebarItemIdentifier, hiding: Bool) {
+		guard case let .feed(accountID, feedID) = sidebarItemID else {
+			return
+		}
+		cachedFeedReadFilterOverrides.setOverride(accountID: accountID, feedID: feedID, hiding ? .hide : .show)
+		AppDefaults.shared.feedReadFilterOverrides = cachedFeedReadFilterOverrides
 	}
 
 	func restoreState(from state: TimelineWindowState) {
@@ -326,9 +354,9 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 			if let sidebarItemID = SidebarItemIdentifier(userInfo: state.readArticlesFilterStateKeys[i]) {
 				let hidesReadArticles = state.readArticlesFilterStateValues[i]
 				if hidesReadArticles {
-					noteSidebarItemHidesReadArticles(sidebarItemID)
+					noteSidebarItemHidesReadArticles(sidebarItemID, persistOverride: false)
 				} else {
-					noteSidebarItemShowsReadArticles(sidebarItemID)
+					noteSidebarItemShowsReadArticles(sidebarItemID, persistOverride: false)
 				}
 			}
 		}
@@ -365,9 +393,9 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 			if let sidebarItemID = SidebarItemIdentifier(userInfo: readArticlesFilterStateKeys[i]) {
 				let hidesReadArticles = readArticlesFilterStateValues[i]
 				if hidesReadArticles {
-					noteSidebarItemHidesReadArticles(sidebarItemID)
+					noteSidebarItemHidesReadArticles(sidebarItemID, persistOverride: false)
 				} else {
-					noteSidebarItemShowsReadArticles(sidebarItemID)
+					noteSidebarItemShowsReadArticles(sidebarItemID, persistOverride: false)
 				}
 			}
 		}
@@ -762,8 +790,46 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 
 	@MainActor func userDefaultsDidChange() {
 		fontSize = AppDefaults.shared.timelineFontSize
+		let newHideReadArticles = AppDefaults.shared.hideReadArticles
+		let hideReadArticlesDidChange = hideReadArticles != newHideReadArticles
+		hideReadArticles = newHideReadArticles
+		let readFilterTableDidChange = syncReadFilterTableFromDefaults()
 		sortDirection = AppDefaults.shared.timelineSortDirection
 		groupByFeed = AppDefaults.shared.timelineGroupByFeed
+		if hideReadArticlesDidChange || readFilterTableDidChange {
+			fetchAndReplacePreservingSelection()
+		}
+	}
+
+	private func syncReadFilterTableFromDefaults() -> Bool {
+		let overrides = AppDefaults.shared.feedReadFilterOverrides
+		guard overrides != cachedFeedReadFilterOverrides else {
+			return false
+		}
+		cachedFeedReadFilterOverrides = overrides
+
+		// Build set of feed SidebarItemIdentifiers that have persistent overrides
+		var persistedOverrides = [SidebarItemIdentifier: Bool]()
+		for entry in overrides.allFeeds() {
+			persistedOverrides[.feed(entry.accountID, entry.feedID)] = (entry.override == .hide)
+		}
+
+		// Sync feed rows with persistent overrides without mutating non-feed session state.
+		var changed = false
+		for (id, value) in persistedOverrides {
+			if readFilterEnabledTable[id] == nil || readFilterEnabledTable[id] != value {
+				readFilterEnabledTable[id] = value
+				changed = true
+			}
+		}
+		// Remove session entries for feeds whose persistent override was cleared
+		for (id, _) in readFilterEnabledTable {
+			if case .feed = id, persistedOverrides[id] == nil {
+				readFilterEnabledTable[id] = nil
+				changed = true
+			}
+		}
+		return changed
 	}
 
 	// MARK: - Reloading Data
@@ -1262,7 +1328,7 @@ private extension TimelineViewController {
 
 		var fetchedArticles = Set<Article>()
 		for fetchers in fetchers {
-			if (fetchers as? SidebarItem)?.readFiltered(readFilterEnabledTable: readFilterEnabledTable) ?? true {
+			if (fetchers as? SidebarItem)?.readFiltered(readFilterEnabledTable: readFilterEnabledTable, globalHideReadArticles: hideReadArticles) ?? true {
 				let articles = fetchers.fetchUnreadArticles()
 				fetchedArticles.formUnion(articles)
 			} else {
@@ -1279,7 +1345,7 @@ private extension TimelineViewController {
 		precondition(Thread.isMainThread)
 		cancelPendingAsyncFetches()
 		let fetchers = representedObjects.compactMap { $0 as? ArticleFetcher }
-		let fetchOperation = FetchRequestOperation(id: fetchSerialNumber, readFilterEnabledTable: readFilterEnabledTable, fetchers: fetchers) { [weak self] (articles, operation) in
+		let fetchOperation = FetchRequestOperation(id: fetchSerialNumber, readFilterEnabledTable: readFilterEnabledTable, globalHideReadArticles: hideReadArticles, fetchers: fetchers) { [weak self] (articles, operation) in
 			precondition(Thread.isMainThread)
 			guard !operation.isCanceled, let strongSelf = self, operation.id == strongSelf.fetchSerialNumber else {
 				return

--- a/Mac/MainWindow/Timeline/TimelineViewController.swift
+++ b/Mac/MainWindow/Timeline/TimelineViewController.swift
@@ -768,6 +768,9 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 
 	@objc func userDidDeleteAccount(_ note: Notification) {
 		undoManager?.removeAllActions() // Undo stack may contain actions for the deleted account.
+		if let account = note.userInfo?[Account.UserInfoKey.account] as? Account {
+			AppDefaults.shared.clearFeedHideReadOverrides(accountID: account.accountID)
+		}
 		if representedObjectsContainsAnyPseudoFeed() {
 			fetchAndReplacePreservingSelectionAsync()
 		}
@@ -808,13 +811,11 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 		}
 		cachedFeedReadFilterOverrides = overrides
 
-		// Build set of feed SidebarItemIdentifiers that have persistent overrides
 		var persistedOverrides = [SidebarItemIdentifier: Bool]()
 		for entry in overrides.allFeeds() {
 			persistedOverrides[.feed(entry.accountID, entry.feedID)] = (entry.override == .hide)
 		}
 
-		// Sync feed rows with persistent overrides without mutating non-feed session state.
 		var changed = false
 		for (id, value) in persistedOverrides {
 			if readFilterEnabledTable[id] == nil || readFilterEnabledTable[id] != value {
@@ -822,7 +823,6 @@ final class TimelineViewController: NSViewController, UndoableCommandRunner, Unr
 				changed = true
 			}
 		}
-		// Remove session entries for feeds whose persistent override was cleared
 		for (id, _) in readFilterEnabledTable {
 			if case .feed = id, persistedOverrides[id] == nil {
 				readFilterEnabledTable[id] = nil

--- a/Mac/Preferences/Accounts/AccountsDetailView.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailView.swift
@@ -37,80 +37,86 @@ struct AccountsDetailView: View {
 	}
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 0) {
-			Grid(alignment: .leading, verticalSpacing: 0) {
-				GridRow(alignment: .firstTextBaseline) {
-					Text("Type:")
-						.gridColumnAlignment(.trailing)
-					Text(account.defaultName)
-				}
+		Grid(alignment: .leading, verticalSpacing: 0) {
+			GridRow(alignment: .firstTextBaseline) {
+				Text("Type:")
+					.gridColumnAlignment(.trailing)
+				Text(account.defaultName)
+			}
 
-				GridRow {
-					Color.clear
-						.gridCellUnsizedAxes([.horizontal, .vertical])
-					Toggle("Active", isOn: $isActive)
-						.onChange(of: isActive) {
-							account.isActive = isActive
-						}
-						.padding(.top, 9)
-				}
-
-				GridRow(alignment: .firstTextBaseline) {
-					Text("Name:")
-					TextField("", text: $accountName)
-						.frame(width: 150)
-						.onSubmit {
-							commitName()
-						}
-						.onChange(of: accountName) {
-							commitName()
-						}
-				}
-				.padding(.top, 14)
-
-				GridRow {
-					Color.clear
-						.gridCellUnsizedAxes([.horizontal, .vertical])
-					Text("The name can be anything you want. You can even use emoji. 🎸")
-						.foregroundStyle(.secondary)
-						.fixedSize(horizontal: false, vertical: true)
-						.padding(.top, 1)
-				}
-
-				if showCredentialsButton {
-					GridRow {
-						Color.clear
-							.gridCellUnsizedAxes([.horizontal, .vertical])
-						Button("Credentials") {
-							onCredentials?()
-						}
-						.padding(.top, 12)
+			GridRow {
+				Color.clear
+					.gridCellUnsizedAxes([.horizontal, .vertical])
+				Toggle("Active", isOn: $isActive)
+					.onChange(of: isActive) {
+						account.isActive = isActive
 					}
-				}
+					.padding(.top, 9)
+			}
 
+			GridRow(alignment: .firstTextBaseline) {
+				Text("Name:")
+				TextField("", text: $accountName)
+					.frame(width: 150)
+					.onSubmit {
+						commitName()
+					}
+					.onChange(of: accountName) {
+						commitName()
+					}
+			}
+			.padding(.top, 14)
+
+			GridRow {
+				Color.clear
+					.gridCellUnsizedAxes([.horizontal, .vertical])
+				Text("The name can be anything you want. You can even use emoji. 🎸")
+					.foregroundStyle(.secondary)
+					.fixedSize(horizontal: false, vertical: true)
+					.padding(.top, 1)
+			}
+
+			if showCredentialsButton {
 				GridRow {
 					Color.clear
 						.gridCellUnsizedAxes([.horizontal, .vertical])
-					Button("Hide Read Articles Settings…") {
-						onHideReadOverrides?()
+					Button("Credentials") {
+						onCredentials?()
 					}
-					.fixedSize()
 					.padding(.top, 12)
 				}
 			}
 
 			if account.type == .cloudKit {
-				Toggle("Sync content of unread articles", isOn: $syncUnreadContent)
-					.onChange(of: syncUnreadContent) {
-						AccountManager.shared.syncArticleContentForUnreadArticles = syncUnreadContent
-					}
-					.padding(.top, 12)
+				GridRow {
+					Color.clear
+						.gridCellUnsizedAxes([.horizontal, .vertical])
+					Toggle("Sync content of unread articles", isOn: $syncUnreadContent)
+						.onChange(of: syncUnreadContent) {
+							AccountManager.shared.syncArticleContentForUnreadArticles = syncUnreadContent
+						}
+						.padding(.top, 12)
+				}
 
-				Text("Syncing article content increases iCloud storage use, sync time, and battery use.\n\nArticle status and the content of starred articles are always synced.")
-					.foregroundStyle(.secondary)
-					.fixedSize(horizontal: false, vertical: true)
-					.padding(.top, 4)
-					.padding(.leading, 21)
+				GridRow {
+					Color.clear
+						.gridCellUnsizedAxes([.horizontal, .vertical])
+					Text("Syncing article content increases iCloud storage use, sync time, and battery use.\n\nArticle status and the content of starred articles are always synced.")
+						.foregroundStyle(.secondary)
+						.fixedSize(horizontal: false, vertical: true)
+						.padding(.top, 4)
+				}
+			}
+
+			// Placed last so it sits at the bottom for every account type.
+			GridRow {
+				Color.clear
+					.gridCellUnsizedAxes([.horizontal, .vertical])
+				Button("Hide Read Articles Settings…") {
+					onHideReadOverrides?()
+				}
+				.fixedSize()
+				.padding(.top, 12)
 			}
 		}
 		.padding(20)

--- a/Mac/Preferences/Accounts/AccountsDetailView.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailView.swift
@@ -91,9 +91,10 @@ struct AccountsDetailView: View {
 				GridRow {
 					Color.clear
 						.gridCellUnsizedAxes([.horizontal, .vertical])
-					Button("Read Article Filtering…") {
+					Button("Hide Read Articles Settings…") {
 						onHideReadOverrides?()
 					}
+					.fixedSize()
 					.padding(.top, 12)
 				}
 			}

--- a/Mac/Preferences/Accounts/AccountsDetailView.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailView.swift
@@ -12,14 +12,16 @@ struct AccountsDetailView: View {
 
 	let account: Account
 	var onCredentials: (() -> Void)?
+	var onHideReadOverrides: (() -> Void)?
 
 	@State private var accountName: String
 	@State private var isActive: Bool
 	@State private var syncUnreadContent: Bool
 
-	init(account: Account, onCredentials: (() -> Void)? = nil) {
+	init(account: Account, onCredentials: (() -> Void)? = nil, onHideReadOverrides: (() -> Void)? = nil) {
 		self.account = account
 		self.onCredentials = onCredentials
+		self.onHideReadOverrides = onHideReadOverrides
 		_accountName = State(initialValue: account.name ?? "")
 		_isActive = State(initialValue: account.isActive)
 		_syncUnreadContent = State(initialValue: AccountManager.shared.syncArticleContentForUnreadArticles)
@@ -84,6 +86,15 @@ struct AccountsDetailView: View {
 						}
 						.padding(.top, 12)
 					}
+				}
+
+				GridRow {
+					Color.clear
+						.gridCellUnsizedAxes([.horizontal, .vertical])
+					Button("Read Article Filtering…") {
+						onHideReadOverrides?()
+					}
+					.padding(.top, 12)
 				}
 			}
 

--- a/Mac/Preferences/Accounts/AccountsDetailView.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailView.swift
@@ -37,6 +37,16 @@ struct AccountsDetailView: View {
 	}
 
 	var body: some View {
+		// Scrolls so nothing clips when the pane is shorter than its content
+		// (e.g. an iCloud account with the sync controls). `.basedOnSize` keeps
+		// it from rubber-banding when the content already fits.
+		ScrollView {
+			accountForm
+		}
+		.scrollBounceBehavior(.basedOnSize)
+	}
+
+	private var accountForm: some View {
 		Grid(alignment: .leading, verticalSpacing: 0) {
 			GridRow(alignment: .firstTextBaseline) {
 				Text("Type:")
@@ -120,7 +130,7 @@ struct AccountsDetailView: View {
 			}
 		}
 		.padding(20)
-		.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+		.frame(maxWidth: .infinity, alignment: .topLeading)
 	}
 
 	private func commitName() {

--- a/Mac/Preferences/Accounts/AccountsDetailViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailViewController.swift
@@ -25,11 +25,69 @@ final class AccountsDetailViewController: NSViewController {
 	}
 
 	override func loadView() {
-		let detailView = AccountsDetailView(account: account) { [weak self] in
-			self?.showCredentials()
-		}
+		let detailView = AccountsDetailView(
+			account: account,
+			onCredentials: { [weak self] in
+				self?.showCredentials()
+			},
+			onHideReadOverrides: { [weak self] in
+				self?.showHideReadArticlesSettings()
+			}
+		)
 		let hostingView = NSHostingView(rootView: detailView)
 		self.view = hostingView
+	}
+
+	private func showHideReadArticlesSettings() {
+		guard let window = view.window else {
+			return
+		}
+
+		let overridesView = FeedReadFilterOverridesView(
+			account: account,
+			hasOverride: { [weak self] feedID in
+				guard let accountID = self?.account.accountID else {
+					return false
+				}
+				return AppDefaults.shared.feedReadFilterOverrides.hasOverride(accountID: accountID, feedID: feedID)
+			},
+			setOverride: { [weak self] feedID, hasOverride in
+				guard let accountID = self?.account.accountID else {
+					return
+				}
+				var overrides = AppDefaults.shared.feedReadFilterOverrides
+
+				if hasOverride {
+					let globalHides = AppDefaults.shared.hideReadArticles
+					overrides.setOverride(accountID: accountID, feedID: feedID, globalHides ? .show : .hide)
+				} else {
+					overrides.clearOverride(accountID: accountID, feedID: feedID)
+				}
+
+				AppDefaults.shared.feedReadFilterOverrides = overrides
+			},
+			clearAllOverrides: { [weak self] in
+				guard let accountID = self?.account.accountID else {
+					return
+				}
+				var overrides = AppDefaults.shared.feedReadFilterOverrides
+				overrides.clearAll(accountID: accountID)
+				AppDefaults.shared.feedReadFilterOverrides = overrides
+			}
+		)
+
+		var viewWithDone = overridesView
+		viewWithDone.onDone = { [weak window] in
+			guard let window, let sheet = window.attachedSheet else {
+				return
+			}
+			window.endSheet(sheet)
+		}
+
+		let hostingController = NSHostingController(rootView: viewWithDone)
+		let sheetWindow = NSWindow(contentViewController: hostingController)
+		sheetWindow.title = "Hide Read Articles Settings"
+		window.beginSheet(sheetWindow)
 	}
 
 	private func showCredentials() {

--- a/Mac/Preferences/Accounts/AccountsDetailViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailViewController.swift
@@ -67,7 +67,7 @@ final class AccountsDetailViewController: NSViewController {
 
 		let hostingController = NSHostingController(rootView: viewWithDone)
 		let sheetWindow = NSWindow(contentViewController: hostingController)
-		sheetWindow.title = "Hide Read Articles Settings"
+		sheetWindow.title = "Global Overrides"
 		window.beginSheet(sheetWindow)
 	}
 

--- a/Mac/Preferences/Accounts/AccountsDetailViewController.swift
+++ b/Mac/Preferences/Accounts/AccountsDetailViewController.swift
@@ -43,36 +43,17 @@ final class AccountsDetailViewController: NSViewController {
 			return
 		}
 
+		let accountID = account.accountID
 		let overridesView = FeedReadFilterOverridesView(
 			account: account,
-			hasOverride: { [weak self] feedID in
-				guard let accountID = self?.account.accountID else {
-					return false
-				}
-				return AppDefaults.shared.feedReadFilterOverrides.hasOverride(accountID: accountID, feedID: feedID)
+			hasOverride: { feedID in
+				AppDefaults.shared.feedReadFilterOverrides.hasOverride(accountID: accountID, feedID: feedID)
 			},
-			setOverride: { [weak self] feedID, hasOverride in
-				guard let accountID = self?.account.accountID else {
-					return
-				}
-				var overrides = AppDefaults.shared.feedReadFilterOverrides
-
-				if hasOverride {
-					let globalHides = AppDefaults.shared.hideReadArticles
-					overrides.setOverride(accountID: accountID, feedID: feedID, globalHides ? .show : .hide)
-				} else {
-					overrides.clearOverride(accountID: accountID, feedID: feedID)
-				}
-
-				AppDefaults.shared.feedReadFilterOverrides = overrides
+			setOverride: { feedID, enabled in
+				AppDefaults.shared.setFeedHideReadOverride(accountID: accountID, feedID: feedID, enabled: enabled)
 			},
-			clearAllOverrides: { [weak self] in
-				guard let accountID = self?.account.accountID else {
-					return
-				}
-				var overrides = AppDefaults.shared.feedReadFilterOverrides
-				overrides.clearAll(accountID: accountID)
-				AppDefaults.shared.feedReadFilterOverrides = overrides
+			clearAllOverrides: {
+				AppDefaults.shared.clearFeedHideReadOverrides(accountID: accountID)
 			}
 		)
 

--- a/Modules/Account/Sources/Account/SidebarItem.swift
+++ b/Modules/Account/Sources/Account/SidebarItem.swift
@@ -22,14 +22,14 @@ nonisolated public enum ReadFilterType: Sendable {
 
 @MainActor public extension SidebarItem {
 
-	func readFiltered(readFilterEnabledTable: [SidebarItemIdentifier: Bool]) -> Bool {
+	func readFiltered(readFilterEnabledTable: [SidebarItemIdentifier: Bool], globalHideReadArticles: Bool = false) -> Bool {
 		guard defaultReadFilterType != .alwaysRead else {
 			return true
 		}
 		if let sidebarItemID, let readFilterEnabled = readFilterEnabledTable[sidebarItemID] {
 			return readFilterEnabled
 		} else {
-			return defaultReadFilterType == .read
+			return globalHideReadArticles || defaultReadFilterType == .read
 		}
 
 	}

--- a/NetNewsWire.xcodeproj/project.pbxproj
+++ b/NetNewsWire.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 				ArticleSpecifier.swift,
 				Assets.swift,
 				"Extensions/Node+Extensions.swift",
+				Settings/FeedReadFilterOverrides.swift,
 				ShareExtension/ExtensionContainers.swift,
 				ShareExtension/ExtensionContainersFile.swift,
 				ShareExtension/ExtensionFeedAddRequest.swift,
@@ -439,6 +440,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				"Article Rendering/ArticleTextSize.swift",
+				Settings/FeedReadFilterOverrides.swift,
 				ShareExtension/ExtensionContainers.swift,
 				ShareExtension/ExtensionContainersFile.swift,
 				ShareExtension/ExtensionFeedAddRequest.swift,

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -228,6 +228,9 @@
     "Cleanup progress" : {
       "comment" : "Progress bar accessibility label"
     },
+    "Clear All" : {
+
+    },
     "Close" : {
       "comment" : "Close"
     },
@@ -479,6 +482,9 @@
     "Get Info" : {
       "comment" : "Get Info"
     },
+    "Global Overrides" : {
+
+    },
     "Go To All Unread" : {
       "comment" : "Go To All Unread"
     },
@@ -505,6 +511,9 @@
     },
     "Hide Read Articles" : {
       "comment" : "Command"
+    },
+    "Hide Read Articles Settings…" : {
+
     },
     "Hide Read Feeds" : {
       "comment" : "Command"
@@ -1196,6 +1205,9 @@
     },
     "Web accounts sync your feeds across all your devices" : {
       "comment" : "Web Account"
+    },
+    "When a switch is on, that feed uses its own read-article visibility setting instead of the global preference." : {
+
     },
     "You can enable NetNewsWire notifications in System Preferences." : {
       "comment" : "Notifications are not enabled."

--- a/Shared/Settings/FeedReadFilterOverrides.swift
+++ b/Shared/Settings/FeedReadFilterOverrides.swift
@@ -1,0 +1,93 @@
+//
+//  FeedReadFilterOverrides.swift
+//  NetNewsWire
+//
+//  Created by Paul on 4/3/26.
+//  Copyright © 2026 Ranchero Software. All rights reserved.
+//
+
+import Foundation
+
+/// Stores per-feed overrides for the global hide-read-articles setting.
+///
+/// Each feed can override the global setting to either hide or show read articles.
+/// Feeds without an override follow the global setting.
+struct FeedReadFilterOverrides: Codable, Equatable {
+
+	enum Override: String, Codable {
+		case hide
+		case show
+	}
+
+	/// accountID -> feedID -> Override
+	private var overrides: [String: [String: Override]]
+
+	init() {
+		overrides = [:]
+	}
+
+	init(feedsHiding: [String: Set<String>]) {
+		var result = [String: [String: Override]]()
+		for (accountID, feedIDs) in feedsHiding {
+			var accountOverrides = [String: Override]()
+			for feedID in feedIDs {
+				accountOverrides[feedID] = .hide
+			}
+			result[accountID] = accountOverrides
+		}
+		overrides = result
+	}
+
+	func override(accountID: String, feedID: String) -> Override? {
+		overrides[accountID]?[feedID]
+	}
+
+	func hasOverride(accountID: String, feedID: String) -> Bool {
+		overrides[accountID]?[feedID] != nil
+	}
+
+	mutating func setOverride(accountID: String, feedID: String, _ value: Override) {
+		var accountOverrides = overrides[accountID] ?? [:]
+		accountOverrides[feedID] = value
+		overrides[accountID] = accountOverrides
+	}
+
+	mutating func clearOverride(accountID: String, feedID: String) {
+		overrides[accountID]?.removeValue(forKey: feedID)
+		if overrides[accountID]?.isEmpty == true {
+			overrides[accountID] = nil
+		}
+	}
+
+	mutating func clearAll(accountID: String) {
+		overrides[accountID] = nil
+	}
+
+	/// All (accountID, feedID, override) tuples.
+	func allFeeds() -> [(accountID: String, feedID: String, override: Override)] {
+		var result = [(String, String, Override)]()
+		for (accountID, accountOverrides) in overrides {
+			for (feedID, value) in accountOverrides {
+				result.append((accountID, feedID, value))
+			}
+		}
+		return result
+	}
+}
+
+// MARK: - UserDefaults serialization
+
+extension FeedReadFilterOverrides {
+
+	init(data: Data?) {
+		guard let data, let decoded = try? JSONDecoder().decode(FeedReadFilterOverrides.self, from: data) else {
+			self.init()
+			return
+		}
+		self = decoded
+	}
+
+	var data: Data? {
+		try? JSONEncoder().encode(self)
+	}
+}

--- a/Shared/Settings/FeedReadFilterOverrides.swift
+++ b/Shared/Settings/FeedReadFilterOverrides.swift
@@ -26,16 +26,18 @@ struct FeedReadFilterOverrides: Codable, Equatable {
 		overrides = [:]
 	}
 
-	init(feedsHiding: [String: Set<String>]) {
+	static func migrating(legacyFeedsHiding: [String: Set<String>]) -> Self {
 		var result = [String: [String: Override]]()
-		for (accountID, feedIDs) in feedsHiding {
+		for (accountID, feedIDs) in legacyFeedsHiding {
 			var accountOverrides = [String: Override]()
 			for feedID in feedIDs {
 				accountOverrides[feedID] = .hide
 			}
 			result[accountID] = accountOverrides
 		}
-		overrides = result
+		var migrated = Self()
+		migrated.overrides = result
+		return migrated
 	}
 
 	func override(accountID: String, feedID: String) -> Override? {
@@ -63,7 +65,6 @@ struct FeedReadFilterOverrides: Codable, Equatable {
 		overrides[accountID] = nil
 	}
 
-	/// All (accountID, feedID, override) tuples.
 	func allFeeds() -> [(accountID: String, feedID: String, override: Override)] {
 		var result = [(String, String, Override)]()
 		for (accountID, accountOverrides) in overrides {

--- a/Shared/Settings/FeedReadFilterOverridesView.swift
+++ b/Shared/Settings/FeedReadFilterOverridesView.swift
@@ -1,0 +1,77 @@
+//
+//  FeedReadFilterOverridesView.swift
+//  NetNewsWire
+//
+//  Created by Paul on 4/1/26.
+//  Copyright © 2026 Ranchero Software. All rights reserved.
+//
+
+import SwiftUI
+import Account
+
+@MainActor struct FeedReadFilterOverridesView: View {
+
+	let account: Account
+	let hasOverride: (_ feedID: String) -> Bool
+	let setOverride: (_ feedID: String, _ hasOverride: Bool) -> Void
+	let clearAllOverrides: () -> Void
+
+	#if os(macOS)
+	var onDone: (() -> Void)?
+	#endif
+
+	@State private var feeds = [Feed]()
+	@State private var overrideStates = [String: Bool]()
+
+	var body: some View {
+
+		List {
+			Section {
+				ForEach(feeds, id: \.feedID) { feed in
+					Toggle(feed.nameForDisplay, isOn: Binding(
+						get: { overrideStates[feed.feedID] ?? false },
+						set: { overrideStates[feed.feedID] = $0 }
+					))
+					.onChange(of: overrideStates[feed.feedID]) {
+						setOverride(feed.feedID, overrideStates[feed.feedID] ?? false)
+					}
+				}
+			} footer: {
+				Text("When a switch is on, that feed uses its own read-article visibility setting instead of the global preference.")
+			}
+		}
+		.onAppear {
+			feeds = Array(account.flattenedFeeds()).sorted { $0.nameForDisplay.localizedStandardCompare($1.nameForDisplay) == .orderedAscending }
+			var states = [String: Bool]()
+			for feed in feeds {
+				states[feed.feedID] = hasOverride(feed.feedID)
+			}
+			overrideStates = states
+		}
+		.toolbar {
+			#if os(macOS)
+			ToolbarItem(placement: .cancellationAction) {
+				Button("Done") {
+					onDone?()
+				}
+			}
+			#endif
+			ToolbarItem(placement: .primaryAction) {
+				Button("Clear All", action: clearAll)
+			}
+		}
+		#if os(iOS)
+		.navigationTitle("Override Global Setting")
+		.navigationBarTitleDisplayMode(.inline)
+		#else
+		.frame(minWidth: 400, minHeight: 300)
+		#endif
+	}
+
+	private func clearAll() {
+		clearAllOverrides()
+		for key in overrideStates.keys {
+			overrideStates[key] = false
+		}
+	}
+}

--- a/Shared/Settings/FeedReadFilterOverridesView.swift
+++ b/Shared/Settings/FeedReadFilterOverridesView.swift
@@ -30,11 +30,11 @@ import Account
 				ForEach(feeds, id: \.feedID) { feed in
 					Toggle(feed.nameForDisplay, isOn: Binding(
 						get: { overrideStates[feed.feedID] ?? false },
-						set: { overrideStates[feed.feedID] = $0 }
+						set: { newValue in
+							overrideStates[feed.feedID] = newValue
+							setOverride(feed.feedID, newValue)
+						}
 					))
-					.onChange(of: overrideStates[feed.feedID]) {
-						setOverride(feed.feedID, overrideStates[feed.feedID] ?? false)
-					}
 				}
 			} footer: {
 				Text("When a switch is on, that feed uses its own read-article visibility setting instead of the global preference.")

--- a/Shared/Settings/FeedReadFilterOverridesView.swift
+++ b/Shared/Settings/FeedReadFilterOverridesView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import Account
+import Images
 
 @MainActor struct FeedReadFilterOverridesView: View {
 
@@ -22,23 +23,25 @@ import Account
 
 	@State private var feeds = [Feed]()
 	@State private var overrideStates = [String: Bool]()
+	@State private var iconRefreshID = UUID()
 
 	var body: some View {
 
-		List {
-			Section {
-				ForEach(feeds, id: \.feedID) { feed in
-					Toggle(feed.nameForDisplay, isOn: Binding(
-						get: { overrideStates[feed.feedID] ?? false },
-						set: { newValue in
-							overrideStates[feed.feedID] = newValue
-							setOverride(feed.feedID, newValue)
-						}
-					))
-				}
-			} footer: {
+		Group {
+			#if os(macOS)
+			// On macOS a `List` section footer clips to a single line, so the
+			// explanatory text is rendered below the list instead.
+			VStack(spacing: 0) {
+				feedList
 				Text("When a switch is on, that feed uses its own read-article visibility setting instead of the global preference.")
+					.foregroundStyle(.secondary)
+					.frame(maxWidth: .infinity, alignment: .leading)
+					.fixedSize(horizontal: false, vertical: true)
+					.padding()
 			}
+			#else
+			feedList
+			#endif
 		}
 		.onAppear {
 			feeds = Array(account.flattenedFeeds()).sorted { $0.nameForDisplay.localizedStandardCompare($1.nameForDisplay) == .orderedAscending }
@@ -47,6 +50,9 @@ import Account
 				states[feed.feedID] = hasOverride(feed.feedID)
 			}
 			overrideStates = states
+		}
+		.onReceive(NotificationCenter.default.publisher(for: .feedIconDidBecomeAvailable)) { _ in
+			iconRefreshID = UUID()
 		}
 		.toolbar {
 			#if os(macOS)
@@ -61,11 +67,47 @@ import Account
 			}
 		}
 		#if os(iOS)
-		.navigationTitle("Override Global Setting")
+		.navigationTitle("Global Overrides")
 		.navigationBarTitleDisplayMode(.inline)
 		#else
 		.frame(minWidth: 400, minHeight: 300)
 		#endif
+	}
+
+	private var feedList: some View {
+		List {
+			Section {
+				ForEach(feeds, id: \.feedID) { feed in
+					Toggle(isOn: Binding(
+						get: { overrideStates[feed.feedID] ?? false },
+						set: { newValue in
+							overrideStates[feed.feedID] = newValue
+							setOverride(feed.feedID, newValue)
+						}
+					)) {
+						HStack {
+							if let iconImage = iconImage(for: feed) {
+								IconImageView(icon: iconImage)
+									.id(iconRefreshID)
+							}
+							Text(verbatim: feed.nameForDisplay)
+						}
+					}
+					.toggleStyle(.switch)
+				}
+			} footer: {
+				#if os(iOS)
+				Text("When a switch is on, that feed uses its own read-article visibility setting instead of the global preference.")
+				#endif
+			}
+		}
+	}
+
+	private func iconImage(for feed: Feed) -> IconImage? {
+		if let feedID = feed.sidebarItemID, let iconImage = IconImageCache.shared.imageFor(feedID) {
+			return iconImage
+		}
+		return feed.smallIcon
 	}
 
 	private func clearAll() {

--- a/Shared/Timeline/FetchRequestOperation.swift
+++ b/Shared/Timeline/FetchRequestOperation.swift
@@ -29,15 +29,17 @@ typealias FetchRequestOperationResultBlock = (Set<Article>, FetchRequestOperatio
 
 	let id: Int
 	let readFilterEnabledTable: [SidebarItemIdentifier: Bool]
+	let globalHideReadArticles: Bool
 	let resultBlock: FetchRequestOperationResultBlock
 	var isCanceled = false
 	var isFinished = false
 	private let fetchers: [ArticleFetcher]
 
-	init(id: Int, readFilterEnabledTable: [SidebarItemIdentifier: Bool], fetchers: [ArticleFetcher], resultBlock: @escaping FetchRequestOperationResultBlock) {
+	init(id: Int, readFilterEnabledTable: [SidebarItemIdentifier: Bool], globalHideReadArticles: Bool = false, fetchers: [ArticleFetcher], resultBlock: @escaping FetchRequestOperationResultBlock) {
 		precondition(Thread.isMainThread)
 		self.id = id
 		self.readFilterEnabledTable = readFilterEnabledTable
+		self.globalHideReadArticles = globalHideReadArticles
 		self.fetchers = fetchers
 		self.resultBlock = resultBlock
 	}
@@ -95,7 +97,7 @@ typealias FetchRequestOperationResultBlock = (Set<Article>, FetchRequestOperatio
 			for fetcher in fetchers {
 				let articles: Set<Article>
 
-				if (fetcher as? SidebarItem)?.readFiltered(readFilterEnabledTable: readFilterEnabledTable) ?? true {
+				if (fetcher as? SidebarItem)?.readFiltered(readFilterEnabledTable: readFilterEnabledTable, globalHideReadArticles: globalHideReadArticles) ?? true {
 					articles = await fetcher.fetchUnreadArticlesAsync()
 				} else {
 					articles = await fetcher.fetchArticlesAsync()

--- a/Tests/NetNewsWireTests/FeedReadFilterOverridesTests.swift
+++ b/Tests/NetNewsWireTests/FeedReadFilterOverridesTests.swift
@@ -1,0 +1,140 @@
+//
+//  FeedReadFilterOverridesTests.swift
+//  NetNewsWire
+//
+//  Created by Paul on 7/19/26.
+//  Copyright © 2026 Ranchero Software. All rights reserved.
+//
+
+import XCTest
+
+@testable import NetNewsWire
+
+final class FeedReadFilterOverridesTests: XCTestCase {
+
+	private let accountID = "account1"
+	private let otherAccountID = "account2"
+	private let feedID = "feed1"
+	private let otherFeedID = "feed2"
+
+	// MARK: - Empty state
+
+	func testEmptyByDefault() {
+		let overrides = FeedReadFilterOverrides()
+		XCTAssertNil(overrides.override(accountID: accountID, feedID: feedID))
+		XCTAssertFalse(overrides.hasOverride(accountID: accountID, feedID: feedID))
+		XCTAssertTrue(overrides.allFeeds().isEmpty)
+	}
+
+	// MARK: - Legacy migration
+
+	func testMigratingMapsEveryFeedToHide() {
+		let legacy: [String: Set<String>] = [accountID: [feedID, otherFeedID], otherAccountID: [feedID]]
+		let overrides = FeedReadFilterOverrides.migrating(legacyFeedsHiding: legacy)
+
+		XCTAssertEqual(overrides.override(accountID: accountID, feedID: feedID), .hide)
+		XCTAssertEqual(overrides.override(accountID: accountID, feedID: otherFeedID), .hide)
+		XCTAssertEqual(overrides.override(accountID: otherAccountID, feedID: feedID), .hide)
+		XCTAssertEqual(overrides.allFeeds().count, 3)
+	}
+
+	func testMigratingEmptyLegacyProducesEmptyOverrides() {
+		let overrides = FeedReadFilterOverrides.migrating(legacyFeedsHiding: [:])
+		XCTAssertTrue(overrides.allFeeds().isEmpty)
+	}
+
+	// MARK: - Mutation round-trips
+
+	func testSetAndReadHideOverride() {
+		var overrides = FeedReadFilterOverrides()
+		overrides.setOverride(accountID: accountID, feedID: feedID, .hide)
+
+		XCTAssertTrue(overrides.hasOverride(accountID: accountID, feedID: feedID))
+		XCTAssertEqual(overrides.override(accountID: accountID, feedID: feedID), .hide)
+	}
+
+	func testSetAndReadShowOverride() {
+		var overrides = FeedReadFilterOverrides()
+		overrides.setOverride(accountID: accountID, feedID: feedID, .show)
+
+		XCTAssertTrue(overrides.hasOverride(accountID: accountID, feedID: feedID))
+		XCTAssertEqual(overrides.override(accountID: accountID, feedID: feedID), .show)
+	}
+
+	func testSetOverrideReplacesPreviousValue() {
+		var overrides = FeedReadFilterOverrides()
+		overrides.setOverride(accountID: accountID, feedID: feedID, .hide)
+		overrides.setOverride(accountID: accountID, feedID: feedID, .show)
+
+		XCTAssertEqual(overrides.override(accountID: accountID, feedID: feedID), .show)
+		XCTAssertEqual(overrides.allFeeds().count, 1)
+	}
+
+	func testClearOverrideRemovesOnlyThatFeed() {
+		var overrides = FeedReadFilterOverrides()
+		overrides.setOverride(accountID: accountID, feedID: feedID, .hide)
+		overrides.setOverride(accountID: accountID, feedID: otherFeedID, .show)
+
+		overrides.clearOverride(accountID: accountID, feedID: feedID)
+
+		XCTAssertFalse(overrides.hasOverride(accountID: accountID, feedID: feedID))
+		XCTAssertEqual(overrides.override(accountID: accountID, feedID: otherFeedID), .show)
+	}
+
+	// MARK: - Empty-account cleanup
+
+	func testClearingLastFeedRemovesAccount() {
+		var overrides = FeedReadFilterOverrides()
+		overrides.setOverride(accountID: accountID, feedID: feedID, .hide)
+		overrides.clearOverride(accountID: accountID, feedID: feedID)
+
+		XCTAssertTrue(overrides.allFeeds().isEmpty)
+		// A cleaned-up account round-trips identically to a never-used one.
+		XCTAssertEqual(overrides, FeedReadFilterOverrides())
+	}
+
+	func testClearAllRemovesOnlyGivenAccount() {
+		var overrides = FeedReadFilterOverrides()
+		overrides.setOverride(accountID: accountID, feedID: feedID, .hide)
+		overrides.setOverride(accountID: otherAccountID, feedID: otherFeedID, .show)
+
+		overrides.clearAll(accountID: accountID)
+
+		XCTAssertFalse(overrides.hasOverride(accountID: accountID, feedID: feedID))
+		XCTAssertEqual(overrides.override(accountID: otherAccountID, feedID: otherFeedID), .show)
+		XCTAssertEqual(overrides.allFeeds().count, 1)
+	}
+
+	func testClearOverrideForMissingFeedIsNoOp() {
+		var overrides = FeedReadFilterOverrides()
+		overrides.setOverride(accountID: accountID, feedID: feedID, .hide)
+
+		overrides.clearOverride(accountID: accountID, feedID: otherFeedID)
+		overrides.clearOverride(accountID: otherAccountID, feedID: feedID)
+
+		XCTAssertEqual(overrides.override(accountID: accountID, feedID: feedID), .hide)
+		XCTAssertEqual(overrides.allFeeds().count, 1)
+	}
+
+	// MARK: - Serialization
+
+	func testSerializationRoundTrip() {
+		var overrides = FeedReadFilterOverrides()
+		overrides.setOverride(accountID: accountID, feedID: feedID, .hide)
+		overrides.setOverride(accountID: otherAccountID, feedID: otherFeedID, .show)
+
+		let restored = FeedReadFilterOverrides(data: overrides.data)
+		XCTAssertEqual(restored, overrides)
+	}
+
+	func testInitWithNilDataProducesEmptyOverrides() {
+		let overrides = FeedReadFilterOverrides(data: nil)
+		XCTAssertEqual(overrides, FeedReadFilterOverrides())
+	}
+
+	func testInitWithMalformedDataProducesEmptyOverrides() {
+		let garbage = Data("not valid json".utf8)
+		let overrides = FeedReadFilterOverrides(data: garbage)
+		XCTAssertEqual(overrides, FeedReadFilterOverrides())
+	}
+}

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -59,7 +59,7 @@ final class AppDefaults: Sendable {
 
 		let hiding = UserDefaults.standard.dictionary(forKey: legacyKey) as? [String: [String]] ?? [:]
 
-		let overrides = FeedReadFilterOverrides(feedsHiding: hiding.mapValues { Set($0) })
+		let overrides = FeedReadFilterOverrides.migrating(legacyFeedsHiding: hiding.mapValues { Set($0) })
 
 		UserDefaults.standard.set(overrides.data, forKey: Key.feedReadFilterOverrides)
 		UserDefaults.standard.removeObject(forKey: legacyKey)
@@ -432,6 +432,22 @@ final class AppDefaults: Sendable {
 		}
 	}
 
+	func setFeedHideReadOverride(accountID: String, feedID: String, enabled: Bool) {
+		var overrides = feedReadFilterOverrides
+		if enabled {
+			overrides.setOverride(accountID: accountID, feedID: feedID, hideReadArticles ? .show : .hide)
+		} else {
+			overrides.clearOverride(accountID: accountID, feedID: feedID)
+		}
+		feedReadFilterOverrides = overrides
+	}
+
+	func clearFeedHideReadOverrides(accountID: String) {
+		var overrides = feedReadFilterOverrides
+		overrides.clearAll(accountID: accountID)
+		feedReadFilterOverrides = overrides
+	}
+
 	@MainActor static func registerDefaults() {
 		let defaults: [String: Any] = [Key.userInterfaceColorPalette: UserInterfaceColorPalette.automatic.rawValue,
 										Key.timelineGroupByFeed: false,
@@ -638,7 +654,7 @@ struct StateRestorationInfo {
 				  expandedContainers: expandedContainers,
 				  selectedSidebarItem: selectedSidebarItem,
 				  smartFeedsHidingReadArticles: smartFeedsHidingReadArticles,
-				  feedReadFilterOverrides: FeedReadFilterOverrides(feedsHiding: legacyFeedsHiding),
+				  feedReadFilterOverrides: FeedReadFilterOverrides.migrating(legacyFeedsHiding: legacyFeedsHiding),
 				  foldersShowingReadArticles: AppDefaults.shared.foldersShowingReadArticles,
 				  selectedArticle: AppDefaults.shared.selectedArticle,
 				  articleWindowScrollY: AppDefaults.shared.articleWindowScrollY,

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -41,7 +41,29 @@ final class AppDefaults: Sendable {
 	static let defaultThemeName = "Default"
 	fileprivate static let logger = Logger(subsystem: Logger.nnwSubsystem, category: "AppDefaults")
 
-	private init() {}
+	private init() {
+		migrateFeedReadFilterOverridesIfNeeded()
+	}
+
+	/// Migrate legacy `feedsHidingReadArticles` into the unified
+	/// `feedReadFilterOverrides` format.
+	private func migrateFeedReadFilterOverridesIfNeeded() {
+		let legacyKey = "feedsHidingReadArticles"
+
+		guard UserDefaults.standard.dictionary(forKey: legacyKey) != nil else {
+			return
+		}
+		guard UserDefaults.standard.data(forKey: Key.feedReadFilterOverrides) == nil else {
+			return
+		}
+
+		let hiding = UserDefaults.standard.dictionary(forKey: legacyKey) as? [String: [String]] ?? [:]
+
+		let overrides = FeedReadFilterOverrides(feedsHiding: hiding.mapValues { Set($0) })
+
+		UserDefaults.standard.set(overrides.data, forKey: Key.feedReadFilterOverrides)
+		UserDefaults.standard.removeObject(forKey: legacyKey)
+	}
 
 	nonisolated(unsafe) static let store: UserDefaults = {
 		let appIdentifierPrefix = Bundle.main.object(forInfoDictionaryKey: "AppIdentifierPrefix") as! String
@@ -73,13 +95,14 @@ final class AppDefaults: Sendable {
 		static let articleWindowScrollY = "articleWindowScrollY"
 		static let expandedContainers = "expandedContainers"
 		static let smartFeedsHidingReadArticles = "smartFeedsHidingReadArticles"
-		static let feedsHidingReadArticles = "feedsHidingReadArticles"
 		static let foldersShowingReadArticles = "foldersShowingReadArticles"
 		static let selectedSidebarItem = "selectedSidebarItem"
 		static let selectedArticle = "selectedArticle"
 		static let didMigrateLegacyStateRestorationInfo = "didMigrateLegacyStateRestorationInfo"
 		static let splitViewPreferredDisplayMode = "splitViewPreferredDisplayMode"
 		static let timelineWidth = "timelineWidth"
+		static let feedReadFilterOverrides = "feedReadFilterOverrides"
+		static let hideReadArticles = "hideReadArticles"
 	}
 
 	let isDeveloperBuild: Bool = {
@@ -337,19 +360,6 @@ final class AppDefaults: Sendable {
 		}
 	}
 
-	var feedsHidingReadArticles: [String: Set<String>] { // Account id: Set<feed.feedID>
-		get {
-			guard let d = UserDefaults.standard.dictionary(forKey: Key.feedsHidingReadArticles) as? [String: [String]] else {
-				return [String: Set<String>]()
-			}
-			return d.mapValues { Set($0) }
-		}
-		set {
-			let d = newValue.mapValues { Array($0) }
-			UserDefaults.standard.set(d, forKey: Key.feedsHidingReadArticles)
-		}
-	}
-
 	var foldersShowingReadArticles: [String: Set<String>] { // Account id: Set<folder.nameForDisplay>
 		get {
 			guard let d = UserDefaults.standard.dictionary(forKey: Key.foldersShowingReadArticles) as? [String: [String]] else {
@@ -401,6 +411,24 @@ final class AppDefaults: Sendable {
 		}
 		set {
 			UserDefaults.standard.set(newValue, forKey: Key.didMigrateLegacyStateRestorationInfo)
+		}
+	}
+
+	var feedReadFilterOverrides: FeedReadFilterOverrides {
+		get {
+			FeedReadFilterOverrides(data: UserDefaults.standard.data(forKey: Key.feedReadFilterOverrides))
+		}
+		set {
+			UserDefaults.standard.set(newValue.data, forKey: Key.feedReadFilterOverrides)
+		}
+	}
+
+	var hideReadArticles: Bool {
+		get {
+			return AppDefaults.bool(for: Key.hideReadArticles)
+		}
+		set {
+			AppDefaults.setBool(for: Key.hideReadArticles, newValue)
 		}
 	}
 
@@ -486,7 +514,7 @@ struct StateRestorationInfo {
 	let expandedContainers: Set<ContainerIdentifier>
 	let selectedSidebarItem: SidebarItemIdentifier?
 	let smartFeedsHidingReadArticles: Set<String>
-	let feedsHidingReadArticles: [String: Set<String>]
+	let feedReadFilterOverrides: FeedReadFilterOverrides
 	let foldersShowingReadArticles: [String: Set<String>]
 	let selectedArticle: ArticleSpecifier?
 	let articleWindowScrollY: Int
@@ -496,7 +524,7 @@ struct StateRestorationInfo {
 	     expandedContainers: Set<ContainerIdentifier>,
 	     selectedSidebarItem: SidebarItemIdentifier?,
 	     smartFeedsHidingReadArticles: Set<String>,
-	     feedsHidingReadArticles: [String: Set<String>],
+	     feedReadFilterOverrides: FeedReadFilterOverrides,
 	     foldersShowingReadArticles: [String: Set<String>],
 	     selectedArticle: ArticleSpecifier?,
 	     articleWindowScrollY: Int,
@@ -505,13 +533,13 @@ struct StateRestorationInfo {
 		self.expandedContainers = expandedContainers
 		self.selectedSidebarItem = selectedSidebarItem
 		self.smartFeedsHidingReadArticles = smartFeedsHidingReadArticles
-		self.feedsHidingReadArticles = feedsHidingReadArticles
+		self.feedReadFilterOverrides = feedReadFilterOverrides
 		self.foldersShowingReadArticles = foldersShowingReadArticles
 		self.selectedArticle = selectedArticle
 		self.articleWindowScrollY = articleWindowScrollY
 		self.isShowingExtractedArticle = isShowingExtractedArticle
 
-		AppDefaults.logger.debug("AppDefaults: StateRestorationInfo:\nexpandedContainers: \(expandedContainers)\nselectedSidebarItem: \(selectedSidebarItem?.userInfo ?? [String: String]())\nsmartFeedsHidingReadArticles: \(smartFeedsHidingReadArticles)\nfeedsHidingReadArticles: \(feedsHidingReadArticles)\nfoldersShowingReadArticles: \(foldersShowingReadArticles)\nselectedArticle: \(selectedArticle?.dictionary ?? [String: String]())\narticleWindowScrollY: \(articleWindowScrollY)\nisShowingExtractedArticle: \(isShowingExtractedArticle ? "true" : "false")")
+		AppDefaults.logger.debug("AppDefaults: StateRestorationInfo:\nexpandedContainers: \(expandedContainers)\nselectedSidebarItem: \(selectedSidebarItem?.userInfo ?? [String: String]())\nsmartFeedsHidingReadArticles: \(smartFeedsHidingReadArticles)\nfeedReadFilterOverrides: \(String(describing: feedReadFilterOverrides))\nfoldersShowingReadArticles: \(foldersShowingReadArticles)\nselectedArticle: \(selectedArticle?.dictionary ?? [String: String]())\narticleWindowScrollY: \(articleWindowScrollY)\nisShowingExtractedArticle: \(isShowingExtractedArticle ? "true" : "false")")
 	}
 
 	init() {
@@ -519,7 +547,7 @@ struct StateRestorationInfo {
 				  expandedContainers: AppDefaults.shared.expandedContainers,
 				  selectedSidebarItem: AppDefaults.shared.selectedSidebarItem,
 				  smartFeedsHidingReadArticles: AppDefaults.shared.smartFeedsHidingReadArticles,
-				  feedsHidingReadArticles: AppDefaults.shared.feedsHidingReadArticles,
+				  feedReadFilterOverrides: AppDefaults.shared.feedReadFilterOverrides,
 				  foldersShowingReadArticles: AppDefaults.shared.foldersShowingReadArticles,
 				  selectedArticle: AppDefaults.shared.selectedArticle,
 				  articleWindowScrollY: AppDefaults.shared.articleWindowScrollY,
@@ -584,15 +612,15 @@ struct StateRestorationInfo {
 		}
 
 		var smartFeedsHidingReadArticles = Set<String>()
-		var feedsHidingReadArticles = [String: Set<String>]()
+		var legacyFeedsHiding = [String: Set<String>]()
 		for sidebarItem in sidebarItemsHidingReadArticles {
 			switch sidebarItem {
 			case .smartFeed(let id):
 				smartFeedsHidingReadArticles.insert(id)
 			case .feed(let accountID, let feedID):
-				var feedIDs = feedsHidingReadArticles[accountID] ?? Set<String>()
+				var feedIDs = legacyFeedsHiding[accountID] ?? Set<String>()
 				feedIDs.insert(feedID)
-				feedsHidingReadArticles[accountID] = feedIDs
+				legacyFeedsHiding[accountID] = feedIDs
 			default:
 				continue
 			}
@@ -610,7 +638,7 @@ struct StateRestorationInfo {
 				  expandedContainers: expandedContainers,
 				  selectedSidebarItem: selectedSidebarItem,
 				  smartFeedsHidingReadArticles: smartFeedsHidingReadArticles,
-				  feedsHidingReadArticles: feedsHidingReadArticles,
+				  feedReadFilterOverrides: FeedReadFilterOverrides(feedsHiding: legacyFeedsHiding),
 				  foldersShowingReadArticles: AppDefaults.shared.foldersShowingReadArticles,
 				  selectedArticle: AppDefaults.shared.selectedArticle,
 				  articleWindowScrollY: AppDefaults.shared.articleWindowScrollY,

--- a/iOS/HidingReadArticlesState.swift
+++ b/iOS/HidingReadArticlesState.swift
@@ -11,19 +11,23 @@ import Account
 
 @MainActor final class HidingReadArticlesState {
 	private var smartFeedsHidingReadArticles = Set<String>()
-	private var feedsHidingReadArticles = [String: Set<String>]() // accountID: Set<feed.feedID>
+	private(set) var feedReadFilterOverrides = FeedReadFilterOverrides()
 	private var foldersShowingReadArticles = [String: Set<String>]() // accountID: Set<folder.nameForDisplay>
 
 	func copy(from stateRestorationInfo: StateRestorationInfo) {
 		smartFeedsHidingReadArticles = stateRestorationInfo.smartFeedsHidingReadArticles
-		feedsHidingReadArticles = stateRestorationInfo.feedsHidingReadArticles
+		feedReadFilterOverrides = stateRestorationInfo.feedReadFilterOverrides
 		foldersShowingReadArticles = stateRestorationInfo.foldersShowingReadArticles
 	}
 
 	func save() {
 		saveSmartFeedsHidingReadArticles()
-		saveFeedsHidingReadArticles()
+		saveFeedReadFilterOverrides()
 		saveFoldersShowingReadArticles()
+	}
+
+	func reloadFeedOverridesFromDefaults() {
+		feedReadFilterOverrides = AppDefaults.shared.feedReadFilterOverrides
 	}
 
 	func toggleHidingReadArticles(for sidebarItemID: SidebarItemIdentifier) {
@@ -44,14 +48,16 @@ import Account
 			if isUnreadSmartFeed(sidebarItemID) {
 				return true
 			}
-			return smartFeedsHidingReadArticles.contains(id)
+			if smartFeedsHidingReadArticles.contains(id) {
+				return true
+			}
+			return AppDefaults.shared.hideReadArticles
 
 		case .feed(let accountID, let feedID):
-			var isHidingReadArticles = false
-			if let feedIDs = feedsHidingReadArticles[accountID] {
-				isHidingReadArticles = feedIDs.contains(feedID)
+			if let override = feedReadFilterOverrides.override(accountID: accountID, feedID: feedID) {
+				return override == .hide
 			}
-			return isHidingReadArticles
+			return AppDefaults.shared.hideReadArticles
 
 		case .folder(let accountID, let folderName):
 			// Folders hide read articles by default, so we check if not showing read articles.
@@ -66,6 +72,25 @@ import Account
 	func canToggleHidingReadArticles(for sidebarItemID: SidebarItemIdentifier) -> Bool {
 		// The only item that can't be toggled is the unread smart feed.
 		!isUnreadSmartFeed(sidebarItemID)
+	}
+
+	func feedHasOverride(accountID: String, feedID: String) -> Bool {
+		feedReadFilterOverrides.hasOverride(accountID: accountID, feedID: feedID)
+	}
+
+	func clearFeedOverride(accountID: String, feedID: String) {
+		feedReadFilterOverrides.clearOverride(accountID: accountID, feedID: feedID)
+		saveFeedReadFilterOverrides()
+	}
+
+	func setFeedOverride(accountID: String, feedID: String, hiding: Bool) {
+		feedReadFilterOverrides.setOverride(accountID: accountID, feedID: feedID, hiding ? .hide : .show)
+		saveFeedReadFilterOverrides()
+	}
+
+	func clearAllFeedOverrides(accountID: String) {
+		feedReadFilterOverrides.clearAll(accountID: accountID)
+		saveFeedReadFilterOverrides()
 	}
 }
 
@@ -90,19 +115,12 @@ private extension HidingReadArticlesState {
 			saveSmartFeedsHidingReadArticles()
 
 		case .feed(let accountID, let feedID):
-			if hiding {
-				var feedIDs = feedsHidingReadArticles[accountID] ?? Set<String>()
-				feedIDs.insert(feedID)
-				feedsHidingReadArticles[accountID] = feedIDs
-			} else {
-				feedsHidingReadArticles[accountID]?.remove(feedID)
-			}
-			saveFeedsHidingReadArticles()
+			feedReadFilterOverrides.setOverride(accountID: accountID, feedID: feedID, hiding ? .hide : .show)
+			saveFeedReadFilterOverrides()
 
 		case .folder(let accountID, let folderName):
 			// Folders hide read articles by default, so we store the folder
-			// only if it's showing read articles. It's the opposite of
-			// feedsHidingReadArticles.
+			// only if it's showing read articles.
 			if hiding {
 				foldersShowingReadArticles[accountID]?.remove(folderName)
 			} else {
@@ -129,19 +147,18 @@ private extension HidingReadArticlesState {
 		AppDefaults.shared.foldersShowingReadArticles = d
 	}
 
-	func saveFeedsHidingReadArticles() {
-		var d = feedsHidingReadArticles
-
-		// Filter out accounts and feeds that no longer exist.
-		for accountID in Array(d.keys) {
-			guard let account = AccountManager.shared.existingAccount(accountID: accountID) else {
-				d[accountID] = nil
+	func saveFeedReadFilterOverrides() {
+		var cleanedOverrides = FeedReadFilterOverrides()
+		for entry in feedReadFilterOverrides.allFeeds() {
+			guard let account = AccountManager.shared.existingAccount(accountID: entry.accountID),
+				  account.existingFeed(withFeedID: entry.feedID) != nil else {
 				continue
 			}
-			d[accountID] = d[accountID]?.filter { account.existingFeed(withFeedID: $0) != nil }
+			cleanedOverrides.setOverride(accountID: entry.accountID, feedID: entry.feedID, entry.override)
 		}
 
-		AppDefaults.shared.feedsHidingReadArticles = d
+		feedReadFilterOverrides = cleanedOverrides
+		AppDefaults.shared.feedReadFilterOverrides = feedReadFilterOverrides
 	}
 
 	func saveSmartFeedsHidingReadArticles() {

--- a/iOS/HidingReadArticlesState.swift
+++ b/iOS/HidingReadArticlesState.swift
@@ -73,25 +73,6 @@ import Account
 		// The only item that can't be toggled is the unread smart feed.
 		!isUnreadSmartFeed(sidebarItemID)
 	}
-
-	func feedHasOverride(accountID: String, feedID: String) -> Bool {
-		feedReadFilterOverrides.hasOverride(accountID: accountID, feedID: feedID)
-	}
-
-	func clearFeedOverride(accountID: String, feedID: String) {
-		feedReadFilterOverrides.clearOverride(accountID: accountID, feedID: feedID)
-		saveFeedReadFilterOverrides()
-	}
-
-	func setFeedOverride(accountID: String, feedID: String, hiding: Bool) {
-		feedReadFilterOverrides.setOverride(accountID: accountID, feedID: feedID, hiding ? .hide : .show)
-		saveFeedReadFilterOverrides()
-	}
-
-	func clearAllFeedOverrides(accountID: String) {
-		feedReadFilterOverrides.clearAll(accountID: accountID)
-		saveFeedReadFilterOverrides()
-	}
 }
 
 private extension HidingReadArticlesState {

--- a/iOS/Inspector/AccountInspectorViewController.swift
+++ b/iOS/Inspector/AccountInspectorViewController.swift
@@ -136,27 +136,17 @@ final class AccountInspectorViewController: UITableViewController {
 			return
 		}
 
+		let accountID = account.accountID
 		let view = FeedReadFilterOverridesView(
 			account: account,
 			hasOverride: { feedID in
-				AppDefaults.shared.feedReadFilterOverrides.hasOverride(accountID: account.accountID, feedID: feedID)
+				AppDefaults.shared.feedReadFilterOverrides.hasOverride(accountID: accountID, feedID: feedID)
 			},
-			setOverride: { feedID, hasOverride in
-				var overrides = AppDefaults.shared.feedReadFilterOverrides
-
-				if hasOverride {
-					let globalHides = AppDefaults.shared.hideReadArticles
-					overrides.setOverride(accountID: account.accountID, feedID: feedID, globalHides ? .show : .hide)
-				} else {
-					overrides.clearOverride(accountID: account.accountID, feedID: feedID)
-				}
-
-				AppDefaults.shared.feedReadFilterOverrides = overrides
+			setOverride: { feedID, enabled in
+				AppDefaults.shared.setFeedHideReadOverride(accountID: accountID, feedID: feedID, enabled: enabled)
 			},
 			clearAllOverrides: {
-				var overrides = AppDefaults.shared.feedReadFilterOverrides
-				overrides.clearAll(accountID: account.accountID)
-				AppDefaults.shared.feedReadFilterOverrides = overrides
+				AppDefaults.shared.clearFeedHideReadOverrides(accountID: accountID)
 			}
 		)
 

--- a/iOS/Inspector/AccountInspectorViewController.swift
+++ b/iOS/Inspector/AccountInspectorViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import SafariServices
+import SwiftUI
 import RSCore
 import Account
 
@@ -130,6 +131,39 @@ final class AccountInspectorViewController: UITableViewController {
 		present(alertController, animated: true)
 	}
 
+	func showHideReadArticlesSettings() {
+		guard let account else {
+			return
+		}
+
+		let view = FeedReadFilterOverridesView(
+			account: account,
+			hasOverride: { feedID in
+				AppDefaults.shared.feedReadFilterOverrides.hasOverride(accountID: account.accountID, feedID: feedID)
+			},
+			setOverride: { feedID, hasOverride in
+				var overrides = AppDefaults.shared.feedReadFilterOverrides
+
+				if hasOverride {
+					let globalHides = AppDefaults.shared.hideReadArticles
+					overrides.setOverride(accountID: account.accountID, feedID: feedID, globalHides ? .show : .hide)
+				} else {
+					overrides.clearOverride(accountID: account.accountID, feedID: feedID)
+				}
+
+				AppDefaults.shared.feedReadFilterOverrides = overrides
+			},
+			clearAllOverrides: {
+				var overrides = AppDefaults.shared.feedReadFilterOverrides
+				overrides.clearAll(accountID: account.accountID)
+				AppDefaults.shared.feedReadFilterOverrides = overrides
+			}
+		)
+
+		let hostingController = UIHostingController(rootView: view)
+		navigationController?.pushViewController(hostingController, animated: true)
+	}
+
 	@IBAction func openLimitationsAndSolutions(_ sender: Any) {
 		let vc = SFSafariViewController(url: CloudKitWebDocumentation.limitationsAndSolutionsURL)
 		vc.modalPresentationStyle = .pageSheet
@@ -147,6 +181,7 @@ extension AccountInspectorViewController {
 		case credentials = 1
 		case deleteAccount = 2
 		case syncContent = 3
+		case hideReadOverrides = 4
 	}
 
 	var isCloudKitAccount: Bool {
@@ -176,15 +211,15 @@ extension AccountInspectorViewController {
 			return []
 		}
 		if account == AccountManager.shared.defaultAccount {
-			return [.nameAndActive]
+			return [.nameAndActive, .hideReadOverrides]
 		}
 		if isCloudKitAccount {
-			return [.nameAndActive, .syncContent, .deleteAccount]
+			return [.nameAndActive, .syncContent, .hideReadOverrides, .deleteAccount]
 		}
 		if hidesCredentialsSection {
-			return [.nameAndActive, .deleteAccount]
+			return [.nameAndActive, .hideReadOverrides, .deleteAccount]
 		}
-		return [.nameAndActive, .credentials, .deleteAccount]
+		return [.nameAndActive, .credentials, .hideReadOverrides, .deleteAccount]
 	}
 
 	override func numberOfSections(in tableView: UITableView) -> Int {
@@ -238,6 +273,10 @@ extension AccountInspectorViewController {
 	}
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		let section = displayedSections[indexPath.section]
+		if section == .hideReadOverrides {
+			showHideReadArticlesSettings()
+		}
 		tableView.selectRow(at: nil, animated: true, scrollPosition: .none)
 	}
 }

--- a/iOS/Inspector/Inspector.storyboard
+++ b/iOS/Inspector/Inspector.storyboard
@@ -198,6 +198,30 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection id="hideReadOverrides-section-id">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="hideReadOverrides-cell-id" customClass="VibrantBasicTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
+                                        <rect key="frame" x="20" y="417" width="374" height="51"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hideReadOverrides-cell-id" id="hideReadOverrides-content-id">
+                                            <rect key="frame" x="0.0" y="0.0" width="343.5" height="51"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hide Read Articles Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hideReadOverrides-label-id">
+                                                    <rect key="frame" x="20" y="15.5" width="210" height="20.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="hideReadOverrides-label-id" firstAttribute="centerY" secondItem="hideReadOverrides-content-id" secondAttribute="centerY" id="hideReadOverrides-centerY-id"/>
+                                                <constraint firstItem="hideReadOverrides-label-id" firstAttribute="leading" secondItem="hideReadOverrides-content-id" secondAttribute="leadingMargin" id="hideReadOverrides-leading-id"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                         </sections>
                         <connections>
                             <outlet property="dataSource" destination="1m3-fZ-n7g" id="eTZ-Uy-P3l"/>

--- a/iOS/SceneCoordinator.swift
+++ b/iOS/SceneCoordinator.swift
@@ -113,6 +113,8 @@ struct SidebarItemNode: Hashable, Sendable {
 		}
 	}
 
+	private var hideReadArticles = AppDefaults.shared.hideReadArticles
+
 	var prefersStatusBarHidden = false
 
 	private let treeControllerDelegate = SidebarTreeControllerDelegate()
@@ -633,6 +635,15 @@ struct SidebarItemNode: Hashable, Sendable {
 	}
 
 	func userDefaultsDidChange() {
+		let newHideReadArticles = AppDefaults.shared.hideReadArticles
+		let hideReadArticlesDidChange = hideReadArticles != newHideReadArticles
+		hideReadArticles = newHideReadArticles
+		let previousOverrides = hidingReadArticlesState.feedReadFilterOverrides
+		hidingReadArticlesState.reloadFeedOverridesFromDefaults()
+		let overridesDidChange = hidingReadArticlesState.feedReadFilterOverrides != previousOverrides
+		if hideReadArticlesDidChange || overridesDidChange {
+			refreshTimeline(resetScroll: false)
+		}
 		sortDirection = AppDefaults.shared.timelineSortDirection
 		groupByFeed = AppDefaults.shared.timelineGroupByFeed
 	}

--- a/iOS/Settings/Settings.storyboard
+++ b/iOS/Settings/Settings.storyboard
@@ -183,8 +183,41 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="5wo-fM-0l6" customClass="VibrantTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="hRA-c1-Xvz" customClass="VibrantTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
                                         <rect key="frame" x="20" y="581.5" width="374" height="51.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hRA-c1-Xvz" id="hRA-c2-Xvz">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="51.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Hide Read Articles" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hRA-l1-Xvz" customClass="VibrantLabel" customModule="NetNewsWire" customModuleProvider="target">
+                                                    <rect key="frame" x="20" y="15" width="148" height="21.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="hRA-s1-Xvz">
+                                                    <rect key="frame" x="295" y="12" width="63" height="28"/>
+                                                    <color key="onTintColor" name="primaryAccentColor"/>
+                                                    <connections>
+                                                        <action selector="switchHideReadArticles:" destination="a0p-rk-skQ" eventType="valueChanged" id="hRA-a1-Xvz"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="hRA-l1-Xvz" firstAttribute="top" secondItem="hRA-c2-Xvz" secondAttribute="topMargin" id="hRA-t1-Xvz"/>
+                                                <constraint firstItem="hRA-l1-Xvz" firstAttribute="leading" secondItem="hRA-c2-Xvz" secondAttribute="leadingMargin" id="hRA-t2-Xvz"/>
+                                                <constraint firstItem="hRA-s1-Xvz" firstAttribute="top" relation="greaterThanOrEqual" secondItem="hRA-c2-Xvz" secondAttribute="top" constant="6" id="hRA-t3-Xvz"/>
+                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hRA-s1-Xvz" secondAttribute="bottom" constant="6" id="hRA-t4-Xvz"/>
+                                                <constraint firstAttribute="trailing" secondItem="hRA-s1-Xvz" secondAttribute="trailing" constant="18" id="hRA-t5-Xvz"/>
+                                                <constraint firstItem="hRA-s1-Xvz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="hRA-l1-Xvz" secondAttribute="trailing" constant="8" id="hRA-t6-Xvz"/>
+                                                <constraint firstItem="hRA-s1-Xvz" firstAttribute="centerY" secondItem="hRA-c2-Xvz" secondAttribute="centerY" id="hRA-t7-Xvz"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="hRA-l1-Xvz" secondAttribute="bottom" id="hRA-t8-Xvz"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="5wo-fM-0l6" customClass="VibrantTableViewCell" customModule="NetNewsWire" customModuleProvider="target">
+                                        <rect key="frame" x="20" y="633" width="374" height="51.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5wo-fM-0l6" id="XAn-lK-LoN">
                                             <rect key="frame" x="0.0" y="0.0" width="374" height="51.5"/>
@@ -660,6 +693,7 @@
                         <outlet property="confirmMarkAllAsReadSwitch" destination="UOo-9z-IuL" id="yLZ-Kf-wDt"/>
                         <outlet property="enableJavaScriptSwitch" destination="Djo-HE-LWS" id="muL-I5-eDE"/>
                         <outlet property="groupByFeedSwitch" destination="JNi-Wz-RbU" id="TwH-Kd-o6N"/>
+                        <outlet property="hideReadArticlesSwitch" destination="hRA-s1-Xvz" id="hRA-o1-Xvz"/>
                         <outlet property="openLinksInNetNewsWire" destination="dhR-L2-PX3" id="z1b-pX-bwG"/>
                         <outlet property="refreshClearsReadArticlesSwitch" destination="duV-CN-JmH" id="xTd-jF-Ei1"/>
                         <outlet property="showFullscreenArticlesSwitch" destination="2Md-2E-7Z4" id="lEN-VP-wEO"/>

--- a/iOS/Settings/SettingsViewController.swift
+++ b/iOS/Settings/SettingsViewController.swift
@@ -45,9 +45,10 @@ final class SettingsViewController: UITableViewController {
 	private enum TimelineRow: Int {
 		case sortOrder = 0
 		case groupByFeed = 1
-		case refreshClearsReadArticles = 2
-		case confirmMarkAllAsRead = 3
-		case timelineLayout = 4
+		case hideReadArticles = 2
+		case refreshClearsReadArticles = 3
+		case confirmMarkAllAsRead = 4
+		case timelineLayout = 5
 	}
 
 	private enum ArticlesRow: Int, CaseIterable {
@@ -69,6 +70,7 @@ final class SettingsViewController: UITableViewController {
 
 	@IBOutlet var timelineSortOrderSwitch: UISwitch!
 	@IBOutlet var groupByFeedSwitch: UISwitch!
+	@IBOutlet var hideReadArticlesSwitch: UISwitch!
 	@IBOutlet var refreshClearsReadArticlesSwitch: UISwitch!
 	@IBOutlet var articleThemeDetailLabel: UILabel!
 	@IBOutlet var confirmMarkAllAsReadSwitch: UISwitch!
@@ -110,6 +112,8 @@ final class SettingsViewController: UITableViewController {
 		} else {
 			groupByFeedSwitch.isOn = false
 		}
+
+		hideReadArticlesSwitch.isOn = AppDefaults.shared.hideReadArticles
 
 		if AppDefaults.shared.refreshClearsReadArticles {
 			refreshClearsReadArticlesSwitch.isOn = true
@@ -368,6 +372,10 @@ final class SettingsViewController: UITableViewController {
 		} else {
 			AppDefaults.shared.timelineGroupByFeed = false
 		}
+	}
+
+	@IBAction func switchHideReadArticles(_ sender: Any) {
+		AppDefaults.shared.hideReadArticles = hideReadArticlesSwitch.isOn
 	}
 
 	@IBAction func switchClearsReadArticles(_ sender: Any) {


### PR DESCRIPTION
## What changed
Adds a global **Hide Read Articles** preference that defaults every feed to
showing only unread articles, while preserving per-feed overrides. A new
**Hide Read Articles Settings…** entry on each account opens a **Global
Overrides** screen that lists every feed (favicon + name) with a switch; a
switch that is *on* means that feed keeps its own read-article visibility
instead of following the global preference, and **Clear All** resets them in
one step. Toggling hide-read in a timeline still sets that feed's own override
implicitly — it never changes the global preference. Works on macOS and iOS.

## Screenshots
| macOS | iOS |
| --- | --- |
| <img width="1252" height="1164" alt="macOS" src="https://github.com/user-attachments/assets/6c8681c4-eb4c-4e4f-a74c-a59c3db4bd46" /> | <img width="1206" height="2622" alt="iOS" src="https://github.com/user-attachments/assets/ba4c7b54-c27c-4615-b13d-0a0f45c433bf" /> |

## Why
Implements a long-requested global toggle ([forum discussion][1] + existing
repo issue). The per-account screen of switches is the minimal opt-out UI the
maintainers agreed on in the discussion, rather than scattering per-feed
controls through the app.

[1]: https://discourse.netnewswire.com/t/add-global-hide-read-articles-preference/212

## Deviations from the agreed design
This follows the design agreed in the discussion, with two deliberate
departures worth your eye:
- **Screen title.** The thread specified *"Override Global Hide Read Articles
  Setting"*; I shortened it to **"Global Overrides"** — the full string
  overflows the iOS navigation bar and reads as redundant once you're already
  inside the screen. Trivial to revert if you'd rather keep the original.
- **macOS state model (beyond the UI-only discussion).** To make the new
  screen and the timeline agree on macOS, per-feed read-filter state now lives
  in `feedReadFilterOverrides` rather than window-state restoration — which
  also fixes a latent loss of pre-existing per-feed settings. Details below.

## Things to look out for
- **macOS read-filter state model (most nuanced area).** Per-feed hide-read
  was previously stored only in window-state restoration. This change makes
  `feedReadFilterOverrides` (UserDefaults) authoritative for feeds: legacy
  window-state feed entries are migrated into overrides on restore
  (no-clobber), and feeds are no longer persisted to window state. Folders and
  smart feeds remain window-state-backed. See `aba1d896b`.
- **One-time migrations.** iOS migrates the legacy `feedsHidingReadArticles`
  UserDefaults dictionary; macOS migrates legacy window-state feed entries.
  Both run once and never overwrite an existing override.
- **Local, not synced.** Overrides live in UserDefaults per device — consistent
  with hide-read having always been a local UI preference.
- Adopts the SwiftUI favicon wrapper (`IconImageView`) introduced in #5095.

## Related
Closes #3030

## Test plan
- [x] Builds cleanly on macOS and iOS
- [x] Manually verified on both platforms: global toggle; per-feed override
      semantics; timeline toggle sets a per-feed override only; Clear All;
      persistence & state restoration; multi-account isolation
- [x] iOS legacy migration (`feedsHidingReadArticles` → overrides) verified
- [x] macOS legacy migration (window-state → overrides) verified, including
      that previously hidden feeds survive a later override change

## Note on tooling
Per the contributing guidelines: this PR was developed with the help of Claude Code. All changes were orchestrated and reviewed by me and manually tested on macOS and iOS.
