### PR TITLE
feat(reader-api): add custom HTTP headers for self-hosted accounts

### DIFF
--- a/Mac/Preferences/Accounts/AccountsReaderAPIWindowController.swift
+++ b/Mac/Preferences/Accounts/AccountsReaderAPIWindowController.swift
@@ -13,6 +13,18 @@ import Secrets
 
 final class AccountsReaderAPIWindowController: NSWindowController {
 
+	private struct CustomHeaderFieldSet {
+		let container: NSStackView
+		let nameTextField: NSTextField
+		let valueTextField: NSTextField
+	}
+
+	private struct CustomHeaderValidationError: LocalizedError {
+		var errorDescription: String? {
+			NSLocalizedString("Custom header names and values are required. Header names must be valid HTTP field names.", comment: "FreshRSS Custom HTTP Header Error")
+		}
+	}
+
 	@IBOutlet var titleImageView: NSImageView!
 	@IBOutlet var titleLabel: NSTextField!
 
@@ -30,6 +42,13 @@ final class AccountsReaderAPIWindowController: NSWindowController {
 	var accountType: AccountType?
 
 	private weak var hostWindow: NSWindow?
+	private var customHeaderStackView: NSStackView?
+	private var customHeaderFieldSets = [CustomHeaderFieldSet]()
+	private var baseWindowFrame: NSRect?
+	private let customHeaderAdditionalWidth: CGFloat = 0
+	private let customHeaderSectionHeight: CGFloat = 37
+	private let customHeaderRowHeight: CGFloat = 91
+	private let customHeaderFieldWidth: CGFloat = 200
 
 	convenience init() {
 		self.init(windowNibName: NSNib.Name("AccountsReaderAPI"))
@@ -64,14 +83,23 @@ final class AccountsReaderAPIWindowController: NSWindowController {
 			}
 		}
 
+		baseWindowFrame = window?.frame
 		if let account = account, let credentials = try? account.retrieveCredentials(type: .readerBasic) {
 			usernameTextField.stringValue = credentials.username
 			apiURLTextField.stringValue = account.endpointURL?.absoluteString ?? ""
 			actionButton.title = NSLocalizedString("Update", comment: "Update")
+			if accountType == .freshRSS {
+				let customHeaders = (try? account.retrieveReaderAPICustomHTTPHeaders()) ?? []
+				addCustomHeaderControls(customHeaders: customHeaders)
+			}
 		} else {
 			actionButton.title = NSLocalizedString("Create", comment: "Create")
+			if accountType == .freshRSS {
+				addCustomHeaderControls(customHeaders: [])
+			}
 		}
 
+		resizeWindowForCustomHeaders()
 		enableAutofill()
 		usernameTextField.becomeFirstResponder()
 	}
@@ -132,6 +160,14 @@ final class AccountsReaderAPIWindowController: NSWindowController {
 			return
 		}
 
+		let customHTTPHeaders: [ReaderAPICustomHTTPHeader]
+		do {
+			customHTTPHeaders = try validatedCustomHTTPHeaders()
+		} catch {
+			self.errorMessageLabel.stringValue = error.localizedDescription
+			return
+		}
+
 		Task { @MainActor in
 			actionButton.isEnabled = false
 			progressIndicator.isHidden = false
@@ -145,7 +181,7 @@ final class AccountsReaderAPIWindowController: NSWindowController {
 
 			let credentials = Credentials(type: .readerBasic, username: trimmedUsername, secret: passwordTextField.stringValue)
 			do {
-				let validatedCredentials = try await Account.validateCredentials(type: accountType, credentials: credentials, endpoint: apiURL)
+				let validatedCredentials = try await Account.validateCredentials(type: accountType, credentials: credentials, endpoint: apiURL, customHTTPHeaders: customHTTPHeaders)
 				stopAnimation()
 
 				guard let validatedCredentials else {
@@ -162,6 +198,7 @@ final class AccountsReaderAPIWindowController: NSWindowController {
 
 					try account?.storeCredentials(credentials)
 					try account?.storeCredentials(validatedCredentials)
+					try account?.storeReaderAPICustomHTTPHeaders(customHTTPHeaders)
 
 					hostWindow?.endSheet(window!, returnCode: NSApplication.ModalResponse.OK)
 
@@ -196,6 +233,160 @@ final class AccountsReaderAPIWindowController: NSWindowController {
 	func enableAutofill() {
 		usernameTextField.contentType = .username
 		passwordTextField.contentType = .password
+	}
+
+}
+
+private extension AccountsReaderAPIWindowController {
+
+	func addCustomHeaderControls(customHeaders: [ReaderAPICustomHTTPHeader]) {
+		guard customHeaderStackView == nil else {
+			return
+		}
+
+		let label = NSTextField(labelWithString: NSLocalizedString("Headers:", comment: "FreshRSS Custom HTTP Headers"))
+		label.alignment = .right
+
+		let stackView = NSStackView()
+		stackView.orientation = .vertical
+		stackView.alignment = .left
+		stackView.spacing = 6
+		stackView.translatesAutoresizingMaskIntoConstraints = false
+		customHeaderStackView = stackView
+
+		gridView.addRow(with: [label, stackView])
+		gridView.row(at: gridView.numberOfRows - 1).topPadding = 6
+
+		for customHeader in customHeaders {
+			appendCustomHeaderFieldSet(name: customHeader.name, value: customHeader.value)
+		}
+
+		addCustomHeaderButton()
+	}
+
+	func addCustomHeaderButton() {
+		guard let customHeaderStackView else {
+			return
+		}
+
+		let button = NSButton(title: NSLocalizedString("Add Custom Header", comment: "FreshRSS Custom HTTP Header Button"), target: self, action: #selector(addCustomHeader(_:)))
+		button.bezelStyle = .rounded
+		button.controlSize = .small
+		button.setContentCompressionResistancePriority(.required, for: .horizontal)
+		button.setContentHuggingPriority(.required, for: .horizontal)
+		customHeaderStackView.addArrangedSubview(button)
+	}
+
+	@objc func addCustomHeader(_ sender: Any) {
+		appendCustomHeaderFieldSet(name: "", value: "")
+		resizeWindowForCustomHeaders()
+	}
+
+	func appendCustomHeaderFieldSet(name: String, value: String) {
+		guard let customHeaderStackView else {
+			return
+		}
+
+		let nameTextField = NSTextField()
+		nameTextField.placeholderString = NSLocalizedString("Header name", comment: "FreshRSS Custom HTTP Header Name")
+		nameTextField.stringValue = name
+		nameTextField.translatesAutoresizingMaskIntoConstraints = false
+		nameTextField.cell?.usesSingleLineMode = true
+		nameTextField.cell?.lineBreakMode = .byTruncatingTail
+		nameTextField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+		nameTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+		let valueTextField = NSTextField()
+		valueTextField.placeholderString = NSLocalizedString("Header value", comment: "FreshRSS Custom HTTP Header Value")
+		valueTextField.stringValue = value
+		valueTextField.translatesAutoresizingMaskIntoConstraints = false
+		valueTextField.cell?.usesSingleLineMode = true
+		valueTextField.cell?.lineBreakMode = .byTruncatingTail
+		valueTextField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+		valueTextField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+		let removeButton = NSButton(title: "", target: self, action: #selector(removeCustomHeader(_:)))
+		removeButton.image = NSImage(systemSymbolName: "minus.circle", accessibilityDescription: NSLocalizedString("Remove Custom Header", comment: "FreshRSS Remove Custom HTTP Header"))
+		removeButton.title = NSLocalizedString("Remove Header", comment: "FreshRSS Remove Custom HTTP Header Button")
+		removeButton.imagePosition = .imageLeading
+		removeButton.bezelStyle = .rounded
+		removeButton.isBordered = false
+		removeButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+		removeButton.setContentHuggingPriority(.required, for: .horizontal)
+
+		let fieldsStackView = NSStackView(views: [nameTextField, valueTextField, removeButton])
+		fieldsStackView.orientation = .vertical
+		fieldsStackView.alignment = .leading
+		fieldsStackView.spacing = 4
+		fieldsStackView.translatesAutoresizingMaskIntoConstraints = false
+		fieldsStackView.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+		NSLayoutConstraint.activate([
+			nameTextField.widthAnchor.constraint(equalToConstant: customHeaderFieldWidth),
+			valueTextField.widthAnchor.constraint(equalToConstant: customHeaderFieldWidth),
+			fieldsStackView.widthAnchor.constraint(equalToConstant: customHeaderFieldWidth)
+		])
+
+		if let addButton = customHeaderStackView.arrangedSubviews.last as? NSButton {
+			customHeaderStackView.insertArrangedSubview(fieldsStackView, at: max(customHeaderStackView.arrangedSubviews.count - 1, 0))
+			addButton.nextKeyView = nameTextField
+		} else {
+			customHeaderStackView.addArrangedSubview(fieldsStackView)
+		}
+
+		removeButton.target = self
+		removeButton.action = #selector(removeCustomHeader(_:))
+		customHeaderFieldSets.append(CustomHeaderFieldSet(container: fieldsStackView, nameTextField: nameTextField, valueTextField: valueTextField))
+	}
+
+	@objc func removeCustomHeader(_ sender: NSButton) {
+		guard let customHeaderStackView, let fieldSet = customHeaderFieldSets.first(where: { sender.isDescendant(of: $0.container) }) else {
+			return
+		}
+
+		customHeaderStackView.removeArrangedSubview(fieldSet.container)
+		fieldSet.container.removeFromSuperview()
+		customHeaderFieldSets.removeAll { $0.container == fieldSet.container }
+		resizeWindowForCustomHeaders()
+	}
+
+	func resizeWindowForCustomHeaders() {
+		guard let window, let baseWindowFrame else {
+			return
+		}
+
+		let additionalHeight = customHeaderStackView == nil ? 0 : customHeaderSectionHeight + (CGFloat(customHeaderFieldSets.count) * customHeaderRowHeight)
+		let additionalWidth = customHeaderStackView == nil ? 0 : customHeaderAdditionalWidth
+		var frame = baseWindowFrame
+		frame.size.height += additionalHeight
+		frame.origin.y -= additionalHeight
+		frame.size.width += additionalWidth
+		frame.origin.x -= additionalWidth / 2
+		window.setFrame(frame, display: true)
+	}
+
+	func validatedCustomHTTPHeaders() throws -> [ReaderAPICustomHTTPHeader] {
+		guard accountType == .freshRSS else {
+			return []
+		}
+
+		var customHeaders = [ReaderAPICustomHTTPHeader]()
+		for fieldSet in customHeaderFieldSets {
+			let name = fieldSet.nameTextField.stringValue
+			let value = fieldSet.valueTextField.stringValue
+
+			if name.trimmingWhitespace.isEmpty && value.trimmingWhitespace.isEmpty {
+				continue
+			}
+
+			guard let customHeader = ReaderAPICustomHTTPHeader(name: name, value: value) else {
+				throw CustomHeaderValidationError()
+			}
+
+			customHeaders.append(customHeader)
+		}
+
+		return customHeaders
 	}
 
 }

--- a/Modules/Account/Sources/Account/Account.swift
+++ b/Modules/Account/Sources/Account/Account.swift
@@ -401,7 +401,41 @@ public enum FetchType {
 		}
 	}
 
-	public static func validateCredentials(type: AccountType, credentials: Credentials, endpoint: URL? = nil) async throws -> Credentials? {
+	public func storeReaderAPICustomHTTPHeaders(_ headers: [ReaderAPICustomHTTPHeader]) throws {
+		guard !headers.isEmpty else {
+			try removeCredentials(type: .readerAPICustomHTTPHeaders)
+			(delegate as? ReaderAPIAccountDelegate)?.customHTTPHeaders = []
+			return
+		}
+		guard let username else {
+			throw CredentialsError.missingUsername
+		}
+
+		let data = try JSONEncoder().encode(headers)
+		guard let secret = String(data: data, encoding: .utf8) else {
+			throw AccountError.invalidParameter
+		}
+
+		let credentials = Credentials(type: .readerAPICustomHTTPHeaders, username: username, secret: secret)
+		guard let server = delegate.server else {
+			assertionFailure()
+			return
+		}
+		try CredentialsManager.storeCredentials(credentials, server: server)
+		(delegate as? ReaderAPIAccountDelegate)?.customHTTPHeaders = headers
+	}
+
+	public func retrieveReaderAPICustomHTTPHeaders() throws -> [ReaderAPICustomHTTPHeader] {
+		guard let credentials = try retrieveCredentials(type: .readerAPICustomHTTPHeaders) else {
+			return []
+		}
+		guard let data = credentials.secret.data(using: .utf8) else {
+			return []
+		}
+		return (try? JSONDecoder().decode([ReaderAPICustomHTTPHeader].self, from: data)) ?? []
+	}
+
+	public static func validateCredentials(type: AccountType, credentials: Credentials, endpoint: URL? = nil, customHTTPHeaders: [ReaderAPICustomHTTPHeader] = []) async throws -> Credentials? {
 		try await ActivityLog.shared.logActivity(owner: .app, kind: .validateCredentials, detail: type.displayName, successMessage: { $0 == nil ? "Invalid credentials" : "Credentials valid" }, {
 			switch type {
 			case .feedbin:
@@ -409,7 +443,7 @@ public enum FetchType {
 			case .newsBlur:
 				return try await NewsBlurAccountDelegate.validateCredentials(credentials: credentials, endpoint: endpoint)
 			case .freshRSS, .inoreader, .bazQux, .theOldReader:
-				return try await ReaderAPIAccountDelegate.validateCredentials(credentials: credentials, endpoint: endpoint)
+				return try await ReaderAPIAccountDelegate.validateCredentials(credentials: credentials, endpoint: endpoint, customHTTPHeaders: customHTTPHeaders)
 			default:
 				return nil
 			}

--- a/Modules/Account/Sources/Account/ReaderAPI/ReaderAPIAccountDelegate.swift
+++ b/Modules/Account/Sources/Account/ReaderAPI/ReaderAPIAccountDelegate.swift
@@ -86,6 +86,12 @@ final class ReaderAPIAccountDelegate: AccountDelegate {
 		}
 	}
 
+	var customHTTPHeaders = [ReaderAPICustomHTTPHeader]() {
+		didSet {
+			caller.customHTTPHeaders = customHTTPHeaders
+		}
+	}
+
 	var accountSettings: AccountSettings? {
 		didSet {
 			caller.accountSettings = accountSettings
@@ -164,6 +170,7 @@ final class ReaderAPIAccountDelegate: AccountDelegate {
 			if wrappedError.isCredentialsError, let basicCredentials = try? account.retrieveCredentials(type: .readerBasic), let endpoint = account.endpointURL {
 
 				self.caller.credentials = basicCredentials
+				self.customHTTPHeaders = (try? account.retrieveReaderAPICustomHTTPHeaders()) ?? []
 
 				do {
 					if let apiCredentials = try await caller.validateCredentials(endpoint: endpoint) {
@@ -690,6 +697,10 @@ final class ReaderAPIAccountDelegate: AccountDelegate {
 	}
 
 	static func validateCredentials(credentials: Credentials, endpoint: URL?) async throws -> Credentials? {
+		try await validateCredentials(credentials: credentials, endpoint: endpoint, customHTTPHeaders: [])
+	}
+
+	static func validateCredentials(credentials: Credentials, endpoint: URL?, customHTTPHeaders: [ReaderAPICustomHTTPHeader]) async throws -> Credentials? {
 		Self.logger.debug("ReaderAPIAccountDelegate: validateCredentials")
 
 		guard let endpoint else {
@@ -698,6 +709,7 @@ final class ReaderAPIAccountDelegate: AccountDelegate {
 
 		let caller = ReaderAPICaller(logger: Self.logger)
 		caller.credentials = credentials
+		caller.customHTTPHeaders = customHTTPHeaders
 		return try await caller.validateCredentials(endpoint: endpoint)
 	}
 
@@ -743,6 +755,7 @@ private extension ReaderAPIAccountDelegate {
 		if credentials == nil {
 			credentials = try? account.retrieveCredentials(type: .readerAPIKey)
 		}
+		customHTTPHeaders = (try? account.retrieveReaderAPICustomHTTPHeaders()) ?? []
 	}
 
 	@MainActor func refreshAccount(_ account: Account) async throws {

--- a/Modules/Account/Sources/Account/ReaderAPI/ReaderAPICaller.swift
+++ b/Modules/Account/Sources/Account/ReaderAPI/ReaderAPICaller.swift
@@ -61,7 +61,7 @@ struct ReaderAPIUsageLimits {
 		case editTag = "/reader/api/0/edit-tag"
 	}
 
-	private let session = URLSession.makeWebserviceSession()
+	private var session = URLSession.makeWebserviceSession()
 	private let uriComponentAllowed: CharacterSet
 	private let logger: Logger
 	private var accessToken: String?
@@ -70,6 +70,14 @@ struct ReaderAPIUsageLimits {
 
 	var variant: ReaderAPIVariant = .generic
 	var credentials: Credentials?
+	var customHTTPHeaders = [ReaderAPICustomHTTPHeader]() {
+		didSet {
+			let additionalHeaders = customHTTPHeaders.reduce(into: [String: String]()) { headers, customHeader in
+				headers[customHeader.name] = customHeader.value
+			}
+			session = URLSession.makeWebserviceSession(additionalHeaders: additionalHeaders)
+		}
+	}
 
 	/// Most recent usage report. Nil for services that don’t send the headers.
 	private(set) var usageLimits: ReaderAPIUsageLimits?
@@ -120,15 +128,7 @@ struct ReaderAPIUsageLimits {
 				throw WebserviceError.noData
 			}
 
-			var authData: [String: String] = [:]
-			for line in rawData.split(separator: "\n") {
-				let items = line.split(separator: "=").map { String($0) }
-				if items.count == 2 {
-					authData[items[0]] = items[1]
-				}
-			}
-
-			guard let authString = authData["Auth"] else {
+			guard let authString = Self.clientLoginAuthToken(in: rawData) else {
 				throw CredentialsError.missingAccessToken
 			}
 
@@ -144,6 +144,21 @@ struct ReaderAPIUsageLimits {
 				throw error
 			}
 		}
+	}
+
+	nonisolated static func clientLoginAuthToken(in rawData: String) -> String? {
+		clientLoginAuthData(in: rawData)["Auth"]
+	}
+
+	nonisolated private static func clientLoginAuthData(in rawData: String) -> [String: String] {
+		var authData: [String: String] = [:]
+		for line in rawData.split(separator: "\n") {
+			let items = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false).map { String($0) }
+			if items.count == 2 {
+				authData[items[0]] = items[1]
+			}
+		}
+		return authData
 	}
 
 	func requestAuthorizationToken(endpoint: URL) async throws -> String {
@@ -606,6 +621,10 @@ private extension ReaderAPICaller {
 	}
 
 	func addVariantHeaders(_ request: inout URLRequest) {
+		for header in customHTTPHeaders {
+			request.setValue(header.value, forHTTPHeaderField: header.name)
+		}
+
 		if variant == .inoreader {
 			request.addValue(SecretKey.inoreaderAppID, forHTTPHeaderField: "AppId")
 			request.addValue(SecretKey.inoreaderAppKey, forHTTPHeaderField: "AppKey")

--- a/Modules/Account/Sources/Account/ReaderAPI/ReaderAPICustomHTTPHeader.swift
+++ b/Modules/Account/Sources/Account/ReaderAPI/ReaderAPICustomHTTPHeader.swift
@@ -1,0 +1,39 @@
+//
+//  ReaderAPICustomHTTPHeader.swift
+//  Account
+//
+//  Created by NetNewsWire.
+//
+
+import Foundation
+
+nonisolated public struct ReaderAPICustomHTTPHeader: Codable, Equatable, Sendable {
+
+	public let name: String
+	public let value: String
+
+	public init?(name: String, value: String) {
+		let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+		let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+
+		guard !trimmedName.isEmpty, !trimmedValue.isEmpty, Self.isValidName(trimmedName), !Self.containsNewline(trimmedValue) else {
+			return nil
+		}
+
+		self.name = trimmedName
+		self.value = trimmedValue
+	}
+
+	public static func isValidName(_ name: String) -> Bool {
+		guard !name.isEmpty else {
+			return false
+		}
+
+		let allowedScalars = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&'*+-.^_`|~")
+		return name.unicodeScalars.allSatisfy { allowedScalars.contains($0) }
+	}
+
+	private static func containsNewline(_ value: String) -> Bool {
+		value.contains("\n") || value.contains("\r")
+	}
+}

--- a/Modules/Account/Sources/Account/URLRequest+Account.swift
+++ b/Modules/Account/Sources/Account/URLRequest+Account.swift
@@ -50,6 +50,8 @@ public extension URLRequest {
 		case .readerAPIKey:
 			let auth = "GoogleLogin auth=\(credentials.secret)"
 			setValue(auth, forHTTPHeaderField: HTTPRequestHeader.authorization)
+		case .readerAPICustomHTTPHeaders:
+			assertionFailure("Custom HTTP header credentials are stored in Keychain and applied separately from request credentials.")
 		case .oauthAccessToken:
 			let auth = "OAuth \(credentials.secret)"
 			setValue(auth, forHTTPHeaderField: "Authorization")

--- a/Modules/Account/Tests/AccountTests/ReaderAPICustomHTTPHeaderTests.swift
+++ b/Modules/Account/Tests/AccountTests/ReaderAPICustomHTTPHeaderTests.swift
@@ -1,0 +1,58 @@
+//
+//  ReaderAPICustomHTTPHeaderTests.swift
+//  AccountTests
+//
+//  Created by NetNewsWire.
+//
+
+import XCTest
+@testable import Account
+
+final class ReaderAPICustomHTTPHeaderTests: XCTestCase {
+
+	func testCreatesAnyNumberOfValidHeaders() throws {
+		let headers = try (0..<25).map { index in
+			try XCTUnwrap(ReaderAPICustomHTTPHeader(name: "X-Test-Header-\(index)", value: "value-\(index)"))
+		}
+
+		XCTAssertEqual(headers.count, 25)
+		XCTAssertEqual(headers.first?.name, "X-Test-Header-0")
+		XCTAssertEqual(headers.last?.value, "value-24")
+	}
+
+	func testHeadersRoundTripThroughJSONForKeychainStorage() throws {
+		let headers = try (0..<25).map { index in
+			try XCTUnwrap(ReaderAPICustomHTTPHeader(name: "X-Test-Header-\(index)", value: "value-\(index)"))
+		}
+
+		let data = try JSONEncoder().encode(headers)
+		let decoded = try JSONDecoder().decode([ReaderAPICustomHTTPHeader].self, from: data)
+
+		XCTAssertEqual(decoded, headers)
+	}
+
+	func testHeaderValidationRejectsPartialOrUnsafeInput() {
+		XCTAssertNil(ReaderAPICustomHTTPHeader(name: "", value: "value"))
+		XCTAssertNil(ReaderAPICustomHTTPHeader(name: "Header Name", value: "value"))
+		XCTAssertNil(ReaderAPICustomHTTPHeader(name: "X-Test", value: ""))
+		XCTAssertNil(ReaderAPICustomHTTPHeader(name: "X-Test", value: "value\nInjected: nope"))
+	}
+
+	func testHeaderValidationTrimsInput() throws {
+		let header = try XCTUnwrap(ReaderAPICustomHTTPHeader(name: "  X-Test  ", value: "  value  "))
+
+		XCTAssertEqual(header.name, "X-Test")
+		XCTAssertEqual(header.value, "value")
+	}
+
+	@MainActor func testClientLoginAuthTokenAllowsEqualsInTokenValue() throws {
+		let rawData = """
+		SID=session
+		LSID=session2
+		Auth=token-with-padding==
+		"""
+
+		XCTAssertEqual(ReaderAPICaller.clientLoginAuthToken(in: rawData), "token-with-padding==")
+	}
+
+}

--- a/Modules/RSWeb/Sources/RSWeb/WebServices/URLSession+Webservice.swift
+++ b/Modules/RSWeb/Sources/RSWeb/WebServices/URLSession+Webservice.swift
@@ -39,7 +39,7 @@ nonisolated extension URLSession {
 	/// so canceling one account’s requests can’t cancel another account’s.
 	/// When running unit tests, it routes requests through `TestingURLProtocol`
 	/// so no outside code needs any knowledge of testing.
-	public static func makeWebserviceSession() -> URLSession {
+	public static func makeWebserviceSession(additionalHeaders: [String: String]? = nil) -> URLSession {
 
 		let sessionConfiguration = URLSessionConfiguration.default
 		sessionConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
@@ -52,8 +52,14 @@ nonisolated extension URLSession {
 		sessionConfiguration.httpCookieStorage = nil
 		sessionConfiguration.urlCache = nil
 
-		if let userAgentHeaders = UserAgent.headers() {
-			sessionConfiguration.httpAdditionalHeaders = userAgentHeaders
+		var httpAdditionalHeaders = UserAgent.headers() ?? [:]
+		if let additionalHeaders {
+			for (field, value) in additionalHeaders {
+				httpAdditionalHeaders[field] = value
+			}
+		}
+		if !httpAdditionalHeaders.isEmpty {
+			sessionConfiguration.httpAdditionalHeaders = httpAdditionalHeaders
 		}
 
 		if Platform.isRunningUnitTests {

--- a/Modules/Secrets/Sources/Secrets/Credentials.swift
+++ b/Modules/Secrets/Sources/Secrets/Credentials.swift
@@ -58,6 +58,7 @@ public enum CredentialsType: String, Sendable {
 	case newsBlurSessionID = "newsBlurSessionId"
 	case readerBasic = "readerBasic"
 	case readerAPIKey = "readerAPIKey"
+	case readerAPICustomHTTPHeaders = "readerAPICustomHTTPHeaders"
 	case oauthAccessToken = "oauthAccessToken"
 	case oauthAccessTokenSecret = "oauthAccessTokenSecret"
 	case oauthRefreshToken = "oauthRefreshToken"

--- a/iOS/Account/ReaderAPIAccountViewController.swift
+++ b/iOS/Account/ReaderAPIAccountViewController.swift
@@ -28,6 +28,15 @@ final class ReaderAPIAccountViewController: UITableViewController {
 	var accountType: AccountType?
 	weak var delegate: AddAccountDismissDelegate?
 
+	private struct CustomHeaderInput {
+		var name: String
+		var value: String
+	}
+
+	private static let customHeaderCellIdentifier = "CustomHeaderCell"
+	private static let addCustomHeaderCellIdentifier = "AddCustomHeaderCell"
+	private var customHeaderInputs = [CustomHeaderInput]()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 		setupFooter()
@@ -42,6 +51,9 @@ final class ReaderAPIAccountViewController: UITableViewController {
 			actionButton.isEnabled = true
 			usernameTextField.text = credentials.username
 			passwordTextField.text = credentials.secret
+			apiURLTextField.text = unwrappedAccount.endpointURL?.absoluteString
+			let customHeaders = (try? unwrappedAccount.retrieveReaderAPICustomHTTPHeaders()) ?? []
+			customHeaderInputs = customHeaders.map { CustomHeaderInput(name: $0.name, value: $0.value) }
 		} else {
 			actionButton.setTitle(NSLocalizedString("Add Account", comment: "Add Account"), for: .normal)
 		}
@@ -66,6 +78,8 @@ final class ReaderAPIAccountViewController: UITableViewController {
 		NotificationCenter.default.addObserver(self, selector: #selector(textDidChange(_:)), name: UITextField.textDidChangeNotification, object: passwordTextField)
 
 		tableView.register(ImageHeaderView.self, forHeaderFooterViewReuseIdentifier: "SectionHeader")
+		tableView.register(CustomHTTPHeaderCell.self, forCellReuseIdentifier: Self.customHeaderCellIdentifier)
+		tableView.register(AddCustomHTTPHeaderCell.self, forCellReuseIdentifier: Self.addCustomHeaderCellIdentifier)
 
     }
 
@@ -107,13 +121,82 @@ final class ReaderAPIAccountViewController: UITableViewController {
 		case 0:
 			switch accountType {
 			case .freshRSS:
-				return 3
+				return 4 + customHeaderInputs.count
 			default:
 				return 2
 			}
 		default:
 			return 1
 		}
+	}
+
+	override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+		if accountType == .freshRSS, indexPath.section == 0, indexPath.row > 2 {
+			return UITableView.automaticDimension
+		}
+		return UITableView.automaticDimension
+	}
+
+	override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+		if accountType == .freshRSS, indexPath.section == 0, indexPath.row > 2 {
+			return 51
+		}
+		return 44
+	}
+
+	override func tableView(_ tableView: UITableView, indentationLevelForRowAt indexPath: IndexPath) -> Int {
+		return 0
+	}
+
+	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		guard accountType == .freshRSS, indexPath.section == 0, indexPath.row > 2 else {
+			return super.tableView(tableView, cellForRowAt: indexPath)
+		}
+
+		let addHeaderRow = 3 + customHeaderInputs.count
+		if indexPath.row == addHeaderRow {
+			let cell = tableView.dequeueReusableCell(withIdentifier: Self.addCustomHeaderCellIdentifier, for: indexPath) as! AddCustomHTTPHeaderCell
+			cell.configure { [weak self] in
+				self?.appendCustomHeader()
+			}
+			cell.selectionStyle = .default
+			return cell
+		}
+
+		let headerIndex = indexPath.row - 3
+		let cell = tableView.dequeueReusableCell(withIdentifier: Self.customHeaderCellIdentifier, for: indexPath) as! CustomHTTPHeaderCell
+		let input = customHeaderInputs[headerIndex]
+		cell.configure(name: input.name, value: input.value) { [weak self] name, value in
+			self?.customHeaderInputs[headerIndex] = CustomHeaderInput(name: name, value: value)
+		}
+		return cell
+	}
+
+	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		guard accountType == .freshRSS, indexPath.section == 0, indexPath.row == 3 + customHeaderInputs.count else {
+			return
+		}
+
+		tableView.deselectRow(at: indexPath, animated: true)
+		appendCustomHeader()
+	}
+
+	private func appendCustomHeader() {
+		let insertedRow = 3 + customHeaderInputs.count
+		customHeaderInputs.append(CustomHeaderInput(name: "", value: ""))
+		tableView.insertRows(at: [IndexPath(row: insertedRow, section: 0)], with: .automatic)
+	}
+
+	override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+		accountType == .freshRSS && indexPath.section == 0 && indexPath.row >= 3 && indexPath.row < 3 + customHeaderInputs.count
+	}
+
+	override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+		guard editingStyle == .delete, self.tableView(tableView, canEditRowAt: indexPath) else {
+			return
+		}
+		customHeaderInputs.remove(at: indexPath.row - 3)
+		tableView.reloadData()
 	}
 
 	@IBAction func cancel(_ sender: Any) {
@@ -138,6 +221,7 @@ final class ReaderAPIAccountViewController: UITableViewController {
 		let username = usernameTextField.text!
 		let password = passwordTextField.text!
 		let url = apiURL()!
+		let customHTTPHeaders = readerAPICustomHTTPHeaders()
 
 		// When you fill in the email address via auto-complete it adds extra whitespace
 		let trimmedUsername = username.trimmingWhitespace
@@ -158,7 +242,7 @@ final class ReaderAPIAccountViewController: UITableViewController {
 
 			let credentials = Credentials(type: .readerBasic, username: trimmedUsername, secret: password)
 			do {
-				let validatedCredentials = try await Account.validateCredentials(type: type, credentials: credentials, endpoint: url)
+				let validatedCredentials = try await Account.validateCredentials(type: type, credentials: credentials, endpoint: url, customHTTPHeaders: customHTTPHeaders)
 				stopAnimation()
 
 				if let validatedCredentials {
@@ -171,6 +255,7 @@ final class ReaderAPIAccountViewController: UITableViewController {
 
 						try account?.storeCredentials(credentials)
 						try account?.storeCredentials(validatedCredentials)
+						try account?.storeReaderAPICustomHTTPHeaders(customHTTPHeaders)
 
 						account?.triggerRefreshAll()
 
@@ -227,6 +312,10 @@ final class ReaderAPIAccountViewController: UITableViewController {
 				showError(NSLocalizedString("Invalid API URL.", comment: "Invalid API URL"))
 				return false
 			}
+			guard customHeaderFieldsAreValid() else {
+				showError(NSLocalizedString("Custom header names and values must be valid.", comment: "Custom Headers Error"))
+				return false
+			}
 		default:
 			if !usernameTextField.hasText || !passwordTextField.hasText {
 				showError(NSLocalizedString("Username and password are required.", comment: "Credentials Error"))
@@ -270,6 +359,27 @@ final class ReaderAPIAccountViewController: UITableViewController {
 		}
 	}
 
+	private func readerAPICustomHTTPHeaders() -> [ReaderAPICustomHTTPHeader] {
+		customHeaderInputs.compactMap { input in
+			ReaderAPICustomHTTPHeader(name: input.name, value: input.value)
+		}
+	}
+
+	private func customHeaderFieldsAreValid() -> Bool {
+		for input in customHeaderInputs {
+			let trimmedName = input.name.trimmingWhitespace
+			let trimmedValue = input.value.trimmingWhitespace
+
+			if trimmedName.isEmpty && trimmedValue.isEmpty {
+				continue
+			}
+			guard ReaderAPICustomHTTPHeader(name: trimmedName, value: trimmedValue) != nil else {
+				return false
+			}
+		}
+		return true
+	}
+
 	@objc func textDidChange(_ note: Notification) {
 		actionButton.isEnabled = !(usernameTextField.text?.isEmpty ?? false)
 	}
@@ -304,5 +414,113 @@ extension ReaderAPIAccountViewController: UITextFieldDelegate {
 	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
 		textField.resignFirstResponder()
 		return true
+	}
+}
+
+private final class CustomHTTPHeaderCell: UITableViewCell {
+
+	private let nameTextField = UITextField()
+	private let valueTextField = UITextField()
+	private var onChange: ((String, String) -> Void)?
+
+	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+		super.init(style: style, reuseIdentifier: reuseIdentifier)
+		setup()
+	}
+
+	required init?(coder: NSCoder) {
+		super.init(coder: coder)
+		setup()
+	}
+
+	func configure(name: String, value: String, onChange: @escaping (String, String) -> Void) {
+		self.onChange = onChange
+		nameTextField.text = name
+		valueTextField.text = value
+	}
+
+	private func setup() {
+		selectionStyle = .none
+
+		nameTextField.placeholder = NSLocalizedString("Header Name", comment: "Header Name")
+		nameTextField.autocorrectionType = .no
+		nameTextField.spellCheckingType = .no
+		nameTextField.smartDashesType = .no
+		nameTextField.smartInsertDeleteType = .no
+		nameTextField.smartQuotesType = .no
+		nameTextField.adjustsFontForContentSizeCategory = true
+		nameTextField.font = UIFont.preferredFont(forTextStyle: .body)
+		nameTextField.addTarget(self, action: #selector(textDidChange(_:)), for: .editingChanged)
+
+		valueTextField.placeholder = NSLocalizedString("Header Value", comment: "Header Value")
+		valueTextField.autocorrectionType = .no
+		valueTextField.spellCheckingType = .no
+		valueTextField.smartDashesType = .no
+		valueTextField.smartInsertDeleteType = .no
+		valueTextField.smartQuotesType = .no
+		valueTextField.adjustsFontForContentSizeCategory = true
+		valueTextField.font = UIFont.preferredFont(forTextStyle: .body)
+		valueTextField.addTarget(self, action: #selector(textDidChange(_:)), for: .editingChanged)
+
+		let stackView = UIStackView(arrangedSubviews: [nameTextField, valueTextField])
+		stackView.axis = .horizontal
+		stackView.spacing = 12
+		stackView.distribution = .fillEqually
+		stackView.translatesAutoresizingMaskIntoConstraints = false
+		contentView.addSubview(stackView)
+
+		NSLayoutConstraint.activate([
+			stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 14),
+			stackView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+			stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+			stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10)
+		])
+	}
+
+	@objc private func textDidChange(_ sender: UITextField) {
+		onChange?(nameTextField.text ?? "", valueTextField.text ?? "")
+	}
+}
+
+private final class AddCustomHTTPHeaderCell: UITableViewCell {
+
+	private let addButton = UIButton(type: .system)
+	private var onAdd: (() -> Void)?
+
+	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+		super.init(style: style, reuseIdentifier: reuseIdentifier)
+		setup()
+	}
+
+	required init?(coder: NSCoder) {
+		super.init(coder: coder)
+		setup()
+	}
+
+	func configure(onAdd: @escaping () -> Void) {
+		self.onAdd = onAdd
+	}
+
+	private func setup() {
+		addButton.setTitle(NSLocalizedString("Add Custom Header", comment: "Add Custom Header"), for: .normal)
+		addButton.setImage(UIImage(systemName: "plus.circle"), for: .normal)
+		addButton.contentHorizontalAlignment = .leading
+		addButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+		addButton.titleLabel?.adjustsFontForContentSizeCategory = true
+		addButton.translatesAutoresizingMaskIntoConstraints = false
+		addButton.addTarget(self, action: #selector(addHeader(_:)), for: .touchUpInside)
+
+		contentView.addSubview(addButton)
+
+		NSLayoutConstraint.activate([
+			addButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 14),
+			addButton.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+			addButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+			addButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
+		])
+	}
+
+	@objc private func addHeader(_ sender: UIButton) {
+		onAdd?()
 	}
 }


### PR DESCRIPTION
closes #3920

<img width="854" height="982" alt="FreshRSS-customheaders-mac" src="https://github.com/user-attachments/assets/78b72e75-a14f-460c-bd8b-1bd7054c6e4f" />
<img width="812" height="1768" alt="FreshRSS-customheaders" src="https://github.com/user-attachments/assets/42965eec-1fa2-437d-bb06-fe10b722bc9d" />
