### PR TITLE
Keep looking for a favicon when the home page can't be read

### DIFF
--- a/Modules/HTMLMetadata/Sources/HTMLMetadata/HTMLMetadataDownloader.swift
+++ b/Modules/HTMLMetadata/Sources/HTMLMetadata/HTMLMetadataDownloader.swift
@@ -26,6 +26,9 @@ nonisolated public final class HTMLMetadataDownloader: Sendable {
 	/// In-memory mirror so `cachedMetadata(for:)` can answer synchronously.
 	private let cache = OSAllocatedUnfairLock(initialState: [String: HTMLMetadataRecord]())
 
+	/// URLs whose last fetch failed and that aren’t due for a retry yet.
+	private let unavailableURLs = OSAllocatedUnfairLock(initialState: Set<String>())
+
 	init() {
 		NotificationCenter.default.addObserver(self, selector: #selector(handleAppDidGoToBackground(_:)), name: .appDidGoToBackground, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(handleLowMemory(_:)), name: .lowMemory, object: nil)
@@ -54,6 +57,11 @@ nonisolated public final class HTMLMetadataDownloader: Sendable {
 		return nil
 	}
 
+	/// True when the last fetch failed and no retry is pending, so there is no point waiting for
+	/// metadata. Callers that can proceed without it — a `/favicon.ico` guess, say — should.
+	public func metadataIsUnavailable(for url: String) -> Bool {
+		unavailableURLs.withLock { $0.contains(url) }
+	}
 }
 
 // MARK: - Private
@@ -75,6 +83,7 @@ nonisolated private extension HTMLMetadataDownloader {
 			}
 
 			if await HTMLMetadataDatabase.shared.recentlyFailed(for: url) {
+				markUnavailable(url)
 				return
 			}
 
@@ -84,6 +93,21 @@ nonisolated private extension HTMLMetadataDownloader {
 
 	func cacheRecord(_ record: HTMLMetadataRecord) {
 		cache.withLock { $0[record.url] = record }
+		unavailableURLs.withLock { _ = $0.remove(record.url) }
+	}
+
+	/// Marked before any stale record is returned, so a usable record still wins.
+	func markUnavailable(_ url: String) {
+		let inserted = unavailableURLs.withLock { $0.insert(url).inserted }
+		guard inserted else {
+			return
+		}
+		// Observers re-query on this Notification, and metadataIsUnavailable then tells them
+		// not to keep waiting. There is no record to send.
+		let userInfo: [String: Any] = [HTMLMetadataUserInfoKey.url: url]
+		NotificationCenter.default.postOnMainThread(
+			name: .htmlMetadataAvailable, object: self, userInfo: userInfo
+		)
 	}
 
 	func downloadMetadataIfNeeded(_ url: String) {
@@ -139,6 +163,7 @@ nonisolated private extension HTMLMetadataDownloader {
 					await HTMLMetadataDatabase.shared.noteFailure(url: url, statusCode: statusCode)
 				}
 
+				markUnavailable(url)
 				// Download failed — try returning stale cached data.
 				await returnStaleCacheIfAvailable(url)
 
@@ -149,6 +174,7 @@ nonisolated private extension HTMLMetadataDownloader {
 			} catch {
 				// Pre-response failure (DNS, TLS, network).
 				await HTMLMetadataDatabase.shared.noteTransientFailure(url: url)
+				markUnavailable(url)
 				await returnStaleCacheIfAvailable(url)
 
 				activityLog.didFail(.htmlMetadataDownloader, kind: kind, error: error)

--- a/Modules/HTMLMetadata/Sources/HTMLMetadata/HTMLMetadataRecord.swift
+++ b/Modules/HTMLMetadata/Sources/HTMLMetadata/HTMLMetadataRecord.swift
@@ -71,6 +71,11 @@ public extension HTMLMetadataRecord {
 	struct Favicon: Codable, Sendable {
 		public let type: String?
 		public let urlString: String?
+
+		public init(type: String?, urlString: String?) {
+			self.type = type
+			self.urlString = urlString
+		}
 	}
 
 	struct AppleTouchIcon: Codable, Sendable {

--- a/Modules/Images/Package.swift
+++ b/Modules/Images/Package.swift
@@ -36,6 +36,9 @@ let package = Package(
 				.enableUpcomingFeature("InferIsolatedConformances"),
 				.unsafeFlags(["-warnings-as-errors"])
 			]
-		)
+		),
+		.testTarget(
+			name: "ImagesTests",
+			dependencies: ["Images", "HTMLMetadata"])
 	]
 )

--- a/Modules/Images/Sources/Images/FaviconDownloader.swift
+++ b/Modules/Images/Sources/Images/FaviconDownloader.swift
@@ -30,7 +30,7 @@ extension Notification.Name {
 	private let diskCache: BinaryDiskCache
 	private var singleFaviconDownloaderCache = [String: SingleFaviconDownloader]() // faviconURL: SingleFaviconDownloader
 	private var remainingFaviconURLs = [String: ArraySlice<String>]() // homePageURL: array of faviconURLs that haven't been checked yet
-	private var currentHomePageHasOnlyFaviconICO = false
+	private var homePagesWithOnlyDefaultFaviconURL = Set<String>()
 
 	private let queue: DispatchQueue
 	private var cache = [Feed: IconImage]() // faviconURL: RSImage
@@ -151,8 +151,6 @@ extension Notification.Name {
 		}
 
 		if let faviconURLs = findFaviconURLs(with: url) {
-			// If the site explicitly specifies favicon.ico, it will appear twice.
-			self.currentHomePageHasOnlyFaviconICO = faviconURLs.count == 1
 			self.remainingFaviconURLs[url] = faviconURLs[...]
 			downloadNextFavicon(forHomePageURL: url)
 		}
@@ -179,6 +177,10 @@ extension Notification.Name {
 			return
 		}
 		guard singleFaviconDownloader.iconImage != nil else {
+			if singleFaviconDownloader.error == nil {
+				// Transient — not an answer about the site.
+				homePagesWithOnlyDefaultFaviconURL.remove(homePageURL)
+			}
 			if remainingFaviconURLs[homePageURL] != nil {
 				downloadNextFavicon(forHomePageURL: homePageURL)
 			}
@@ -186,6 +188,7 @@ extension Notification.Name {
 		}
 
 		remainingFaviconURLs[homePageURL] = nil
+		homePagesWithOnlyDefaultFaviconURL.remove(homePageURL)
 
 		postFaviconDidBecomeAvailableNotification(singleFaviconDownloader.faviconURL)
 	}
@@ -211,24 +214,22 @@ private extension FaviconDownloader {
 		SpecialCase.urlStringContainSpecialCase(feed.url, Self.specialCasesToSkip)
 	}
 
-	static let localeForLowercasing = Locale(identifier: "en_US")
+	nonisolated static let localeForLowercasing = Locale(identifier: "en_US")
 
 	func findFaviconURLs(with homePageURL: String) -> [String]? {
 
-		guard let url = URL(string: homePageURL) else {
+		let downloader = HTMLMetadataDownloader.shared
+		let metadata = downloader.cachedMetadata(for: homePageURL)
+		let candidates = Self.faviconCandidates(homePageURL: homePageURL, favicons: metadata?.favicons,
+												metadataIsUnavailable: downloader.metadataIsUnavailable(for: homePageURL))
+
+		guard let candidates else {
 			return nil
 		}
-		guard let htmlMetadata = HTMLMetadataDownloader.shared.cachedMetadata(for: homePageURL) else {
-			return nil
+		if candidates.onlyDefaultFaviconURL {
+			homePagesWithOnlyDefaultFaviconURL.insert(homePageURL)
 		}
-		let faviconURLs = htmlMetadata.usableFaviconURLs() ?? [String]()
-
-		guard let scheme = url.scheme, let host = url.host else {
-			return faviconURLs.isEmpty ? nil : faviconURLs
-		}
-
-		let defaultFaviconURL = "\(scheme)://\(host)/favicon.ico".lowercased(with: FaviconDownloader.localeForLowercasing)
-		return faviconURLs + [defaultFaviconURL]
+		return candidates.urls
 	}
 
 	func canAttemptDownload(_ faviconURL: String) -> Bool {
@@ -256,7 +257,7 @@ private extension FaviconDownloader {
 		}
 
 		remainingFaviconURLs[homePageURL] = nil
-		if currentHomePageHasOnlyFaviconICO {
+		if homePagesWithOnlyDefaultFaviconURL.remove(homePageURL) != nil {
 			ImageMetadataDatabase.shared.saveHomePageFavicon(homePageURL: homePageURL, faviconURL: nil)
 		}
 	}
@@ -297,7 +298,7 @@ private extension FaviconDownloader {
 
 private extension HTMLMetadataRecord {
 
-	func usableFaviconURLs() -> [String]? {
+	static func usableFaviconURLs(_ favicons: [Favicon]) -> [String] {
 
 		favicons.compactMap { favicon in
 			shouldAllowFavicon(favicon) ? favicon.urlString : nil
@@ -306,7 +307,7 @@ private extension HTMLMetadataRecord {
 
 	static let ignoredTypes = [UTType.svg]
 
-	private func shouldAllowFavicon(_ favicon: HTMLMetadataRecord.Favicon) -> Bool {
+	private static func shouldAllowFavicon(_ favicon: HTMLMetadataRecord.Favicon) -> Bool {
 
 		// Only http(s) — a data: or other non-web URL can't be downloaded as a favicon.
 		guard let urlString = favicon.urlString,
@@ -329,5 +330,49 @@ private extension HTMLMetadataRecord {
 		}
 
 		return true
+	}
+}
+
+// MARK: - Candidates
+
+extension FaviconDownloader {
+
+	struct FaviconCandidates: Equatable {
+		let urls: [String]
+		/// The page was read and named no favicon of its own, leaving only the default
+		/// favicon.ico — so failing to fetch it is a real answer about the site.
+		let onlyDefaultFaviconURL: Bool
+	}
+
+	/// The favicon URLs to try for a home page, best first. `favicons` is nil when the page’s
+	/// metadata hasn’t been read; `metadataIsUnavailable` says it isn’t coming.
+	nonisolated static func faviconCandidates(homePageURL: String, favicons: [HTMLMetadataRecord.Favicon]?, metadataIsUnavailable: Bool) -> FaviconCandidates? {
+
+		guard let url = URL(string: homePageURL) else {
+			return nil
+		}
+		let defaultFaviconURL = defaultFaviconURL(for: url)
+
+		guard let favicons else {
+			// favicon.ico needs no HTML, so it’s still worth a try when the page won’t load.
+			guard metadataIsUnavailable, let defaultFaviconURL else {
+				return nil
+			}
+			return FaviconCandidates(urls: [defaultFaviconURL], onlyDefaultFaviconURL: false)
+		}
+
+		let declaredURLs = HTMLMetadataRecord.usableFaviconURLs(favicons)
+		guard let defaultFaviconURL else {
+			return declaredURLs.isEmpty ? nil : FaviconCandidates(urls: declaredURLs, onlyDefaultFaviconURL: false)
+		}
+		return FaviconCandidates(urls: declaredURLs + [defaultFaviconURL], onlyDefaultFaviconURL: declaredURLs.isEmpty)
+	}
+
+	/// Every site is entitled to a favicon.ico at its root, whether or not it says so.
+	nonisolated static func defaultFaviconURL(for url: URL) -> String? {
+		guard let scheme = url.scheme, let host = url.host else {
+			return nil
+		}
+		return "\(scheme)://\(host)/favicon.ico".lowercased(with: localeForLowercasing)
 	}
 }

--- a/Modules/Images/Tests/ImagesTests/FaviconCandidatesTests.swift
+++ b/Modules/Images/Tests/ImagesTests/FaviconCandidatesTests.swift
@@ -1,0 +1,101 @@
+//
+//  FaviconCandidatesTests.swift
+//  ImagesTests
+//
+//  Created by Dave Marquard on 9/7/26.
+//
+
+import Foundation
+import Testing
+import HTMLMetadata
+@testable import Images
+
+struct FaviconCandidatesTests {
+
+	private static let homePageURL = "https://example.com/blog"
+	private static let defaultFaviconURL = "https://example.com/favicon.ico"
+
+	private func candidates(_ favicons: [HTMLMetadataRecord.Favicon]?, metadataIsUnavailable: Bool = false) -> FaviconDownloader.FaviconCandidates? {
+		FaviconDownloader.faviconCandidates(homePageURL: Self.homePageURL, favicons: favicons, metadataIsUnavailable: metadataIsUnavailable)
+	}
+
+	// MARK: - Reading the page
+
+	@Test func declaredFaviconComesBeforeTheDefault() {
+		let favicon = HTMLMetadataRecord.Favicon(type: nil, urlString: "https://example.com/icon.png")
+		let result = candidates([favicon])
+
+		#expect(result?.urls == ["https://example.com/icon.png", Self.defaultFaviconURL])
+		#expect(result?.onlyDefaultFaviconURL == false)
+	}
+
+	@Test func pageDeclaringNothingFallsBackToTheDefault() {
+		let result = candidates([])
+
+		#expect(result?.urls == [Self.defaultFaviconURL])
+		#expect(result?.onlyDefaultFaviconURL == true)
+	}
+
+	// MARK: - Unusable favicons
+
+	@Test(arguments: [
+		HTMLMetadataRecord.Favicon(type: nil, urlString: "https://example.com/icon.svg"),
+		HTMLMetadataRecord.Favicon(type: "image/svg+xml", urlString: "https://example.com/icon"),
+		HTMLMetadataRecord.Favicon(type: nil, urlString: "data:image/png;base64,iVBORw0KGgo="),
+		HTMLMetadataRecord.Favicon(type: nil, urlString: nil)
+	])
+	func unusableFaviconLeavesOnlyTheDefault(_ favicon: HTMLMetadataRecord.Favicon) {
+		let result = candidates([favicon])
+
+		#expect(result?.urls == [Self.defaultFaviconURL])
+		// The page was read and named nothing we can use, so failing the default is an answer.
+		#expect(result?.onlyDefaultFaviconURL == true)
+	}
+
+	/// Hacker News declares only y18.svg, so favicon.ico is the one thing left to try.
+	@Test func siteDeclaringOnlySVGStillGetsItsFaviconICO() {
+		let svg = HTMLMetadataRecord.Favicon(type: nil, urlString: "https://news.ycombinator.com/y18.svg")
+		let result = FaviconDownloader.faviconCandidates(homePageURL: "https://news.ycombinator.com/bestcomments",
+														favicons: [svg], metadataIsUnavailable: false)
+
+		#expect(result?.urls == ["https://news.ycombinator.com/favicon.ico"])
+	}
+
+	// MARK: - Without the page
+
+	@Test func metadataStillDownloadingProducesNoCandidates() {
+		// Guessing now would cache favicon.ico before we ever see what the page declares.
+		#expect(candidates(nil, metadataIsUnavailable: false) == nil)
+	}
+
+	@Test func metadataThatIsntComingStillTriesTheDefault() {
+		let result = candidates(nil, metadataIsUnavailable: true)
+
+		#expect(result?.urls == [Self.defaultFaviconURL])
+		// We never read the page, so exhausting this must not record “no favicon”.
+		#expect(result?.onlyDefaultFaviconURL == false)
+	}
+
+	// MARK: - Default favicon URL
+
+	@Test func defaultFaviconURLIsTheSiteRoot() throws {
+		let url = try #require(URL(string: "HTTPS://Example.COM/deep/path?q=1"))
+
+		#expect(FaviconDownloader.defaultFaviconURL(for: url) == "https://example.com/favicon.ico")
+	}
+
+	@Test func urlWithoutAHostHasNoDefaultFaviconURL() throws {
+		let url = try #require(URL(string: "file:///tmp/page.html"))
+
+		#expect(FaviconDownloader.defaultFaviconURL(for: url) == nil)
+	}
+
+	@Test func hostlessHomePageKeepsOnlyItsDeclaredFavicons() {
+		let favicon = HTMLMetadataRecord.Favicon(type: nil, urlString: "https://example.com/icon.png")
+		let result = FaviconDownloader.faviconCandidates(homePageURL: "file:///tmp/page.html",
+														favicons: [favicon], metadataIsUnavailable: false)
+
+		#expect(result?.urls == ["https://example.com/icon.png"])
+		#expect(result?.onlyDefaultFaviconURL == false)
+	}
+}

--- a/NetNewsWire-CI.xctestplan
+++ b/NetNewsWire-CI.xctestplan
@@ -103,6 +103,13 @@
         "identifier" : "FeedFinderTests",
         "name" : "FeedFinderTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/Images",
+        "identifier" : "ImagesTests",
+        "name" : "ImagesTests"
+      }
     }
   ],
   "version" : 1

--- a/NetNewsWire.xctestplan
+++ b/NetNewsWire.xctestplan
@@ -100,6 +100,13 @@
         "identifier" : "FeedFinderTests",
         "name" : "FeedFinderTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Modules\/Images",
+        "identifier" : "ImagesTests",
+        "name" : "ImagesTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
fixes #5421 

findFaviconURLs returned nil whenever cachedMetadata did, so a feed whose home page couldn't be fetched got no favicon at all -- for as long as the failure record lasted, 11 days after a 4xx. But the last candidate it appends, scheme://host/favicon.ico, needs no HTML to find.

cachedMetadata returns nil in two different situations: the download is still in flight, or it isn't coming. Only the first is worth waiting for. HTMLMetadataDownloader now tracks the second and answers metadataIsUnavailable, posting htmlMetadataAvailable so existing observers re-query.

Sync accounts feel this most, since Miniflux, Feedly, ReaderAPI and local accounts never set iconURL or faviconURL -- those are JSON-Feed-only -- so scraping the home page is their only route to an icon. Hacker News is a good example: it declares only y18.svg, which we filter, leaving favicon.ico as the sole candidate.

Also fixes the verdict that suppresses future lookups. currentHomePageHasOnlyFaviconICO was one flag, written when candidates were built and read later, asynchronously, once some home page ran out of them. Different home pages interleave, so it often belonged to a different site than the one being finalized. It's now a set keyed by home page, and a transient failure -- which SingleFaviconDownloader reports as a nil error -- no longer counts as an answer about the site.

Candidate assembly moves to a pure faviconCandidates function, which makes the decision table testable. Adds an ImagesTests target, the first for this module.